### PR TITLE
fix(dev-core): mock workspace in project.test.ts — prevent vault leak

### DIFF
--- a/plugins/dev-core/skills/init/__tests__/project.test.ts
+++ b/plugins/dev-core/skills/init/__tests__/project.test.ts
@@ -23,6 +23,12 @@ vi.mock('../../shared/queries', () => ({
   UPDATE_PROJECT_WORKFLOW_MUTATION: 'UPDATE_PROJECT_WORKFLOW_MUTATION',
 }))
 
+vi.mock('../../shared/workspace', () => ({
+  readWorkspace: vi.fn(() => ({ projects: [] })),
+  writeWorkspace: vi.fn(),
+  getWorkspacePath: () => '/tmp/test-workspace.json',
+}))
+
 describe('createProject', () => {
   let mockRun: ReturnType<typeof vi.fn>
 


### PR DESCRIPTION
## Summary
- Mock `../../shared/workspace` in `__tests__/project.test.ts` so `createProject` calls don't write to the real `~/.roxabi-vault/workspace.json`
- PR #11 updated `project.ts` to call `writeWorkspace`, but the existing test had no workspace mock — every `bun run test` silently appended `TestOrg/test-repo / PVT_new` to the live vault, breaking the dashboard

## Test Plan
- [x] 160/160 tests pass
- [x] `~/.roxabi-vault/workspace.json` clean after test run

Closes the vault leak introduced by #11.