### PR TITLE
refactor(forge): add build/deploy scripts from lyra-stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+FORGE_DIR ?= $(HOME)/.roxabi/forge
+DEPLOY_HOST := $(shell grep '^DEPLOY_HOST=' .env 2>/dev/null | cut -d= -f2)
+
+forge-build:
+	@bash forge/scripts/build.sh
+
+forge-deploy:
+	@bash forge/scripts/build.sh
+	@echo "▸ Deploying to Cloudflare Pages…"
+	@set -a; [ -f .env ] && . ./.env; set +a; CLOUDFLARE_ACCOUNT_ID=b5e90be971920ce406f7b679c4f1cd33 npx wrangler pages deploy $(FORGE_DIR)/_dist --project-name=diagrams --branch=main --commit-dirty=true
+
+forge-deploy-prod:
+	@echo "── rsync $(FORGE_DIR)/ → production ──"
+	@rsync -avz --delete \
+		--exclude "__pycache__/" \
+		--exclude "*.pyc" \
+		--exclude ".DS_Store" \
+		--exclude ".sync.log" \
+		--exclude "_dist/" \
+		--exclude "*.py" \
+		--exclude "build.sh" \
+		--exclude "manifest.json" \
+		$(FORGE_DIR)/ $(DEPLOY_HOST):$(FORGE_DIR)/
+	@echo "Done."
+
+forge-du:
+	@du -sh $(FORGE_DIR)/*/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 FORGE_DIR ?= $(HOME)/.roxabi/forge
+export FORGE_DIR
 DEPLOY_HOST := $(shell grep '^DEPLOY_HOST=' .env 2>/dev/null | cut -d= -f2)
 
 forge-build:
@@ -7,9 +8,10 @@ forge-build:
 forge-deploy:
 	@bash forge/scripts/build.sh
 	@echo "▸ Deploying to Cloudflare Pages…"
-	@set -a; [ -f .env ] && . ./.env; set +a; CLOUDFLARE_ACCOUNT_ID=b5e90be971920ce406f7b679c4f1cd33 npx wrangler pages deploy $(FORGE_DIR)/_dist --project-name=diagrams --branch=main --commit-dirty=true
+	@set -a; [ -f .env ] && . ./.env; set +a; npx wrangler pages deploy $(FORGE_DIR)/_dist --project-name=diagrams --branch=main --commit-dirty=true
 
 forge-deploy-prod:
+	@test -n "$(DEPLOY_HOST)" || (echo "ERROR: DEPLOY_HOST not set in .env" && exit 1)
 	@echo "── rsync $(FORGE_DIR)/ → production ──"
 	@rsync -avz --delete \
 		--exclude "__pycache__/" \

--- a/forge/scripts/build.sh
+++ b/forge/scripts/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# build.sh — assemble _dist/ for static deployment
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export FORGE_DIR="${FORGE_DIR:-${DIAGRAMS_DIR:-$HOME/.roxabi/forge}}"
+DIST="$FORGE_DIR/_dist"
+
+echo "▸ Regenerating manifest.json…"
+python3 "$SCRIPT_DIR/gen-manifest.py"
+
+echo "▸ Generating dependency tab from roadmap-deps.json…"
+python3 "$SCRIPT_DIR/gen-deps.py"
+
+echo "▸ Generating image gallery manifests…"
+python3 "$SCRIPT_DIR/gen-image-manifests.py"
+
+echo "▸ Syncing to _dist/…"
+mkdir -p "$DIST"
+rsync -a --delete \
+  --exclude='_dist/' \
+  --exclude='*.py' \
+  --exclude='__pycache__/' \
+  --exclude='.git/' \
+  "$FORGE_DIR/" "$DIST/"
+
+# Copy gallery UI from canonical forge location into _dist
+cp "$FORGE_DIR/index.html" "$DIST/index.html"
+
+FILE_COUNT=$(find "$DIST" -type f | wc -l)
+SIZE=$(du -sh "$DIST" | cut -f1)
+echo "▸ Build ready: $FILE_COUNT files, $SIZE → $DIST"

--- a/forge/scripts/gen-deps.py
+++ b/forge/scripts/gen-deps.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""
+gen-deps.py — generate tab-dependencies.html from roadmap-deps.json.
+
+Usage:
+  python3 gen-deps.py [data.json] [--out path/to/tab-dependencies.html]
+  python3 gen-deps.py --github-sync   # pull closed dates from gh CLI, update JSON status
+"""
+
+import json
+import os
+import re
+import sys
+import subprocess
+from pathlib import Path
+from collections import defaultdict
+
+FORGE_DIR = Path(os.environ.get('FORGE_DIR', os.environ.get('DIAGRAMS_DIR', Path.home() / '.roxabi' / 'forge')))
+DEFAULT_DATA = FORGE_DIR / "lyra/visuals/deps/roadmap-deps.json"
+DEFAULT_OUT  = FORGE_DIR / "lyra/visuals/tabs/lyra-status/tab-dependencies.html"
+
+# ── Styles ──────────────────────────────────────────────────────────────────
+
+CROSS_PHASE_STYLE = (
+    "fill:#0f172a,color:#94a3b8,stroke:#6366f1,"
+    "stroke-width:1px,stroke-dasharray:4 3"
+)
+
+VIRTUAL_STYLE = (
+    "fill:#1e1a2e,color:#94a3b8,stroke:#6d28d9,"
+    "stroke-width:1px,stroke-dasharray:3 3"
+)
+
+def domain_style(domain, domains):
+    d = domains.get(domain, {"fill":"#6366f1","text":"#fff","stroke":"#4338ca"})
+    return f"fill:{d['fill']},color:{d['text']},stroke:{d['stroke']},stroke-width:2px"
+
+def node_style(issue, domains):
+    status = issue.get("status", "open")
+    domain = issue.get("domain", "")
+    d = domains.get(domain, {"fill":"#6366f1","text":"#fff","stroke":"#4338ca"})
+    if status == "done_recent":
+        return f"fill:#374151,color:#9ca3af,stroke:{d['stroke']},stroke-width:2px,stroke-dasharray:5 5"
+    if status == "deferred":
+        return "fill:#1a1000,color:#fbbf24,stroke:#ca8a04,stroke-width:2px,stroke-dasharray:4 3"
+    if status == "external":
+        return "fill:#ef4444,color:#fff,stroke:#b91c1c,stroke-width:2px"
+    if status == "virtual":
+        return VIRTUAL_STYLE
+    return domain_style(domain, domains)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def mid(issue_id: str) -> str:
+    """Safe Mermaid node ID."""
+    return "N" + re.sub(r"[^a-zA-Z0-9]", "_", str(issue_id))
+
+def node_label(issue: dict) -> str:
+    label = issue.get("label", issue["id"])
+    status = issue.get("status", "open")
+    if status == "done_recent":
+        return f"done {label}"
+    if status == "deferred":
+        return f"{label} (deferred)"
+    return label
+
+def phase_short(phase_id: str) -> str:
+    """ph3a → Ph3a"""
+    return phase_id.replace("ph", "Ph")
+
+
+# ── Mermaid generation ───────────────────────────────────────────────────────
+
+def build_mermaid(phase_id, all_issues, domains):
+    """
+    Generate a Mermaid flowchart for one phase.
+    Includes intra-phase edges, incoming cross-phase ghost nodes,
+    and outgoing cross-phase ghost nodes.
+    """
+    phase_issues = {
+        iid: iss for iid, iss in all_issues.items()
+        if iss.get("phase") == phase_id and iss.get("status") != "done_old"
+    }
+
+    if not phase_issues:
+        return 'flowchart TD\n    EMPTY["(no active issues)"]\n'
+
+    # Collect edges and ghost nodes
+    edges = []           # (from_nid, to_nid)
+    ghost_in  = {}       # ghost_nid -> (style, label)
+    ghost_out = {}       # ghost_nid -> (style, label)
+
+    for iid, issue in phase_issues.items():
+        nid = mid(iid)
+
+        # Outgoing: this issue blocks something else
+        for blocked_id in issue.get("blocks", []):
+            blocked = all_issues.get(blocked_id)
+            if not blocked or blocked.get("status") == "done_old":
+                continue
+            if blocked.get("phase") == phase_id:
+                # Intra-phase
+                edges.append((nid, mid(blocked_id)))
+            else:
+                # Cross-phase outgoing ghost
+                gid = f"XO_{mid(blocked_id)}"
+                if gid not in ghost_out:
+                    ph = phase_short(blocked.get("phase", "?"))
+                    lbl = blocked.get("label", f"#{blocked_id}")
+                    ghost_out[gid] = (CROSS_PHASE_STYLE, f"&#8594; {ph} {lbl}")
+                edges.append((nid, gid))
+
+        # Incoming: this issue is blocked by something in another phase
+        for blocker_id in issue.get("blocked_by", []):
+            blocker = all_issues.get(blocker_id)
+            if not blocker or blocker.get("status") == "done_old":
+                continue
+            if blocker.get("phase") != phase_id:
+                # Cross-phase incoming ghost
+                gid = f"XI_{mid(blocker_id)}"
+                if gid not in ghost_in:
+                    ph = phase_short(blocker.get("phase", "?"))
+                    lbl = blocker.get("label", f"#{blocker_id}")
+                    ghost_in[gid] = (CROSS_PHASE_STYLE, f"&#8592; {ph} {lbl}")
+                edges.append((gid, nid))
+
+    lines = ["flowchart TD"]
+
+    # Declare nodes (phase issues first, then ghosts)
+    for iid, issue in phase_issues.items():
+        lines.append(f'    {mid(iid)}["{node_label(issue)}"]')
+    for gid, (_, lbl) in {**ghost_in, **ghost_out}.items():
+        lines.append(f'    {gid}["{lbl}"]')
+
+    for a, b in edges:
+        lines.append(f'    {a} --> {b}')
+
+    for iid, issue in phase_issues.items():
+        lines.append(f'    style {mid(iid)} {node_style(issue, domains)}')
+    for gid, (style, _) in {**ghost_in, **ghost_out}.items():
+        lines.append(f'    style {gid} {style}')
+
+    return "\n".join(lines) + "\n    "
+
+
+def incoming_banner(phase_id, all_issues, phases_by_id):
+    """Auto-derive the incoming dep banner text from cross-phase blocked_by."""
+    seen = {}
+    for iss in all_issues.values():
+        if iss.get("phase") != phase_id or iss.get("status") == "done_old":
+            continue
+        for blocker_id in iss.get("blocked_by", []):
+            blocker = all_issues.get(blocker_id)
+            if not blocker or blocker.get("phase") == phase_id or blocker.get("status") == "done_old":
+                continue
+            ph = phase_short(blocker["phase"])
+            lbl = blocker.get("label", f"#{blocker_id}")
+            key = (blocker["phase"], blocker_id)
+            if key not in seen:
+                seen[key] = f"<strong>{lbl}</strong> ({ph})"
+
+    if not seen:
+        return "&#8649; no hard blockers &#8212; can start immediately"
+    return "&#8592; " + " &middot; ".join(seen.values())
+
+
+# ── Progress cards ────────────────────────────────────────────────────────────
+
+def render_chain_card(chain, all_issues, domains):
+    cid     = chain["id"]
+    label   = chain["label"]
+    color   = chain.get("color", "#6366f1")
+    issues  = chain.get("issues", [])
+
+    # Complete card
+    if chain.get("complete"):
+        return f"""
+  <div class="card" style="border-left:3px solid var(--green)">
+    <div class="card-header">
+      <span class="card-title" style="color:var(--green)">{label}</span>
+      <span class="card-version">&#10003; complete</span>
+    </div>
+    <div class="card-body" style="font-size:13px">
+      <div style="margin-bottom:8px">
+        <div style="background:var(--surface2);border-radius:99px;height:8px;overflow:hidden">
+          <div style="background:var(--green);height:100%;width:100%;border-radius:99px"></div>
+        </div>
+      </div>
+      <ul style="list-style:none;padding:0">
+        <li style="color:var(--green)">&#10003; {chain.get('complete_note','')}</li>
+      </ul>
+      <div style="margin-top:8px;font-size:11px;color:var(--text-dim)">{chain.get('note','')}</div>
+    </div>
+  </div>"""
+
+    # Count done vs open
+    done_ids = [i for i in issues if all_issues.get(i, {}).get("status") == "done_recent"]
+    open_ids = [i for i in issues if all_issues.get(i, {}).get("status") not in ("done_recent", "done_old")]
+    total = len(issues)
+    done_count = len(done_ids)
+    pct = int(done_count / total * 100) if total else 0
+
+    # Done list display
+    done_labels = [all_issues[i]["label"] for i in done_ids if i in all_issues]
+    open_labels = [all_issues[i]["label"] for i in open_ids if i in all_issues]
+
+    done_row = ""
+    if done_labels:
+        done_row = f'<li style="color:var(--green)">&#10003; {", ".join(done_labels)}</li>'
+    open_row = ""
+    if open_labels:
+        open_row = f'<li style="color:var(--text-dim)">&#9675; {", ".join(open_labels[:6])}{"&hellip;" if len(open_labels)>6 else ""}</li>'
+
+    # Footer note
+    if chain.get("blocked_note"):
+        footer = f"""
+      <div style="margin-top:8px;padding-top:8px;border-top:1px solid var(--border);font-size:11px;font-family:var(--font-mono);display:flex;flex-wrap:wrap;align-items:center;gap:5px">
+        <span style="color:#6366f1;margin-right:2px">&#8592; waiting on:</span>
+        {_ghost_badges(chain['blocked_note'])}
+      </div>"""
+    elif chain.get("next_note"):
+        footer = f'<div style="margin-top:8px;font-size:11px;color:var(--text-dim)"><strong>Next:</strong> {chain["next_note"]}</div>'
+    else:
+        footer = ""
+
+    # Unlock row: find cross-phase outgoing deps for issues in this chain
+    unlocks = _compute_unlocks(issues, all_issues, set(issues))
+    unlock_row = ""
+    if unlocks:
+        badges = "".join(_badge_span(lbl) for lbl in unlocks)
+        # Describe "when X done" trigger
+        trigger = _unlock_trigger(chain, all_issues)
+        unlock_row = f"""
+      <div style="margin-top:8px;padding-top:8px;border-top:1px solid var(--border);font-size:11px;font-family:var(--font-mono);display:flex;flex-wrap:wrap;align-items:center;gap:5px">
+        <span style="color:#6366f1;margin-right:2px">&#8680; {trigger}:</span>
+        {badges}
+      </div>"""
+
+    # Done recent closed items (ops-style)
+    done_recent_rows = ""
+    for d in chain.get("done_recent", []):
+        done_recent_rows += f'<li style="color:var(--green)">&#10003; {d} &#8212; closed recently</li>'
+
+    open_count_label = f"{done_count}/{total} done" if total else "0 open"
+
+    return f"""
+  <div class="card{'  card--active' if pct > 0 and pct < 100 else ''}" style="border-left:3px solid {color}">
+    <div class="card-header">
+      <span class="card-title" style="color:{color}">{label}</span>
+      <span class="card-version">{open_count_label}</span>
+    </div>
+    <div class="card-body" style="font-size:13px">
+      <div style="margin-bottom:8px">
+        <div style="background:var(--surface2);border-radius:99px;height:8px;overflow:hidden">
+          <div style="background:{color};height:100%;width:{pct}%;border-radius:99px"></div>
+        </div>
+      </div>
+      <ul style="list-style:none;padding:0">
+        {done_row}
+        {open_row}
+        {done_recent_rows}
+      </ul>
+      {footer}
+      {unlock_row}
+    </div>
+  </div>"""
+
+
+def _badge_span(lbl: str) -> str:
+    return f'<span style="background:#0f172a;color:#94a3b8;border:1px dashed #6366f1;border-radius:4px;padding:2px 6px">{lbl}</span>'
+
+
+def _ghost_badges(note_str):
+    """Convert a plain text note into ghost badge spans."""
+    return "".join(_badge_span(p.strip()) for p in note_str.split("+"))
+
+
+def _compute_unlocks(chain_issue_ids, all_issues, chain_set):
+    """Return ghost badge labels for cross-chain/cross-phase unlocks."""
+    seen = set()
+    for iid in chain_issue_ids:
+        issue = all_issues.get(iid)
+        if not issue:
+            continue
+        for blocked_id in issue.get("blocks", []):
+            if blocked_id in chain_set:
+                continue  # intra-chain, skip
+            blocked = all_issues.get(blocked_id)
+            if not blocked or blocked.get("status") == "done_old":
+                continue
+            ph = phase_short(blocked.get("phase", "?"))
+            lbl = f"{ph} {blocked.get('label', blocked_id)}"
+            seen.add(lbl)
+    return list(seen)
+
+
+def _unlock_trigger(chain, all_issues):
+    """Describe the trigger condition for the unlock row."""
+    # Find the last terminal node of the chain (most downstream)
+    issues = chain.get("issues", [])
+    for iid in reversed(issues):
+        iss = all_issues.get(iid)
+        if iss and iss.get("status") not in ("done_recent", "done_old"):
+            return f"when {iss.get('label', iid)} done"
+    return "when complete"
+
+
+# ── Critical paths ────────────────────────────────────────────────────────────
+
+def render_critical_paths(critical_paths, all_issues):
+    html = ""
+    for path in critical_paths:
+        badges = ""
+        for step in path["steps"]:
+            sid = step.get("id")
+            iss = all_issues.get(sid) if sid else None
+            lbl = step.get("label") or (iss["label"] if iss else sid)
+            st  = step.get("status", iss.get("status","planned") if iss else "planned")
+            if st in ("done", "done_recent"):
+                badges += f'<span class="badge badge--done" style="opacity:0.6">{lbl} &#10003;</span>\n'
+            elif st == "north-star":
+                badges += f'<span style="color:var(--green);font-weight:600">{lbl}</span>\n'
+            else:
+                badges += f'<span class="badge badge--planned">{lbl}</span>\n'
+            if step != path["steps"][-1]:
+                badges += '<span class="flow-arrow">&#8594;</span>\n'
+
+        html += f"""    <div style="font-family:var(--font-mono);font-size:12px;color:var(--text-dim);margin-bottom:8px">{path['label']}</div>
+    <div style="display:flex;flex-wrap:wrap;align-items:center;gap:8px;font-size:12px;font-family:var(--font-mono);margin-bottom:12px">
+      {badges}
+    </div>\n"""
+    return html
+
+
+# ── Full tab render ──────────────────────────────────────────────────────────
+
+CTRL_BUTTONS = '<button class="dep-ctrl dep-zi">+</button><button class="dep-ctrl dep-zo">-</button><button class="dep-ctrl dep-ft" style="width:auto;padding:0 10px;font-size:11px">Fit</button>'
+
+def render_tab(data):
+    all_issues  = {i["id"]: i for i in data["issues"]}
+    phases      = data["phases"]
+    phases_by_id= {p["id"]: p for p in phases}
+    domains     = data["domains"]
+    chains      = data.get("chains", [])
+    cp          = data.get("critical_paths", [])
+    meta        = data.get("_meta", {})
+    updated     = meta.get("updated", "")
+    total       = meta.get("total_tracked", "?")
+    done_days   = meta.get("done_visible_days", 7)
+
+    # ── Legend ──
+    domain_legend = ""
+    for dom, cfg in domains.items():
+        domain_legend += (
+            f'<div style="display:flex;align-items:center;gap:6px">'
+            f'<div style="width:12px;height:12px;border-radius:3px;background:{cfg["fill"]}"></div>'
+            f' {dom.capitalize()}</div>\n'
+        )
+
+    # ── Phase blocks ──
+    phase_blocks = ""
+    for phase in phases:
+        pid   = phase["id"]
+        pname = phase["name"]
+        pcolor= phase["color"]
+        pnote = phase.get("note", "")
+        note_span = f' <span style="font-size:11px;color:var(--green);font-weight:400;margin-left:8px">{pnote}</span>' if pnote else ""
+
+        banner = incoming_banner(pid, all_issues, phases_by_id)
+        mermaid = build_mermaid(pid, all_issues, domains)
+
+        phase_blocks += f"""
+  <!-- ── {pname} ── -->
+  <div class="dep-phase" style="--phase-color:{pcolor}">
+    <div class="dep-phase__incoming">{banner}</div>
+    <div class="dep-phase__header">{pname}{note_span}</div>
+    <div class="dep-phase__viewer"><div class="dep-controls-overlay">{CTRL_BUTTONS}</div><div class="dep-phase__svg"><pre class="mermaid">
+{mermaid}</pre></div></div>
+  </div>
+"""
+
+    # ── Progress cards ──
+    cards_html = ""
+    for chain in chains:
+        cards_html += render_chain_card(chain, all_issues, domains)
+
+    # ── Critical paths ──
+    cp_html = render_critical_paths(cp, all_issues)
+
+    # ── Footer ──
+    n_done = sum(1 for i in all_issues.values() if i.get("status") == "done_recent")
+    n_chains = len(chains)
+
+    return f"""<!-- Tab: Dependencies — auto-generated by gen-deps.py from roadmap-deps.json -->
+<!-- DO NOT EDIT BY HAND — edit roadmap-deps.json then run gen-deps.py -->
+
+<h2 class="sec-title"><span class="icon">&#9670;</span> Issue Dependencies</h2>
+<p class="sec-desc">Each phase is a horizontal band with its own dependency tree. <span style="color:#6366f1">Indigo dashed</span> = cross-phase dep. <span style="color:#fbbf24">Amber dashed</span> = deferred.</p>
+
+<!-- ── Legend ── -->
+<div style="display:flex;gap:16px;flex-wrap:wrap;margin-bottom:var(--space-xl);font-size:12px;font-family:var(--font-mono);color:var(--text-dim)">
+  {domain_legend}
+  <div style="display:flex;align-items:center;gap:6px"><div style="width:12px;height:12px;border-radius:3px;background:#374151;border:2px dashed #6b7280"></div> Done</div>
+  <div style="display:flex;align-items:center;gap:6px"><div style="width:12px;height:12px;border-radius:3px;background:#0f172a;border:2px dashed #6366f1"></div> Cross-phase dep</div>
+  <div style="display:flex;align-items:center;gap:6px"><div style="width:12px;height:12px;border-radius:3px;background:#1a1000;border:2px dashed #ca8a04"></div> Deferred</div>
+  <div style="display:flex;align-items:center;gap:6px"><div style="width:12px;height:12px;border-radius:3px;background:#1e1a2e;border:2px dashed #6d28d9"></div> No issue yet</div>
+</div>
+
+<!-- ── Phase bands ── -->
+<div id="dep-board">
+{phase_blocks}
+</div>
+
+<!-- ── Progress by Chain ── -->
+<h3 class="sec-subtitle">Progress by Chain</h3>
+<div class="card-grid" style="margin-bottom:var(--space-xl)">
+{cards_html}
+</div>
+
+<!-- ── Critical Paths ── -->
+<h3 class="sec-subtitle">Critical Paths</h3>
+<div class="card" style="border-color:var(--accent);margin-bottom:var(--space-lg)">
+  <div class="card-body">
+{cp_html}  </div>
+</div>
+
+<p style="font-size:12px;color:var(--text-dim);font-family:var(--font-mono);text-align:center">
+  ~{total} tracked issues &middot; {n_done} done recently &middot; {n_chains} chains &middot; generated {updated}
+</p>
+"""
+
+
+# ── GitHub sync ───────────────────────────────────────────────────────────────
+
+def github_sync(data_file: Path):
+    """Pull closed dates from gh CLI and update issue statuses in JSON."""
+    from datetime import datetime, timezone
+
+    data = json.loads(data_file.read_text())
+    all_issues = {i["id"]: i for i in data["issues"]}
+    done_days  = data.get("_meta", {}).get("done_visible_days", 7)
+
+    # Collect numeric IDs
+    numeric_ids = [iid for iid in all_issues if iid.isdigit()]
+    if not numeric_ids:
+        print("No numeric issue IDs found.")
+        return
+
+    print(f"Syncing {len(numeric_ids)} issues from GitHub...")
+    result = subprocess.run(
+        ["gh", "issue", "list", "--state", "all",
+         "--json", "number,state,closedAt", "--limit", "500"],
+        capture_output=True, text=True, cwd=Path.home() / "projects/lyra"
+    )
+    if result.returncode != 0:
+        print(f"gh error: {result.stderr}", file=sys.stderr)
+        return
+
+    gh_issues = {str(i["number"]): i for i in json.loads(result.stdout)}
+    today = datetime.now(timezone.utc)
+
+    changed = 0
+    for iid, issue in all_issues.items():
+        if not iid.isdigit():
+            continue
+        gh = gh_issues.get(iid)
+        if not gh:
+            continue
+        if gh["state"] == "OPEN":
+            new_status = issue.get("status", "open")
+            if new_status in ("done_recent", "done_old"):
+                issue["status"] = "open"
+                changed += 1
+        elif gh["state"] == "CLOSED":
+            closed_at = datetime.fromisoformat(gh["closedAt"].replace("Z", "+00:00"))
+            days_ago = (today - closed_at).days
+            new_status = "done_recent" if days_ago <= done_days else "done_old"
+            if issue.get("status") != new_status:
+                issue["status"] = new_status
+                issue["closed_days_ago"] = days_ago
+                changed += 1
+
+    if changed:
+        data_file.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+        print(f"Updated {changed} issue statuses in {data_file}")
+    else:
+        print("No status changes.")
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    args = sys.argv[1:]
+
+    if "--github-sync" in args:
+        data_file = Path(next((a for a in args if not a.startswith("--")), DEFAULT_DATA))
+        github_sync(data_file)
+        args = [a for a in args if a not in ("--github-sync",)]
+        if not args:
+            return
+
+    data_file = Path(args[0]) if args else DEFAULT_DATA
+    out_arg = next((args[i+1] for i, a in enumerate(args) if a == "--out" and i+1 < len(args)), None)
+    out_file = Path(out_arg) if out_arg else DEFAULT_OUT
+
+    data = json.loads(data_file.read_text())
+    html = render_tab(data)
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    out_file.write_text(html)
+    print(f"Generated {out_file} ({len(html):,} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/forge/scripts/gen-image-manifests.py
+++ b/forge/scripts/gen-image-manifests.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Generate manifest.json files for image galleries — API-style listing for static hosting.
+
+Writes a [{name, size, mtime, is_dir}] manifest.json into each image directory
+so galleries can discover images without the serve.py /api/list/ endpoint.
+
+Auto-discovers all directories under FORGE_DIR that contain .png files.
+"""
+import json
+import os
+from pathlib import Path
+
+FORGE_DIR = Path(os.environ.get('FORGE_DIR', os.environ.get('FORGE_DIR', Path.home() / '.roxabi' / 'forge')))
+SKIP = {'_dist', '__pycache__', '.git'}
+
+for dirpath, dirnames, filenames in os.walk(FORGE_DIR):
+    dirnames[:] = [d for d in dirnames if d not in SKIP]
+    pngs = [f for f in filenames if f.endswith('.png')]
+    if not pngs:
+        continue
+    d = Path(dirpath)
+    entries = sorted(
+        [
+            {
+                'name': f,
+                'size': (d / f).stat().st_size,
+                'mtime': int((d / f).stat().st_mtime),
+                'is_dir': False,
+            }
+            for f in pngs
+        ],
+        key=lambda x: x['name'],
+    )
+    manifest = d / 'manifest.json'
+    manifest.write_text(json.dumps(entries, indent=2) + '\n')
+    rel = d.relative_to(FORGE_DIR)
+    print(f'  {rel}/manifest.json: {len(entries)} images')

--- a/forge/scripts/gen-manifest.py
+++ b/forge/scripts/gen-manifest.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""gen-manifest.py — scan diagram HTML files, read diagram:* meta tags, write manifest.json.
+
+Run after editing meta tags in any diagram file:
+    python3 gen-manifest.py
+
+Meta tags read (all in <head>):
+    diagram:title     — display title
+    diagram:date      — ISO date (YYYY-MM-DD)
+    diagram:category  — short key: guide | lyra | ve | ext
+    diagram:cat-label — display label: "User Guide", "Lyra Docs", etc.
+    diagram:color     — amber | blue | purple | green
+    diagram:badges    — comma-separated: latest,split,plan  (any combination)
+
+kb is computed from actual file size (no need to maintain manually).
+"""
+import glob as globmod
+import json, os, re, time
+from pathlib import Path
+
+DIR = Path(os.environ.get('FORGE_DIR', os.environ.get('DIAGRAMS_DIR', Path.home() / '.roxabi' / 'forge')))
+META_RE = re.compile(r'<meta\s+name="diagram:([\w-]+)"\s+content="([^"]*)"', re.IGNORECASE)
+TITLE_RE = re.compile(r'<title>([^<]+)</title>', re.IGNORECASE)
+
+END_MARKER = '<!-- diagram-meta:end -->'
+
+def parse(filepath, rel=''):
+    # Read until our end marker or </head>
+    buf = ''
+    with open(filepath, encoding='utf-8', errors='ignore') as f:
+        for line in f:
+            buf += line
+            if END_MARKER in line:
+                break
+            if '</head>' in line.lower():
+                break
+            if len(buf) > 512 * 1024:  # 512 KB hard cap (safety only)
+                break
+
+    metas = dict(META_RE.findall(buf))
+
+    # Fallback: extract <title> when diagram:title meta is missing
+    if 'title' not in metas:
+        m = TITLE_RE.search(buf)
+        if not m:
+            return None
+        metas['title'] = m.group(1).strip()
+
+    badges = [b.strip() for b in metas.get('badges', '').split(',') if b.strip()]
+    kb = max(1, round(filepath.stat().st_size / 1024))
+
+    # Infer category from path when not in meta
+    cat = metas.get('category', '')
+    cat_label = metas.get('cat-label', '')
+    color = metas.get('color', '')
+    if not cat:
+        if rel.startswith('brand/'):
+            cat, cat_label, color = 'brand', 'Lyra Brand', 'amber'
+        elif rel.startswith('lyra-visuals/') or filepath.name.startswith('lyra-'):
+            cat, cat_label, color = 'lyra', 'Lyra Docs', 'blue'
+        elif filepath.name.startswith('ve-'):
+            cat, cat_label, color = 've', 'Visual Explainer', 'purple'
+        else:
+            cat, cat_label, color = 'ext', 'External', 'green'
+    if not color:
+        color = 'blue'
+
+    # Infer date from file mtime when not in meta
+    date = metas.get('date', '')
+    if not date:
+        date = time.strftime('%Y-%m-%d', time.localtime(filepath.stat().st_mtime))
+
+    return {
+        'f':  filepath.name,
+        't':  metas['title'],
+        'd':  date,
+        'kb': kb,
+        'cat': cat,
+        'cl': cat_label,
+        'c':  color,
+        'b':  badges,
+    }
+
+
+entries, skipped = [], []
+for match in sorted(globmod.glob(str(DIR / '**/*.html'), recursive=True)):
+    fp = Path(match)
+    rel = str(fp.relative_to(DIR))
+    if fp.name == 'index.html' or '/tabs/' in rel or rel.startswith('tabs/') or rel.startswith('_dist/'):
+        continue
+    entry = parse(fp, rel)
+    if entry:
+        entry['f'] = rel
+        entries.append(entry)
+    else:
+        skipped.append(rel)
+
+out = DIR / 'manifest.json'
+out.write_text(json.dumps(entries, ensure_ascii=False, indent=2) + '\n')
+
+print(f'manifest.json — {len(entries)} visuals written.')
+if skipped:
+    print(f'Skipped (no diagram meta): {", ".join(skipped)}')

--- a/forge/scripts/seed-meta.py
+++ b/forge/scripts/seed-meta.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""seed-meta.py — inject diagram:* meta tags into every diagram HTML file.
+
+Run once to bootstrap. After that, edit meta tags directly in each file,
+then run gen-manifest.py to regenerate manifest.json.
+"""
+import os, re
+from pathlib import Path
+
+DIR = Path(os.environ.get('FORGE_DIR', os.environ.get('DIAGRAMS_DIR', Path.home() / '.roxabi' / 'forge')))
+
+# Source of truth: one entry per diagram file.
+# kb is omitted — gen-manifest.py computes it from actual file size.
+DATA = [
+    # User Guide
+    {'f':'lyra-user-guide-v11.html',  't':'Lyra — User Guide v11',                          'd':'2026-03-18', 'cat':'guide', 'cl':'User Guide',       'c':'amber', 'b':['latest']},
+    {'f':'lyra-user-guide-v10.html',  't':'Lyra — User Guide v10',                          'd':'2026-03-18', 'cat':'guide', 'cl':'User Guide',       'c':'amber', 'b':[]},
+    {'f':'lyra-user-guide-v8.html',   't':'Lyra User Guide v8',                             'd':'2026-03-18', 'cat':'guide', 'cl':'User Guide',       'c':'amber', 'b':['split']},
+    {'f':'lyra-user-guide-v7.html',   't':'Lyra — Documentation v7',                        'd':'2026-03-18', 'cat':'guide', 'cl':'User Guide',       'c':'amber', 'b':['split']},
+    {'f':'lyra-user-guide-v6.html',   't':'Lyra — Documentation v6',                        'd':'2026-03-16', 'cat':'guide', 'cl':'User Guide',       'c':'amber', 'b':[]},
+    {'f':'lyra-user-guide-v5.html',   't':'Lyra — Complete User Guide v5',                  'd':'2026-03-16', 'cat':'guide', 'cl':'User Guide',       'c':'amber', 'b':[]},
+    {'f':'lyra-user-guide-v4.html',   't':'Lyra — Complete User Guide v4',                  'd':'2026-03-15', 'cat':'guide', 'cl':'User Guide',       'c':'amber', 'b':[]},
+    {'f':'lyra-user-guide-v3.html',   't':'Lyra — Complete User Guide v3',                  'd':'2026-03-15', 'cat':'guide', 'cl':'User Guide',       'c':'amber', 'b':[]},
+    {'f':'lyra-user-guide-v2.html',   't':'Lyra — Complete User Guide v2',                  'd':'2026-03-15', 'cat':'guide', 'cl':'User Guide',       'c':'amber', 'b':[]},
+    {'f':'lyra-user-guide.html',      't':'Lyra — Complete User Guide v1',                  'd':'2026-03-14', 'cat':'guide', 'cl':'User Guide',       'c':'amber', 'b':[]},
+    # Lyra Docs
+    {'f':'lyra-architecture-v3.html',           't':'Lyra — Architecture Flow & Domain Map',         'd':'2026-03-16', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':['latest']},
+    {'f':'lyra-architecture-v2.html',           't':'Lyra — Architecture Deep Dive',                 'd':'2026-03-16', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    {'f':'lyra-architecture.html',              't':'Lyra Engine — Architecture Visual Explainer',   'd':'2026-03-12', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    {'f':'architecture-visual-explainer.html',  't':'Lyra — Architecture',                           'd':'2026-03-12', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    {'f':'lyra-command-routing.html',           't':'Lyra — Command Routing Architecture',           'd':'2026-03-15', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    {'f':'lyra-e2e-happy-paths.html',           't':'Lyra — End-to-End Happy Paths',                 'd':'2026-03-15', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    {'f':'lyra-happy-paths.html',               't':'Lyra — 26 End-to-End Happy Paths',              'd':'2026-03-15', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    {'f':'lyra-voice-flow.html',                't':'Lyra — Voice Flow (flux complet)',               'd':'2026-03-15', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    {'f':'lyra-project-roadmap.html',           't':'Lyra Engine — Project Master Plan',             'd':'2026-03-12', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    {'f':'lyra-recap-2w-mar15.html',            't':'Lyra — Project Recap (Mar 1–15)',               'd':'2026-03-15', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    {'f':'lyra-recap-march-2026.html',          't':'Lyra — Project Recap · March 2026',             'd':'2026-03-12', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    {'f':'44-event-driven-monitoring-plan.html','t':'Issue #44 — Event-Driven Agent Monitoring',     'd':'2026-03-14', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':['plan']},
+    {'f':'83-memory-agent-integration-plan.html','t':'#83 — Memory Agent Integration Plan',          'd':'2026-03-14', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':['plan']},
+    {'f':'backend-architecture-audit.html',     't':'Roxabi Backend Architecture Audit',             'd':'2026-03-10', 'cat':'lyra', 'cl':'Lyra Docs', 'c':'blue', 'b':[]},
+    # Visual Explainer
+    {'f':'ve-01-core-workflow.html', 't':'VE — Core Generation Workflow', 'd':'2026-03-12', 'cat':'ve', 'cl':'Visual Explainer', 'c':'purple', 'b':[]},
+    {'f':'ve-02-slides.html',        't':'VE — Slide Deck Generation',    'd':'2026-03-12', 'cat':'ve', 'cl':'Visual Explainer', 'c':'purple', 'b':[]},
+    {'f':'ve-03-diff-review.html',   't':'VE — Diff Review Process',      'd':'2026-03-12', 'cat':'ve', 'cl':'Visual Explainer', 'c':'purple', 'b':[]},
+    {'f':'ve-04-plan-review.html',   't':'VE — Plan Review Process',      'd':'2026-03-12', 'cat':'ve', 'cl':'Visual Explainer', 'c':'purple', 'b':[]},
+    {'f':'ve-05-project-recap.html', 't':'VE — Project Recap Process',    'd':'2026-03-12', 'cat':'ve', 'cl':'Visual Explainer', 'c':'purple', 'b':[]},
+    {'f':'ve-06-visual-plan.html',   't':'VE — Visual Plan Generation',   'd':'2026-03-12', 'cat':'ve', 'cl':'Visual Explainer', 'c':'purple', 'b':[]},
+    {'f':'ve-07-fact-check.html',    't':'VE — Fact Check Process',       'd':'2026-03-12', 'cat':'ve', 'cl':'Visual Explainer', 'c':'purple', 'b':[]},
+    {'f':'ve-08-share.html',         't':'VE — Share Process',            'd':'2026-03-12', 'cat':'ve', 'cl':'Visual Explainer', 'c':'purple', 'b':[]},
+    # External
+    {'f':'benchmark-2026.html',             't':'AI Agent Workflow Benchmark 2026',                   'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'agent-teams-lite.html',           't':'Agent Teams Lite',                                   'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'alphaclaw.html',                  't':'AlphaClaw',                                          'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'cli-anything-architecture.html',  't':'CLI-Anything — Agent-Native Software',               'd':'2026-03-12', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'decapod.html',                    't':'Decapod',                                            'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'droid-cli-orchestrator.html',     't':'Droid CLI Orchestrator',                             'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'forgeflow.html',                  't':'Forgeflow',                                          'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'fractals.html',                   't':'Fractals',                                           'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'get-shit-done.html',              't':'Get Shit Done',                                      'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'gstack.html',                     't':'gstack',                                             'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'jido.html',                       't':'Jido',                                               'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'library-meta-skill-recap.html',   't':'The Library Meta-Skill — Video Recap',               'd':'2026-03-16', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'mission-control.html',            't':'Mission Control',                                    'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'oh-my-openagent.html',            't':'Oh My OpenAgent',                                    'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'opencode-workflow.html',          't':'OpenCode Workflow',                                  'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'orchestra.html',                  't':'Open Orchestra',                                     'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'paperclip.html',                  't':'Paperclip',                                          'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'pi-mono.html',                    't':'Pi Monorepo',                                        'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'pro-workflow.html',               't':'Pro Workflow',                                       'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'qaya-visual.html',                't':'Qaya — Architecture cognitive persistante',           'd':'2026-03-10', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'spec-kit.html',                   't':'Spec Kit',                                           'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'superpowers.html',                't':'Superpowers',                                        'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'symphony.html',                   't':'Symphony',                                           'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'upstream-diff-review.html',       't':'Upstream Diff Review: roxabi-dashboard vs boilerplate','d':'2026-03-10','cat':'ext','cl':'External','c':'green','b':[]},
+    {'f':'valora-ai-v2.html',               't':'VALORA v2',                                          'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':['latest']},
+    {'f':'valora-ai.html',                  't':'VALORA.AI v1',                                       'd':'2026-03-12', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'valora-vs-pi.html',               't':'VALORA.AI vs Pi Agent — Comparison',                 'd':'2026-03-12', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+    {'f':'wshobson-agents.html',            't':'wshobson/agents — Visual Explainer',                 'd':'2026-03-13', 'cat':'ext', 'cl':'External', 'c':'green', 'b':[]},
+]
+
+START = '<!-- diagram-meta:start -->'
+END   = '<!-- diagram-meta:end -->'
+BLOCK_RE = re.compile(r'\s*' + re.escape(START) + r'.*?' + re.escape(END) + r'\n?', re.DOTALL)
+
+
+def build_block(e):
+    badges = ','.join(e['b'])
+    lines = [
+        START,
+        f'<meta name="diagram:title"     content="{e["t"]}">',
+        f'<meta name="diagram:date"      content="{e["d"]}">',
+        f'<meta name="diagram:category"  content="{e["cat"]}">',
+        f'<meta name="diagram:cat-label" content="{e["cl"]}">',
+        f'<meta name="diagram:color"     content="{e["c"]}">',
+    ]
+    if badges:
+        lines.append(f'<meta name="diagram:badges"    content="{badges}">')
+    lines.append(END)
+    return '\n'.join(lines) + '\n'
+
+
+def inject(filepath, block):
+    text = filepath.read_text(encoding='utf-8')
+    # Remove existing block
+    text = BLOCK_RE.sub('', text)
+    # Insert before </head>
+    text = text.replace('</head>', block + '</head>', 1)
+    filepath.write_text(text, encoding='utf-8')
+
+
+ok, skip = 0, 0
+for entry in DATA:
+    fp = DIR / entry['f']
+    if not fp.exists():
+        print(f'SKIP (not found): {entry["f"]}')
+        skip += 1
+        continue
+    inject(fp, build_block(entry))
+    print(f'OK: {entry["f"]}')
+    ok += 1
+
+print(f'\nDone: {ok} injected, {skip} skipped.')
+print('Next: python3 gen-manifest.py')

--- a/forge/scripts/update-meta.py
+++ b/forge/scripts/update-meta.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""update-meta.py — one-shot script to audit and correct all diagram meta tags.
+
+Strategy:
+  - Use <title> from the HTML as the authoritative title for most files.
+  - OVERRIDES dict wins when the html <title> is too generic or missing version info.
+  - New files (no existing meta block) get full metadata from NEW_FILES dict.
+  - After running, call gen-manifest.py to rebuild manifest.json.
+"""
+import os, re, html as html_lib
+from pathlib import Path
+
+DIR = Path(os.environ.get('FORGE_DIR', os.environ.get('DIAGRAMS_DIR', Path.home() / '.roxabi' / 'forge')))
+
+START = '<!-- diagram-meta:start -->'
+END   = '<!-- diagram-meta:end -->'
+BLOCK_RE   = re.compile(r'\s*' + re.escape(START) + r'.*?' + re.escape(END) + r'\n?', re.DOTALL)
+HTML_TITLE = re.compile(r'<title>(.*?)</title>', re.IGNORECASE | re.DOTALL)
+META_RE    = re.compile(r'<meta\s+name="diagram:([\w-]+)"\s+content="([^"]*)"', re.IGNORECASE)
+
+
+# ── Title overrides (when <title> is too generic or strips useful version info) ──
+TITLE_OVERRIDES = {
+    # Strip "// Lyra" suffix that appears in some issue plan titles
+    '44-event-driven-monitoring-plan.html': 'Issue #44 — Event-Driven Agent Monitoring',
+    # Voice flow: html title is the French subtitle, meta title is cleaner
+    'lyra-voice-flow.html': 'Lyra — Voice Flow (flux complet)',
+    # Add version suffix to generic html titles
+    'lyra-user-guide-v6.html': 'Lyra — Documentation v6',
+    'lyra-user-guide.html':    'Lyra — Complete User Guide v1',
+    # VALORA files: html <title> doesn't mention v1/v2
+    'valora-ai-v2.html': 'VALORA v2',
+    'valora-ai.html':    'VALORA.AI v1',
+}
+
+# ── Fully new files that have no meta block yet ──
+NEW_FILES = {
+    'lyra-customer-personas.html': {
+        'd': '2026-03-18', 'cat': 'lyra', 'cl': 'Lyra Docs', 'c': 'blue', 'b': [],
+    },
+    'lyra-messaging-framework.html': {
+        'd': '2026-03-18', 'cat': 'lyra', 'cl': 'Lyra Docs', 'c': 'blue', 'b': [],
+    },
+    'lyra-positioning-exploration.html': {
+        'd': '2026-03-18', 'cat': 'lyra', 'cl': 'Lyra Docs', 'c': 'blue', 'b': [],
+    },
+}
+
+
+def read_existing_meta(text):
+    return dict(META_RE.findall(text))
+
+
+def html_title(text):
+    m = HTML_TITLE.search(text)
+    if not m:
+        return ''
+    return html_lib.unescape(m.group(1).strip())
+
+
+def build_block(title, date, cat, cl, color, badges):
+    lines = [
+        START,
+        f'<meta name="diagram:title"     content="{title}">',
+        f'<meta name="diagram:date"      content="{date}">',
+        f'<meta name="diagram:category"  content="{cat}">',
+        f'<meta name="diagram:cat-label" content="{cl}">',
+        f'<meta name="diagram:color"     content="{color}">',
+    ]
+    if badges:
+        lines.append(f'<meta name="diagram:badges"    content="{",".join(badges)}">')
+    lines.append(END)
+    return '\n'.join(lines) + '\n'
+
+
+def inject(filepath, block):
+    text = filepath.read_text(encoding='utf-8')
+    text = BLOCK_RE.sub('', text)
+    text = text.replace('</head>', block + '</head>', 1)
+    filepath.write_text(text, encoding='utf-8')
+
+
+ok = skip = 0
+
+for fp in sorted(DIR.glob('*.html')):
+    if fp.name == 'index.html':
+        continue
+
+    text = fp.read_text(encoding='utf-8')
+    existing = read_existing_meta(text)
+    htitle   = html_title(text)
+
+    if fp.name in NEW_FILES:
+        # Brand new file — bootstrap from NEW_FILES dict
+        info = NEW_FILES[fp.name]
+        title  = TITLE_OVERRIDES.get(fp.name, htitle) or fp.stem
+        badges = info.get('b', [])
+        block  = build_block(title, info['d'], info['cat'], info['cl'], info['c'], badges)
+        inject(fp, block)
+        print(f'NEW  {fp.name}  →  {title!r}')
+        ok += 1
+        continue
+
+    if not existing:
+        print(f'SKIP {fp.name}  (no existing meta and not in NEW_FILES)')
+        skip += 1
+        continue
+
+    # Determine the best title
+    title = TITLE_OVERRIDES.get(fp.name) or htitle or existing.get('title', fp.stem)
+
+    # Keep everything else from the existing meta
+    date   = existing.get('date', '')
+    cat    = existing.get('category', '')
+    cl     = existing.get('cat-label', '')
+    color  = existing.get('color', 'blue')
+    badges = [b.strip() for b in existing.get('badges', '').split(',') if b.strip()]
+
+    block = build_block(title, date, cat, cl, color, badges)
+    inject(fp, block)
+
+    old_title = existing.get('title', '')
+    if old_title != title:
+        print(f'UPD  {fp.name}')
+        print(f'       {old_title!r}')
+        print(f'    →  {title!r}')
+    else:
+        print(f'OK   {fp.name}')
+    ok += 1
+
+print(f'\nDone: {ok} updated, {skip} skipped.')
+print('Next: python3 gen-manifest.py')

--- a/plugins/forge/references/gallery-templates/gallery-base.js
+++ b/plugins/forge/references/gallery-templates/gallery-base.js
@@ -305,7 +305,12 @@ function initStarred(storeKey, suffix) {
  * @returns {string} HTML-safe string
  */
 function escHtml(s) {
-  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
 }
 
 /**


### PR DESCRIPTION
## Summary

- Move 6 forge build/deploy scripts (`build.sh`, `gen-manifest.py`, `gen-deps.py`, `gen-image-manifests.py`, `seed-meta.py`, `update-meta.py`) from `lyra-stack/forge/` to `forge/scripts/`
- Add `Makefile` with `forge-build`, `forge-deploy`, `forge-deploy-prod`, `forge-du` targets
- Fix `__file__` fallbacks in 3 scripts to use `~/.roxabi/forge` default instead of script directory

Closes Roxabi/lyra#507

## Test plan

- [x] `make forge-build` runs successfully from roxabi-plugins
- [ ] `make forge-deploy` deploys to Cloudflare Pages (requires `.env` with credentials)
- [ ] `make forge-deploy-prod` rsyncs to production
- [x] All 296 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)