### PR TITLE
feat(dev-core): enable ENABLE_LSP_TOOL support in /init and /doctor

### DIFF
--- a/plugins/dev-core/skills/doctor/SKILL.md
+++ b/plugins/dev-core/skills/doctor/SKILL.md
@@ -160,6 +160,23 @@ Check install state:
 - `.vscode/settings.json` contains `"*.mdx": "markdown"` → ✅ | ⚠️ "VS Code MDX preview not configured"
 - ∄ `.mdx` files → ⏭ skip silently.
 
+**LSP support:**
+- Read `lsp.enabled` from `.claude/stack.yml`.
+  - `false` → ⏭ "Disabled in stack.yml", skip all LSP checks.
+  - `true` ∨ absent → continue.
+- `grep -q '^ENABLE_LSP_TOOL=' .env 2>/dev/null` → ✅ "ENABLE_LSP_TOOL set" | ⚠️ "ENABLE_LSP_TOOL not set in .env — add `ENABLE_LSP_TOOL=1`" (auto-fixable)
+- Detect expected LSP binary from `lsp.server` (if explicit) or `runtime`:
+  - `bun` / `node` / `deno` → `typescript-language-server`
+  - `python` → `pyright`
+  - `rust` → `rust-analyzer`
+  - `go` → `gopls`
+- `which <binary> 2>/dev/null` → ✅ "{binary} found" | ⚠️ "{binary} not installed — {install-hint}" (auto-fixable)
+  - Install hints:
+    - `typescript-language-server`: `{package_manager} add -d typescript-language-server typescript`
+    - `pyright`: `uv tool install pyright` or `pip install pyright`
+    - `rust-analyzer`: `rustup component add rust-analyzer`
+    - `gopls`: `go install golang.org/x/tools/gopls@latest`
+
 Print summary:
 ```
 Stack config: N checks passed, M warnings, K errors
@@ -184,6 +201,8 @@ Auto-fixable issues:
   [ ] hooks.tool not set
   [ ] lefthook not installed
   [ ] VS Code MDX preview missing
+  [ ] ENABLE_LSP_TOOL not set
+  [ ] LSP server not installed
   ...
 ```
 
@@ -204,6 +223,8 @@ Apply each selected fix:
 | `pre-commit config missing` | Write `.pre-commit-config.yaml` with local hooks for `commands.lint` + `commands.typecheck`; then `pip install pre-commit && pre-commit install` (or `uv add --dev pre-commit && uv run pre-commit install`) |
 | `pre-commit not activated` | `pre-commit install` (or `uv run pre-commit install`) |
 | `VS Code MDX preview missing` | Merge `"*.mdx": "markdown"` into `.vscode/settings.json` `files.associations` (create file if missing) |
+| `ENABLE_LSP_TOOL not set` | `echo 'ENABLE_LSP_TOOL=1' >> .env && grep -q '^ENABLE_LSP_TOOL=' .env.example 2>/dev/null \|\| echo 'ENABLE_LSP_TOOL=1' >> .env.example` |
+| `LSP server not installed` | Run install command for detected stack (see LSP support section): TS → `{package_manager} add -d typescript-language-server typescript`, Python → `uv tool install pyright`, Rust → `rustup component add rust-analyzer`, Go → `go install golang.org/x/tools/gopls@latest` |
 | `tools/licenseChecker.ts missing` | Run `/init` Phase 10e2 — or manually: `Φ=$(dirname "$(dirname "${CLAUDE_PLUGIN_ROOT}")") && mkdir -p tools && cp "${Φ}/tools/licenseChecker.ts" tools/licenseChecker.ts` |
 | `.license-policy.json missing` (JS) | `Φ=$(dirname "$(dirname "${CLAUDE_PLUGIN_ROOT}")") && cp "${Φ}/tools/license-policy.json.example" .license-policy.json` |
 | `docs.path missing` \| `docs structure incomplete` | Run scaffold-docs: `bun "${CLAUDE_PLUGIN_ROOT}/skills/init/init.ts" scaffold-docs --format {docs.format} --path {docs.path}` — then re-check docs checks and display updated Docs row |

--- a/plugins/dev-core/skills/init/SKILL.md
+++ b/plugins/dev-core/skills/init/SKILL.md
@@ -678,6 +678,55 @@ Marketplace plugins
   installed: compress, web-intel, vault  (or: ⏭ None installed)
 ```
 
+## Phase 10c — LSP Support (Optional)
+
+Enable `ENABLE_LSP_TOOL` for richer code intelligence (go-to-definition, hover docs, diagnostics) in Claude Code sessions.
+
+1. Read `lsp.enabled` from `.claude/stack.yml`.
+   - `false` → display `LSP ⏭ Disabled in stack.yml`, skip.
+   - `true` ∨ absent → continue.
+
+2. Check if `ENABLE_LSP_TOOL` already in `.env`:
+   ```bash
+   grep -q '^ENABLE_LSP_TOOL=' .env 2>/dev/null && echo "set" || echo "missing"
+   ```
+   - set → display `ENABLE_LSP_TOOL ✅ Already configured`, skip to step 6.
+
+3. AskUserQuestion: **Enable LSP support** (adds `ENABLE_LSP_TOOL=1` to `.env` and installs language server) | **Skip**
+
+4. If yes:
+   a. Add to `.env` and `.env.example`:
+      ```bash
+      echo 'ENABLE_LSP_TOOL=1' >> .env
+      grep -q '^ENABLE_LSP_TOOL=' .env.example 2>/dev/null || echo 'ENABLE_LSP_TOOL=1' >> .env.example
+      ```
+
+   b. Detect LSP server from `lsp.server` (if explicit) or `runtime` in stack.yml:
+
+      | runtime | LSP server | Install command | Binary |
+      |---------|-----------|----------------|--------|
+      | `bun` / `node` / `deno` | typescript-language-server | `{package_manager} add -d typescript-language-server typescript` | `typescript-language-server` |
+      | `python` | pyright | `uv tool install pyright` or `pip install pyright` | `pyright` |
+      | `rust` | rust-analyzer | `rustup component add rust-analyzer` | `rust-analyzer` |
+      | `go` | gopls | `go install golang.org/x/tools/gopls@latest` | `gopls` |
+
+   c. Check if binary already in PATH:
+      ```bash
+      which <binary> 2>/dev/null && echo "installed" || echo "missing"
+      ```
+
+   d. missing → run install command. Verify post-install:
+      ```bash
+      which <binary> 2>/dev/null && echo "installed" || echo "still-missing"
+      ```
+      still-missing → ⚠️ "LSP server installed but not in PATH — you may need to restart your shell"
+
+   e. Display: `LSP ✅ ENABLE_LSP_TOOL=1 set, <lsp-server> installed`
+
+5. Skip → display `LSP ⏭ Skipped`
+
+6. `ENABLE_LSP_TOOL` already set ∧ binary ∃ → display `LSP ✅ Already configured (<binary>)`, no-op.
+
 ## Phase 11 — Report
 
 Display final summary:
@@ -709,6 +758,7 @@ dev-core initialized
   Pre-commit hooks      ✅ lefthook installed / ✅ pre-commit installed / ✅ Already configured / ⏭ Disabled / ⏭ Skipped
   License checker   ✅ tools/licenseChecker.ts copied (JS) / ✅ tools/license_check.py copied (Python) / ⏭ Skipped
   License policy    ✅ .license-policy.json created (N packages) / ✅ All compliant / ⏭ Skipped / ⏭ pip-licenses missing
+  LSP               ✅ ENABLE_LSP_TOOL=1 set, <server> installed / ✅ Already configured / ⏭ Disabled / ⏭ Skipped
 
 Next steps:
   /doctor                Verify full configuration health

--- a/plugins/dev-core/stack.yml.example
+++ b/plugins/dev-core/stack.yml.example
@@ -50,6 +50,11 @@ hooks:
   tool: auto                      # auto | lefthook | pre-commit | husky | none
                                   # auto: bun/node/deno → lefthook, python → pre-commit
 
+lsp:
+  enabled: true                   # set ENABLE_LSP_TOOL=1 in .env for richer code intelligence
+  # server: auto                  # auto | typescript-language-server | pyright | pylsp | rust-analyzer | gopls
+                                  # auto: detect from runtime field
+
 deploy:
   platform: vercel                # vercel | railway | fly | aws | none
   secrets_cmd: "vercel env add"   # command to add a secret to the deployment platform


### PR DESCRIPTION
## Summary

- Add Phase 10c to `/init` that sets `ENABLE_LSP_TOOL=1` in `.env`/`.env.example` and installs the appropriate LSP server based on the project's runtime (TS, Python, Rust, Go)
- Add LSP health checks to `/doctor` Phase 2 with auto-fix support for missing env var and missing LSP binary
- Add `lsp.enabled` and `lsp.server` fields to `stack.yml.example`

Closes #43

## Test plan

- [ ] Run `/init` on a fresh project → verify Phase 10c offers LSP setup
- [ ] Run `/init` on a project with `ENABLE_LSP_TOOL=1` already set → verify no-op
- [ ] Run `/doctor` on a project without `ENABLE_LSP_TOOL` → verify ⚠️ warning + auto-fix
- [ ] Run `/doctor` on a project with `lsp.enabled: false` → verify ⏭ skip
- [ ] Verify `stack.yml.example` has `lsp` section with comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)