### PR TITLE
refactor(dev-core): use CLAUDE_SKILL_DIR and CLAUDE_PLUGIN_ROOT in SKILL.md refs

### DIFF
--- a/plugins/dev-core/skills/analyze/SKILL.md
+++ b/plugins/dev-core/skills/analyze/SKILL.md
@@ -128,7 +128,7 @@ When analysis involves data flow or architectural choices, include mermaid in `#
 
 Tier S may omit Shapes + Fit Check.
 
-∃ specific technical question → spawn domain expert via Task. See [references/expert-consultation.md](references/expert-consultation.md).
+∃ specific technical question → spawn domain expert via Task. See [references/expert-consultation.md](${CLAUDE_SKILL_DIR}/references/expert-consultation.md).
 
 ## Step 2.5 — Investigation (Optional)
 
@@ -145,7 +145,7 @@ Skip if ¬technical uncertainty in Step 2 findings.
 4. Report findings → incorporate into analysis
 5. `git worktree remove ../${REPO}-spike-{N}` (throwaway, ¬merge)
 
-See [references/investigation.md](references/investigation.md) if ∃, else use inline flow above.
+See [references/investigation.md](${CLAUDE_SKILL_DIR}/references/investigation.md) if ∃, else use inline flow above.
 
 ## Step 3 — Expert Review
 

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -205,7 +205,7 @@ Gate fires → Step 7 skips its own prompt (gate IS confirmation). ¬double-prom
 
 Let: critical_steps := {spec, plan, implement}.
 
-audit_enabled ∧ S* ∈ critical_steps → present reasoning audit per [reasoning-audit.md](../shared/references/reasoning-audit.md), using field guidance for S*.
+audit_enabled ∧ S* ∈ critical_steps → present reasoning audit per [reasoning-audit.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/reasoning-audit.md), using field guidance for S*.
 
 **Merge rule:** Step 6 gate ∃ for S* → audit **replaces** gate — single combined AskUserQuestion. ¬two consecutive prompts.
 

--- a/plugins/dev-core/skills/frame/SKILL.md
+++ b/plugins/dev-core/skills/frame/SKILL.md
@@ -69,7 +69,7 @@ Auto-detect τ from complexity signals:
 | Issue label M | F-lite |
 | Issue label L ∨ XL | F-full |
 
-See [tier-classification.md](../../../shared/references/tier-classification.md) for canonical rules.
+See [tier-classification.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/tier-classification.md) for canonical rules.
 
 AskUserQuestion: **Confirm {τ}** | **Override → S** | **Override → F-lite** | **Override → F-full**
 

--- a/plugins/dev-core/skills/implement/SKILL.md
+++ b/plugins/dev-core/skills/implement/SKILL.md
@@ -111,7 +111,7 @@ Ref file paths from `/plan` Step 3. Inject the 1-2 ref files stored there.
 
 ## Step 3b — Reasoning Audit (optional)
 
-`--audit` → present reasoning audit per [reasoning-audit.md](../shared/references/reasoning-audit.md) (implement guidance). Read plan/spec in full before presenting.
+`--audit` → present reasoning audit per [reasoning-audit.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/reasoning-audit.md) (implement guidance). Read plan/spec in full before presenting.
 → AskUserQuestion: **Proceed** | **Adjust approach** | **Abort**
 ¬`--audit` → skip to Step 4.
 
@@ -170,7 +170,7 @@ git branch -D feat/<N>-<slug>
 
 ## Edge Cases
 
-Read [references/edge-cases.md](references/edge-cases.md).
+Read [references/edge-cases.md](${CLAUDE_SKILL_DIR}/references/edge-cases.md).
 
 | Merge conflict (worktree setup) | `git rebase --abort` → AskUserQuestion: **Resolve manually** (fix conflicts → `git rebase --continue`) \| **Abort** |
 | Abandon after 3✗ gate failures | `git worktree remove ../${REPO}-<N> --force && git branch -D feat/<N>-<slug>` |

--- a/plugins/dev-core/skills/interview/SKILL.md
+++ b/plugins/dev-core/skills/interview/SKILL.md
@@ -125,6 +125,6 @@ Write using appropriate template. Rules:
 
 ## Document Templates
 
-Use templates from [references/templates.md](references/templates.md) — Brainstorm, Analysis, Spec.
+Use templates from [references/templates.md](${CLAUDE_SKILL_DIR}/references/templates.md) — Brainstorm, Analysis, Spec.
 
 $ARGUMENTS

--- a/plugins/dev-core/skills/issue-triage/SKILL.md
+++ b/plugins/dev-core/skills/issue-triage/SKILL.md
@@ -115,8 +115,8 @@ gh issue edit <number> --body "$BODY
 
 κ is advisory. Human judgment overrides. AskUserQuestion if score ≠ intuition.
 
-See [Tier Classification Reference](../../../shared/references/tier-classification.md) for full rules.
-Reference: [artifacts/analyses/280-token-consumption.mdx](../../../artifacts/analyses/280-token-consumption.mdx) for scoring examples.
+See [Tier Classification Reference](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/tier-classification.md) for full rules.
+Reference: `artifacts/analyses/280-token-consumption.mdx` for scoring examples.
 
 ## Status Values
 

--- a/plugins/dev-core/skills/plan/SKILL.md
+++ b/plugins/dev-core/skills/plan/SKILL.md
@@ -40,7 +40,7 @@ Read `docs/processes/dev-process.mdx` + σ.
 
 ### Step 2a-pre — Reasoning Audit (optional)
 
-`--audit` → after reading σ, present reasoning audit per [reasoning-audit.md](../shared/references/reasoning-audit.md) (plan guidance).
+`--audit` → after reading σ, present reasoning audit per [reasoning-audit.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/reasoning-audit.md) (plan guidance).
 → AskUserQuestion: **Proceed** | **Adjust approach** | **Abort**
 ¬`--audit` → continue to Step 2a.
 
@@ -80,13 +80,13 @@ Find similar existing feature → read 1–2 files for conventions. Store paths 
 
 ## Step 4 — Micro-Tasks (Tier F only)
 
-τ=S → skip → Step 5. Read [references/micro-tasks.md](references/micro-tasks.md) for complete process.
+τ=S → skip → Step 5. Read [references/micro-tasks.md](${CLAUDE_SKILL_DIR}/references/micro-tasks.md) for complete process.
 
 **Summary:** Detect σ format (Breadboard+Slices ∨ Success Criteria) → generate micro-tasks with verify commands → detect parallelization → scale task count → consistency check (σ↔tasks bidirectional) → write to π.
 
 Key outputs: micro-tasks with fields below, `[P]` parallel markers, RED-GATE sentinels per slice.
 
-See [references/micro-task-example.mdx](references/micro-task-example.mdx) for a worked example.
+See [references/micro-task-example.mdx](${CLAUDE_SKILL_DIR}/references/micro-task-example.mdx) for a worked example.
 
 ### Micro-Task Fields
 
@@ -109,7 +109,7 @@ See [references/micro-task-example.mdx](references/micro-task-example.mdx) for a
 
 Write to `artifacts/plans/{N}-{slug}-plan.mdx`. Create `artifacts/plans/` dir if needed.
 
-Use [references/plan-template.mdx](references/plan-template.mdx). See [references/micro-task-example.mdx](references/micro-task-example.mdx) for task formatting.
+Use [references/plan-template.mdx](${CLAUDE_SKILL_DIR}/references/plan-template.mdx). See [references/micro-task-example.mdx](${CLAUDE_SKILL_DIR}/references/micro-task-example.mdx) for task formatting.
 
 ```markdown
 ---
@@ -147,7 +147,7 @@ On Approve → commit: `git add artifacts/plans/{N}-{slug}-plan.mdx` + commit pe
 
 ## Edge Cases
 
-Read [references/edge-cases.md](references/edge-cases.md).
+Read [references/edge-cases.md](${CLAUDE_SKILL_DIR}/references/edge-cases.md).
 
 ## Safety
 

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -45,7 +45,7 @@ gh api repos/:owner/:repo/commits/staging/check-runs \
 
 ## Steps 2-4 — Version, Changelog, Commit
 
-Read [references/release-artifacts.md](references/release-artifacts.md) for full procedure.
+Read [references/release-artifacts.md](${CLAUDE_SKILL_DIR}/references/release-artifacts.md) for full procedure.
 
 ## Step 5 — Deploy Preview
 

--- a/plugins/dev-core/skills/spec/SKILL.md
+++ b/plugins/dev-core/skills/spec/SKILL.md
@@ -64,7 +64,7 @@ Glob `artifacts/specs/{N}-*`, `artifacts/specs/*{slug}*`.
 
 ## Step 1b — Reasoning Audit (optional)
 
-`--audit` → after reading SRC, present reasoning audit per [reasoning-audit.md](../shared/references/reasoning-audit.md) (spec guidance).
+`--audit` → after reading SRC, present reasoning audit per [reasoning-audit.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/reasoning-audit.md) (spec guidance).
 → AskUserQuestion: **Proceed** | **Adjust approach** | **Abort**
 ¬`--audit` → skip to Step 2.
 
@@ -158,7 +158,7 @@ bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts set <N> --status Specs
 
 ## Gate 2.5: Smart Splitting (Optional)
 
-Tier S → skip. Read [references/smart-splitting.md](references/smart-splitting.md).
+Tier S → skip. Read [references/smart-splitting.md](${CLAUDE_SKILL_DIR}/references/smart-splitting.md).
 
 **Triggers:** |acceptance criteria| > 8 ∨ |slices| > 3.
 - Acceptance criteria := `- [ ]` checkboxes in `## Success Criteria`


### PR DESCRIPTION
## Summary

- Replace fragile `../` traversals in 9 SKILL.md files with robust variable-based paths
- Cross-skill refs now use `${CLAUDE_PLUGIN_ROOT}/skills/shared/references/`
- Intra-skill refs now use `${CLAUDE_SKILL_DIR}/references/`
- Project artifact ref converted to inline code path (project-root relative)

Closes #55

## Test plan

- [x] `bun run lint` — passes (10 pre-existing infos)
- [x] `bun run typecheck` — passes
- [x] `bun run test` — 269 tests pass
- [x] `grep ']\(\.\./' skills/**/SKILL.md` — zero matches (no remaining `../` in markdown links)
- [ ] Invoke each affected skill to verify references resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)