### PR TITLE
fix(doctor): detect missing contents:read in job-level CI permissions

### DIFF
--- a/plugins/dev-core/skills/doctor/SKILL.md
+++ b/plugins/dev-core/skills/doctor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: doctor
 description: 'Health check — verify dev-core config, GitHub project, labels, workflows, branch protection. Triggers: "doctor" | "health check" | "check setup" | "verify config".'
-version: 0.6.0
+version: 0.7.0
 allowed-tools: Bash
 ---
 
@@ -261,5 +261,27 @@ The doctor CLI (Phase 1) already checks Workflows and Secrets sections. Only run
    - Display: `CI/CD workflows ✅ Created` + `PAT secret ✅ Set` + `allow_auto_merge ✅ Enabled`
 
 6. **If skip:** display `CI/CD workflows ⏭ Skipped`
+
+### Phase 5 — CI Permissions check
+
+Runs automatically (no prompt). Scans local `.github/workflows/` files for a private-repo footgun:
+
+> When a job defines its own `permissions:` block it **overrides** the workflow-level permissions entirely. If the block omits `contents: read`, any `actions/checkout` step in that job fails with `remote: Repository not found` on private repos (silent on public repos).
+
+**Algorithm:** for each `.yml`/`.yaml` in `.github/workflows/`:
+1. Find job-level `permissions:` blocks (4-space indent inside a job).
+2. `permissions: read-all` / `write-all` → ✅ (shorthand grants all perms).
+3. Mapping without `contents:` AND job has `actions/checkout` → flag.
+
+**Severity:**
+- `❌ fail` — repo is private (`gh repo view --json isPrivate` returns `true`)
+- `⚠️ warn` — repo is public (checkout works today, breaks on private forks)
+
+**Fix (shown inline):**
+```yaml
+permissions:
+  contents: read   # ← add this
+  actions: read
+```
 
 $ARGUMENTS

--- a/plugins/dev-core/skills/doctor/__tests__/doctor.test.ts
+++ b/plugins/dev-core/skills/doctor/__tests__/doctor.test.ts
@@ -116,4 +116,124 @@ describe('doctor', () => {
     // Assert: the ⏭ skip icon appears in the GitHub section (gh not available skips all checks)
     expect(result.stdout).toContain('⏭')
   })
+
+  describe('CI permissions', () => {
+    function writeWorkflow(dir: string, content: string) {
+      const wfDir = path.join(dir, '.github', 'workflows')
+      fs.mkdirSync(wfDir, { recursive: true })
+      fs.writeFileSync(path.join(wfDir, 'ci.yml'), content)
+    }
+
+    it('warns when a job has job-level permissions without contents: read and uses actions/checkout', () => {
+      // Arrange
+      writeWorkflow(
+        tmpDir,
+        [
+          'name: CI',
+          'on: [push]',
+          'jobs:',
+          '  merge-reports:',
+          '    runs-on: ubuntu-latest',
+          '    permissions:',
+          '      actions: read',
+          '    steps:',
+          '      - uses: actions/checkout@v4',
+        ].join('\n'),
+      )
+
+      // Act
+      const result = runDoctor(tmpDir)
+
+      // Assert
+      expect(result.stdout).toContain('CI permissions')
+      expect(result.stdout).toContain('merge-reports')
+      expect(result.stdout).toContain('contents: read')
+    })
+
+    it('passes when a job with job-level permissions includes contents: read', () => {
+      // Arrange
+      writeWorkflow(
+        tmpDir,
+        [
+          'name: CI',
+          'on: [push]',
+          'jobs:',
+          '  build:',
+          '    runs-on: ubuntu-latest',
+          '    permissions:',
+          '      contents: read',
+          '      actions: read',
+          '    steps:',
+          '      - uses: actions/checkout@v4',
+        ].join('\n'),
+      )
+
+      // Act
+      const result = runDoctor(tmpDir)
+
+      // Assert
+      expect(result.stdout).toContain('CI permissions')
+      expect(result.stdout).toContain('no missing contents: read')
+    })
+
+    it('passes when a job uses permissions: read-all shorthand', () => {
+      // Arrange
+      writeWorkflow(
+        tmpDir,
+        [
+          'name: CI',
+          'on: [push]',
+          'jobs:',
+          '  build:',
+          '    runs-on: ubuntu-latest',
+          '    permissions: read-all',
+          '    steps:',
+          '      - uses: actions/checkout@v4',
+        ].join('\n'),
+      )
+
+      // Act
+      const result = runDoctor(tmpDir)
+
+      // Assert
+      expect(result.stdout).toContain('CI permissions')
+      expect(result.stdout).toContain('no missing contents: read')
+    })
+
+    it('passes when a job has no job-level permissions block (inherits top-level)', () => {
+      // Arrange: top-level permissions only — job inherits, no override
+      writeWorkflow(
+        tmpDir,
+        [
+          'name: CI',
+          'on: [push]',
+          'permissions:',
+          '  contents: read',
+          'jobs:',
+          '  build:',
+          '    runs-on: ubuntu-latest',
+          '    steps:',
+          '      - uses: actions/checkout@v4',
+        ].join('\n'),
+      )
+
+      // Act
+      const result = runDoctor(tmpDir)
+
+      // Assert
+      expect(result.stdout).toContain('CI permissions')
+      expect(result.stdout).toContain('no missing contents: read')
+    })
+
+    it('skips CI permissions check when no workflow files exist', () => {
+      // Arrange: no .github/workflows directory in tmpDir by default
+
+      // Act
+      const result = runDoctor(tmpDir)
+
+      // Assert
+      expect(result.stdout).toContain('CI permissions')
+      expect(result.stdout).toContain('no local workflow files found')
+    })
+  })
 })

--- a/plugins/dev-core/skills/doctor/doctor.ts
+++ b/plugins/dev-core/skills/doctor/doctor.ts
@@ -522,6 +522,143 @@ function checkVercel(): Section {
   return { name: 'Vercel', checks }
 }
 
+// --- CI Permissions ---
+
+/**
+ * Parse a GitHub Actions workflow YAML text and find jobs that have a job-level
+ * `permissions:` block with a `Checkout` step but are missing `contents: read`.
+ * When a job defines its own permissions block it overrides top-level permissions,
+ * so forgetting `contents: read` causes checkout to fail on private repos.
+ */
+function detectMissingContentsRead(
+  content: string,
+  filePath: string,
+): Array<{ file: string; job: string; permissions: string[] }> {
+  const lines = content.split('\n')
+  const issues: Array<{ file: string; job: string; permissions: string[] }> = []
+
+  // Find jobs: section (at root indent)
+  let jobsSectionLine = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (/^jobs:\s*$/.test(lines[i])) {
+      jobsSectionLine = i
+      break
+    }
+  }
+  if (jobsSectionLine === -1) return issues
+
+  // Find job headers (2-space indent within jobs section)
+  const jobHeaders: Array<{ name: string; start: number }> = []
+  for (let i = jobsSectionLine + 1; i < lines.length; i++) {
+    const m = lines[i].match(/^ {2}([a-zA-Z0-9][a-zA-Z0-9_-]*):\s*$/)
+    if (m) {
+      jobHeaders.push({ name: m[1], start: i })
+    } else if (/^\S/.test(lines[i]) && lines[i].trim() && !lines[i].trimStart().startsWith('#')) {
+      break // top-level key — end of jobs section
+    }
+  }
+
+  for (let j = 0; j < jobHeaders.length; j++) {
+    const { name, start } = jobHeaders[j]
+    const end = j + 1 < jobHeaders.length ? jobHeaders[j + 1].start : lines.length
+    const jobLines = lines.slice(start + 1, end)
+
+    let inPermissions = false
+    let hasJobLevelPerms = false
+    const permKeys: string[] = []
+    let hasContentsRead = false
+    let hasCheckout = false
+
+    for (const line of jobLines) {
+      // Job-level permissions block (4-space indent)
+      const permLineMatch = line.match(/^ {4}permissions:\s*(.*)$/)
+      if (permLineMatch) {
+        const val = permLineMatch[1].trim()
+        hasJobLevelPerms = true
+        if (val === 'read-all' || val === 'write-all') {
+          // These shorthand values include contents: read — no issue
+          hasContentsRead = true
+        } else {
+          inPermissions = true
+        }
+        continue
+      }
+
+      if (inPermissions) {
+        const permEntryMatch = line.match(/^ {6}([a-zA-Z-]+):\s*\S/)
+        if (permEntryMatch) {
+          permKeys.push(permEntryMatch[1])
+          if (permEntryMatch[1] === 'contents') hasContentsRead = true
+        } else if (line.trim() && !/^ {6}/.test(line)) {
+          inPermissions = false
+        }
+      }
+
+      if (line.includes('actions/checkout')) hasCheckout = true
+    }
+
+    if (hasJobLevelPerms && !hasContentsRead && hasCheckout) {
+      issues.push({ file: filePath, job: name, permissions: [...permKeys] })
+    }
+  }
+
+  return issues
+}
+
+function checkCIPermissions(ghOk: boolean, owner: string, repo: string): Section {
+  const fs = require('node:fs') as typeof import('fs')
+  const checks: Check[] = []
+
+  const wfDir = '.github/workflows'
+  const files: string[] = []
+  if (fs.existsSync(wfDir)) {
+    for (const f of fs.readdirSync(wfDir) as string[]) {
+      if (f.endsWith('.yml') || f.endsWith('.yaml')) {
+        files.push(`${wfDir}/${f}`)
+      }
+    }
+  }
+
+  if (files.length === 0) {
+    return {
+      name: 'CI permissions',
+      checks: [{ name: 'job permissions', status: 'skip', detail: 'no local workflow files found' }],
+    }
+  }
+
+  let isPrivate = false
+  if (ghOk && owner && repo) {
+    const r = spawnSync(['gh', 'repo', 'view', `${owner}/${repo}`, '--json', 'isPrivate', '--jq', '.isPrivate'])
+    isPrivate = r.stdout === 'true'
+  }
+
+  const issues: Array<{ file: string; job: string; permissions: string[] }> = []
+  for (const filePath of files) {
+    const content = fs.readFileSync(filePath, 'utf8') as string
+    issues.push(...detectMissingContentsRead(content, filePath))
+  }
+
+  if (issues.length === 0) {
+    checks.push({
+      name: 'job permissions',
+      status: 'pass',
+      detail: `${files.length} workflow(s) checked — no missing contents: read`,
+    })
+  } else {
+    for (const issue of issues) {
+      const fileName = issue.file.replace('.github/workflows/', '')
+      const permList = issue.permissions.length > 0 ? `[${issue.permissions.join(', ')}]` : 'empty block'
+      checks.push({
+        name: `${fileName} / ${issue.job}`,
+        status: isPrivate ? 'fail' : 'warn',
+        detail: `job-level permissions missing \`contents: read\` — checkout fails on private repos. Current: ${permList}. Add \`contents: read\`.`,
+      })
+    }
+  }
+
+  return { name: 'CI permissions', checks }
+}
+
 // --- Output formatting ---
 
 const ICONS: Record<Status, string> = { pass: '✅', fail: '❌', warn: '⚠️', skip: '⏭' }
@@ -583,6 +720,7 @@ const sections: Section[] = [
   checkProjectStructure(),
   checkSecurity(),
   checkVercel(),
+  checkCIPermissions(ghOk, owner, repo),
 ]
 
 if (jsonFlag) {


### PR DESCRIPTION
## Summary
- Add Phase 5 to \`/doctor\`: scans \`.github/workflows/\` for jobs with a job-level \`permissions:\` block + \`actions/checkout\` step that are missing \`contents: read\`
- When a job overrides top-level permissions without including \`contents: read\`, checkout fails silently on private repos with \`remote: Repository not found\`
- Severity: ❌ fail on private repos, ⚠️ warn on public (breaks on private forks)
- Handles \`read-all\`/\`write-all\` shorthands correctly (no false positives)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #29: fix(doctor): detect missing contents:read in job-level CI permissions for private repos | Open |
| Implementation | 1 commit on \`feat/29-doctor-ci-permissions\` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (5 new) | Passed |

## Test Plan
- [ ] Run \`/doctor\` on a repo with a workflow job that has job-level permissions + checkout but no \`contents: read\` — should warn/fail
- [ ] Run \`/doctor\` on a repo with correct permissions — should pass with "no missing contents: read"
- [ ] Run \`/doctor\` on a private repo — check should be ❌ fail (not ⚠️ warn)
- [ ] Verify \`permissions: read-all\` jobs are not flagged

Closes #29

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`