### PR TITLE
feat(forge): add base/ layer + shells/ for design system

### DIFF
--- a/plugins/forge/references/base/components.css
+++ b/plugins/forge/references/base/components.css
@@ -1,0 +1,78 @@
+/* ══════════════════════════════════════════════════════════════════
+   components.css — cards, tables, semantic color tokens, anti-patterns
+   Part of forge base/ layer. Inline after typography.css.
+
+   Semantic color tokens are consumed by the component library (#82).
+   Each aesthetic file overrides their values.
+   ══════════════════════════════════════════════════════════════════ */
+
+/* FORGE ANTI-PATTERNS — DO NOT USE
+   - No box-shadow with multiple blur layers (glassmorphism)
+   - No text-shadow except .c-* colored ASCII blocks
+   - No gradient backgrounds (use flat surface tokens)
+   - No border-radius > 8px on content cards
+   - No decorative ::before/::after icons (use text or svg)
+   - No animation/transition except theme-toggle (0.15s max)
+*/
+
+/* ── Semantic Color Tokens — Dark ── */
+:root, [data-theme="dark"] {
+  --success:     #34d399;
+  --success-dim: rgba(52,211,153,0.12);
+  --warning:     #fbbf24;
+  --warning-dim: rgba(251,191,36,0.12);
+  --error:       #f87171;
+  --error-dim:   rgba(248,113,113,0.12);
+  --info:        #60a5fa;
+  --info-dim:    rgba(96,165,250,0.12);
+}
+
+/* ── Semantic Color Tokens — Light ── */
+[data-theme="light"] {
+  --success:     #047857;
+  --success-dim: rgba(4,120,87,0.1);
+  --warning:     #d97706;
+  --warning-dim: rgba(217,119,6,0.1);
+  --error:       #dc2626;
+  --error-dim:   rgba(220,38,38,0.1);
+  --info:        #2563eb;
+  --info-dim:    rgba(37,99,235,0.1);
+}
+
+/* ── Cards ── */
+.card {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 1.25rem;
+}
+.card.accent { border-left: 3px solid var(--accent); }
+.card-label {
+  font-size: 0.6875rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--accent); margin-bottom: 0.5rem;
+}
+.card-title {
+  font-size: 0.9375rem; font-weight: 600;
+  color: var(--text); margin-bottom: 0.375rem;
+}
+.card-body { font-size: 0.875rem; color: var(--text-muted); }
+
+/* ── Tables ── */
+.table-wrap {
+  overflow-x: auto; margin-bottom: 1.5rem;
+  border: 1px solid var(--border); border-radius: 6px;
+}
+table { width: 100%; border-collapse: collapse; }
+thead th {
+  background: var(--surface); color: var(--text-dim);
+  font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.06em;
+  padding: 0.5rem 0.75rem; text-align: left;
+  border-bottom: 1px solid var(--border);
+  position: sticky; top: 3rem;
+}
+tbody td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted); font-size: 0.875rem;
+}
+tbody tr:last-child td { border-bottom: none; }
+tbody tr:hover td { background: var(--surface); }

--- a/plugins/forge/references/base/components.css
+++ b/plugins/forge/references/base/components.css
@@ -12,7 +12,7 @@
    - No gradient backgrounds (use flat surface tokens)
    - No border-radius > 8px on content cards
    - No decorative ::before/::after icons (use text or svg)
-   - No animation/transition except theme-toggle (0.15s max)
+   - No animation/transition except theme-toggle and tab hover (0.15s max)
 */
 
 /* ── Semantic Color Tokens — Dark ── */

--- a/plugins/forge/references/base/layout.css
+++ b/plugins/forge/references/base/layout.css
@@ -1,0 +1,51 @@
+/* ══════════════════════════════════════════════════════════════════
+   layout.css — navigation, panels, grid utilities, responsive
+   Part of forge base/ layer. Inline after reset.css.
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Nav ── */
+.topnav {
+  position: sticky; top: 0; z-index: 100;
+  display: flex; align-items: center; gap: 1rem;
+  padding: 0 1.5rem; height: 3rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+.nav-title {
+  font-size: 0.875rem; font-weight: 600;
+  color: var(--text); margin-right: auto; white-space: nowrap;
+}
+.tabs { display: flex; gap: 0.25rem; }
+.tab-btn {
+  padding: 0.375rem 0.875rem; font-size: 0.8125rem;
+  font-family: inherit; font-weight: 500;
+  color: var(--text-dim); background: transparent;
+  border: none; border-radius: 4px; cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+.tab-btn:hover  { color: var(--text-muted); background: var(--bg); }
+.tab-btn.active { color: var(--accent);     background: var(--bg); }
+.theme-btn {
+  padding: 0.25rem 0.5rem; font-size: 0.75rem;
+  color: var(--text-dim); background: transparent;
+  border: 1px solid var(--border); border-radius: 4px; cursor: pointer;
+}
+.theme-btn:hover { color: var(--text-muted); }
+
+/* ── Panels ── */
+.panel { display: none; padding: 2rem 1.5rem; max-width: 960px; margin: 0 auto; }
+.panel.active { display: block; }
+
+/* ── Cards Grid ── */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem; margin-bottom: 1.5rem;
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .topnav { padding: 0 1rem; flex-wrap: wrap; height: auto; padding-block: 0.5rem; }
+  .tabs { overflow-x: auto; width: 100%; }
+  .panel { padding: 1.5rem 1rem; }
+}

--- a/plugins/forge/references/base/mermaid-init.js
+++ b/plugins/forge/references/base/mermaid-init.js
@@ -9,14 +9,15 @@
      <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/dist/svg-pan-zoom.min.js"></script>
    ══════════════════════════════════════════════════════════════════ */
 
-window.__postLoad = async function (id, panel) {
-  var srcEl     = panel.querySelector('[data-mermaid]')
+window.__postLoad = async (id, panel) => {
+  var srcEl = panel.querySelector('[data-mermaid]')
   var container = panel.querySelector('[data-mermaid-out]')
   if (!srcEl || !container) return
   var { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs')
   mermaid.initialize({
-    startOnLoad: false, theme: 'base',
-    flowchart: { useMaxWidth: false, curve: 'basis' }
+    startOnLoad: false,
+    theme: 'base',
+    flowchart: { useMaxWidth: false, curve: 'basis' },
   })
   var { svg, bindFunctions } = await mermaid.render('mermaid-' + id, srcEl.textContent.trim())
   container.innerHTML = svg
@@ -24,13 +25,17 @@ window.__postLoad = async function (id, panel) {
   if (typeof window.__initPanZoom === 'function') window.__initPanZoom(container)
 }
 
-window.__initPanZoom = function (container) {
+window.__initPanZoom = (container) => {
   var svgEl = container.querySelector('svg')
   if (!svgEl || typeof svgPanZoom === 'undefined') return
   svgEl.style.maxWidth = 'none'
   svgEl.style.height = 'auto'
   svgPanZoom(svgEl, {
-    zoomEnabled: true, controlIconsEnabled: true,
-    fit: true, center: true, minZoom: 0.5, maxZoom: 4
+    zoomEnabled: true,
+    controlIconsEnabled: true,
+    fit: true,
+    center: true,
+    minZoom: 0.5,
+    maxZoom: 4,
   })
 }

--- a/plugins/forge/references/base/mermaid-init.js
+++ b/plugins/forge/references/base/mermaid-init.js
@@ -1,0 +1,36 @@
+/* ══════════════════════════════════════════════════════════════════
+   mermaid-init.js — Mermaid diagram rendering + optional pan/zoom
+   Part of forge base/ layer. Inline verbatim (no placeholders).
+
+   Only include when tabs contain Mermaid diagrams. Tab fragments
+   must have: <pre data-mermaid>...</pre> + <div data-mermaid-out></div>
+
+   For pan/zoom, add to <head>:
+     <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/dist/svg-pan-zoom.min.js"></script>
+   ══════════════════════════════════════════════════════════════════ */
+
+window.__postLoad = async function (id, panel) {
+  var srcEl     = panel.querySelector('[data-mermaid]')
+  var container = panel.querySelector('[data-mermaid-out]')
+  if (!srcEl || !container) return
+  var { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs')
+  mermaid.initialize({
+    startOnLoad: false, theme: 'base',
+    flowchart: { useMaxWidth: false, curve: 'basis' }
+  })
+  var { svg, bindFunctions } = await mermaid.render('mermaid-' + id, srcEl.textContent.trim())
+  container.innerHTML = svg
+  if (bindFunctions) bindFunctions(container.querySelector('svg'))
+  if (typeof window.__initPanZoom === 'function') window.__initPanZoom(container)
+}
+
+window.__initPanZoom = function (container) {
+  var svgEl = container.querySelector('svg')
+  if (!svgEl || typeof svgPanZoom === 'undefined') return
+  svgEl.style.maxWidth = 'none'
+  svgEl.style.height = 'auto'
+  svgPanZoom(svgEl, {
+    zoomEnabled: true, controlIconsEnabled: true,
+    fit: true, center: true, minZoom: 0.5, maxZoom: 4
+  })
+}

--- a/plugins/forge/references/base/reset.css
+++ b/plugins/forge/references/base/reset.css
@@ -1,0 +1,36 @@
+/* ══════════════════════════════════════════════════════════════════
+   reset.css — box-sizing reset, antialiasing, baseline token contract
+   Part of forge base/ layer. Read once, inline into <style>.
+
+   Token contract: every aesthetic file must define the same custom
+   properties listed below. These are Lyra theme defaults.
+   Roxabi theme values are in aesthetics/roxabi.css (issue #79).
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Reset ── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+
+/* ── Baseline Tokens — Lyra Dark (default) ── */
+:root, [data-theme="dark"] {
+  --bg:         #0a0a0f;
+  --surface:    #18181f;
+  --border:     #2a2a35;
+  --text:       #fafafa;
+  --text-muted: #9ca3af;
+  --text-dim:   #6b7280;
+  --accent:     #e85d04;
+  --accent-dim: #7c2d0e;
+}
+
+/* ── Baseline Tokens — Lyra Light ── */
+[data-theme="light"] {
+  --bg:         #fafaf9;
+  --surface:    #f4f4f0;
+  --border:     #d1ccc7;
+  --text:       #1c1917;
+  --text-muted: #57534e;
+  --text-dim:   #78716c;
+  --accent:     #c2410c;
+  --accent-dim: #fef2e8;
+}

--- a/plugins/forge/references/base/tab-loader.js
+++ b/plugins/forge/references/base/tab-loader.js
@@ -1,0 +1,44 @@
+/* ══════════════════════════════════════════════════════════════════
+   tab-loader.js — lazy tab loading + activation for split-file diagrams
+   Part of forge base/ layer.
+
+   IMPORTANT: Before inlining, substitute {NAME} with the diagram's
+   kebab-case slug (e.g., "lyra-user-guide"). The fetch URL uses it
+   to locate tab fragment files at tabs/{NAME}/tab-{id}.html.
+
+   Theme toggle is NOT here — it lives inline in shells/ per ADR-011.
+   ══════════════════════════════════════════════════════════════════ */
+
+;(function () {
+  function loadPanel (id) {
+    var panel = document.querySelector('[data-panel="' + id + '"]')
+    if (!panel || panel._loaded) return
+    fetch('tabs/{NAME}/tab-' + id + '.html')
+      .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status) })
+      .then(function (html) {
+        panel.innerHTML = html
+        panel._loaded = true
+        if (typeof window.__postLoad === 'function') window.__postLoad(id, panel)
+      })
+      .catch(function (e) {
+        panel.innerHTML = '<p style="padding:2rem;color:var(--text-muted)">Failed to load (' + e + ')</p>'
+      })
+  }
+
+  function activate (id) {
+    document.querySelectorAll('[data-tab]').forEach(function (t) {
+      t.classList.toggle('active', t.dataset.tab === id)
+    })
+    document.querySelectorAll('[data-panel]').forEach(function (p) {
+      p.classList.toggle('active', p.dataset.panel === id)
+    })
+    loadPanel(id)
+  }
+
+  document.querySelectorAll('[data-tab]').forEach(function (t) {
+    t.addEventListener('click', function () { activate(t.dataset.tab) })
+  })
+
+  var first = document.querySelector('[data-tab]')
+  if (first) activate(first.dataset.tab)
+})()

--- a/plugins/forge/references/base/tab-loader.js
+++ b/plugins/forge/references/base/tab-loader.js
@@ -9,34 +9,43 @@
    Theme toggle is NOT here — it lives inline in shells/ per ADR-011.
    ══════════════════════════════════════════════════════════════════ */
 
-;(function () {
-  function loadPanel (id) {
+;(() => {
+  function loadPanel(id) {
     var panel = document.querySelector('[data-panel="' + id + '"]')
     if (!panel || panel._loaded) return
     fetch('tabs/{NAME}/tab-' + id + '.html')
-      .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status) })
-      .then(function (html) {
+      .then((r) => (r.ok ? r.text() : Promise.reject(r.status)))
+      .then((html) => {
         panel.innerHTML = html
         panel._loaded = true
         if (typeof window.__postLoad === 'function') window.__postLoad(id, panel)
       })
-      .catch(function (e) {
-        panel.innerHTML = '<p style="padding:2rem;color:var(--text-muted)">Failed to load (' + e + ')</p>'
+      .catch((e) => {
+        var err = document.createElement('p')
+        err.style.cssText = 'padding:2rem;color:var(--text-muted)'
+        err.textContent = 'Failed to load (' + e + ')'
+        panel.innerHTML = ''
+        panel.appendChild(err)
       })
   }
 
-  function activate (id) {
-    document.querySelectorAll('[data-tab]').forEach(function (t) {
-      t.classList.toggle('active', t.dataset.tab === id)
+  function activate(id) {
+    document.querySelectorAll('[data-tab]').forEach((t) => {
+      var isSelected = t.dataset.tab === id
+      t.classList.toggle('active', isSelected)
+      t.setAttribute('aria-selected', isSelected ? 'true' : 'false')
+      t.setAttribute('tabindex', isSelected ? '0' : '-1')
     })
-    document.querySelectorAll('[data-panel]').forEach(function (p) {
+    document.querySelectorAll('[data-panel]').forEach((p) => {
       p.classList.toggle('active', p.dataset.panel === id)
     })
     loadPanel(id)
   }
 
-  document.querySelectorAll('[data-tab]').forEach(function (t) {
-    t.addEventListener('click', function () { activate(t.dataset.tab) })
+  document.querySelectorAll('[data-tab]').forEach((t) => {
+    t.addEventListener('click', () => {
+      activate(t.dataset.tab)
+    })
   })
 
   var first = document.querySelector('[data-tab]')

--- a/plugins/forge/references/base/typography.css
+++ b/plugins/forge/references/base/typography.css
@@ -1,0 +1,43 @@
+/* ══════════════════════════════════════════════════════════════════
+   typography.css — font loading, type scale, code blocks
+   Part of forge base/ layer. Inline after layout.css.
+
+   Preconnect (add to <head> of output HTML):
+     <link rel="preconnect" href="https://fonts.googleapis.com">
+     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono&display=swap" rel="stylesheet">
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Body ── */
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'IBM Plex Sans', system-ui, sans-serif;
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+/* ── Headings ── */
+h1, h2, h3, h4 { color: var(--text); font-weight: 600; }
+h1 { font-size: 1.75rem; margin-bottom: 0.75rem; }
+h2 { font-size: 1.25rem; margin: 2rem 0 0.75rem; }
+h3 { font-size: 1rem;    margin: 1.5rem 0 0.5rem; }
+
+/* ── Body Text ── */
+p  { color: var(--text-muted); margin-bottom: 0.875rem; }
+ul, ol { color: var(--text-muted); padding-left: 1.5rem; margin-bottom: 0.875rem; }
+li { margin-bottom: 0.25rem; }
+
+/* ── Code ── */
+code {
+  font-family: 'IBM Plex Mono', monospace; font-size: 0.875em;
+  background: var(--surface); border: 1px solid var(--border);
+  padding: 0.125em 0.35em; border-radius: 3px; color: var(--text);
+}
+pre {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 1rem; overflow-x: auto; margin-bottom: 1rem;
+}
+pre code {
+  background: none; border: none; padding: 0;
+  font-size: 0.875rem; white-space: pre-wrap;
+}

--- a/plugins/forge/references/shells/single.html
+++ b/plugins/forge/references/shells/single.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{TITLE}</title>
+  <!-- diagram-meta:start -->
+  <meta name="diagram:title"     content="{TITLE}">
+  <meta name="diagram:date"      content="{DATE}">
+  <meta name="diagram:category"  content="{CATEGORY}">
+  <meta name="diagram:cat-label" content="{CAT_LABEL}">
+  <meta name="diagram:color"     content="{COLOR}">
+  <meta name="diagram:badges"    content="{BADGES}">
+  <!-- diagram-meta:end -->
+  <!-- PRECONNECT: Add Google Fonts links for the aesthetic's font pair -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono&display=swap" rel="stylesheet">
+  <!-- HEAD_EXTRAS: Optional <head> tags (e.g., svg-pan-zoom CDN for Mermaid pan/zoom) -->
+  {HEAD_EXTRAS}
+  <style>
+    /* BASE_STYLES: Concatenate base/*.css in order: reset → layout → typography → components */
+    {BASE_STYLES}
+
+    /* AESTHETIC_STYLES: Aesthetic CSS override (empty if no aesthetic selected) */
+    {AESTHETIC_STYLES}
+
+    /* EXTRA_STYLES: Diagram-specific CSS additions */
+    {EXTRA_STYLES}
+  </style>
+</head>
+<body>
+  <!-- CONTENT: Self-contained diagram body (cards, grids, Mermaid containers, etc.) -->
+  {CONTENT}
+
+  <script>
+    /* ── Theme Toggle (inline per ADR-011) ── */
+    ;(function () {
+      var THEME_KEY = 'diag-{NAME}-theme'
+      var saved = localStorage.getItem(THEME_KEY) || 'dark'
+      document.documentElement.setAttribute('data-theme', saved)
+      var themeBtn = document.getElementById('theme-toggle')
+      if (themeBtn) {
+        themeBtn.textContent = saved === 'dark' ? '◑ light' : '◑ dark'
+        themeBtn.addEventListener('click', function () {
+          var cur  = document.documentElement.getAttribute('data-theme')
+          var next = cur === 'dark' ? 'light' : 'dark'
+          document.documentElement.setAttribute('data-theme', next)
+          localStorage.setItem(THEME_KEY, next)
+          this.textContent = next === 'dark' ? '◑ light' : '◑ dark'
+        })
+      }
+    })()
+  </script>
+  <!-- EXTRA_SCRIPTS: Optional — mermaid-init.js or custom JS -->
+  <script>
+    {EXTRA_SCRIPTS}
+  </script>
+</body>
+</html>

--- a/plugins/forge/references/shells/single.html
+++ b/plugins/forge/references/shells/single.html
@@ -32,6 +32,9 @@
   <!-- CONTENT: Self-contained diagram body (cards, grids, Mermaid containers, etc.) -->
   {CONTENT}
 
+  <!-- Theme Toggle: Position as needed for diagram type -->
+  <button class="theme-btn" id="theme-toggle" aria-label="Toggle color theme" aria-pressed="false">◑ light</button>
+
   <script>
     /* ── Theme Toggle (inline per ADR-011) ── */
     ;(function () {
@@ -41,12 +44,14 @@
       var themeBtn = document.getElementById('theme-toggle')
       if (themeBtn) {
         themeBtn.textContent = saved === 'dark' ? '◑ light' : '◑ dark'
+        themeBtn.setAttribute('aria-pressed', saved === 'light' ? 'true' : 'false')
         themeBtn.addEventListener('click', function () {
           var cur  = document.documentElement.getAttribute('data-theme')
           var next = cur === 'dark' ? 'light' : 'dark'
           document.documentElement.setAttribute('data-theme', next)
           localStorage.setItem(THEME_KEY, next)
           this.textContent = next === 'dark' ? '◑ light' : '◑ dark'
+          this.setAttribute('aria-pressed', next === 'light' ? 'true' : 'false')
         })
       }
     })()

--- a/plugins/forge/references/shells/split.html
+++ b/plugins/forge/references/shells/split.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{TITLE}</title>
+  <!-- diagram-meta:start -->
+  <meta name="diagram:title"     content="{TITLE}">
+  <meta name="diagram:date"      content="{DATE}">
+  <meta name="diagram:category"  content="{CATEGORY}">
+  <meta name="diagram:cat-label" content="{CAT_LABEL}">
+  <meta name="diagram:color"     content="{COLOR}">
+  <meta name="diagram:badges"    content="{BADGES}">
+  <!-- diagram-meta:end -->
+  <!-- PRECONNECT: Add Google Fonts links for the aesthetic's font pair -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono&display=swap" rel="stylesheet">
+  <!-- HEAD_EXTRAS: Optional <head> tags (e.g., svg-pan-zoom CDN for Mermaid pan/zoom) -->
+  {HEAD_EXTRAS}
+  <style>
+    /* BASE_STYLES: Concatenate base/*.css in order: reset → layout → typography → components */
+    {BASE_STYLES}
+
+    /* AESTHETIC_STYLES: Aesthetic CSS override (empty if no aesthetic selected) */
+    {AESTHETIC_STYLES}
+
+    /* EXTRA_STYLES: Guide-specific CSS additions */
+    {EXTRA_STYLES}
+  </style>
+</head>
+<body>
+  <nav class="topnav">
+    <span class="nav-title">{TITLE}</span>
+    <div class="tabs" role="tablist">
+      <!-- TABS: Tab button elements — one per tab -->
+      <!-- Example: <button class="tab-btn" data-tab="overview" role="tab">Overview</button> -->
+      {TABS}
+    </div>
+    <button class="theme-btn" id="theme-toggle">◑ light</button>
+  </nav>
+  <main>
+    <!-- PANELS: Panel container elements — one per tab, matching data-tab IDs -->
+    <!-- Example: <div class="panel" data-panel="overview" role="tabpanel"></div> -->
+    {PANELS}
+  </main>
+
+  <script>
+    /* ── Theme Toggle (inline per ADR-011 — MUST appear before tab-loader) ── */
+    ;(function () {
+      var THEME_KEY = 'diag-{NAME}-theme'
+      var saved = localStorage.getItem(THEME_KEY) || 'dark'
+      document.documentElement.setAttribute('data-theme', saved)
+      var themeBtn = document.getElementById('theme-toggle')
+      if (themeBtn) {
+        themeBtn.textContent = saved === 'dark' ? '◑ light' : '◑ dark'
+        themeBtn.addEventListener('click', function () {
+          var cur  = document.documentElement.getAttribute('data-theme')
+          var next = cur === 'dark' ? 'light' : 'dark'
+          document.documentElement.setAttribute('data-theme', next)
+          localStorage.setItem(THEME_KEY, next)
+          this.textContent = next === 'dark' ? '◑ light' : '◑ dark'
+        })
+      }
+    })()
+  </script>
+  <script>
+    /* TAB_LOADER_JS: tab-loader.js content with {NAME} already substituted.
+       Runs AFTER theme-toggle JS in document order. */
+    {TAB_LOADER_JS}
+  </script>
+  <!-- EXTRA_SCRIPTS: Optional — mermaid-init.js or custom JS -->
+  <script>
+    {EXTRA_SCRIPTS}
+  </script>
+</body>
+</html>

--- a/plugins/forge/references/shells/split.html
+++ b/plugins/forge/references/shells/split.html
@@ -29,14 +29,14 @@
   </style>
 </head>
 <body>
-  <nav class="topnav">
+  <nav class="topnav" aria-label="Main">
     <span class="nav-title">{TITLE}</span>
     <div class="tabs" role="tablist">
       <!-- TABS: Tab button elements — one per tab -->
       <!-- Example: <button class="tab-btn" data-tab="overview" role="tab">Overview</button> -->
       {TABS}
     </div>
-    <button class="theme-btn" id="theme-toggle">◑ light</button>
+    <button class="theme-btn" id="theme-toggle" aria-label="Toggle color theme" aria-pressed="false">◑ light</button>
   </nav>
   <main>
     <!-- PANELS: Panel container elements — one per tab, matching data-tab IDs -->
@@ -53,12 +53,14 @@
       var themeBtn = document.getElementById('theme-toggle')
       if (themeBtn) {
         themeBtn.textContent = saved === 'dark' ? '◑ light' : '◑ dark'
+        themeBtn.setAttribute('aria-pressed', saved === 'light' ? 'true' : 'false')
         themeBtn.addEventListener('click', function () {
           var cur  = document.documentElement.getAttribute('data-theme')
           var next = cur === 'dark' ? 'light' : 'dark'
           document.documentElement.setAttribute('data-theme', next)
           localStorage.setItem(THEME_KEY, next)
           this.textContent = next === 'dark' ? '◑ light' : '◑ dark'
+          this.setAttribute('aria-pressed', next === 'light' ? 'true' : 'false')
         })
       }
     })()


### PR DESCRIPTION
## Summary
- Extract forge's prose-embedded CSS/JS from `tokens.md` and `split-file.md` into 8 actual code files (`base/` × 6 + `shells/` × 2) so skills read and inline verbatim — eliminates per-invocation CSS re-derivation and visual drift
- Introduces semantic color token contract (`--success/warning/error/info` + dim variants) and anti-pattern enforcement block in `components.css`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #78: forge: foundation — base/ layer + shells/ (S1–S3) | Open |
| Analysis | [forge-design-system-evolution-analysis.mdx](artifacts/analyses/forge-design-system-evolution-analysis.mdx) | Present (epic-level) |
| Spec | [78-forge-foundation-base-shells-spec.mdx](artifacts/specs/78-forge-foundation-base-shells-spec.mdx) | Approved |
| Implementation | 1 commit on `feat/78-forge-foundation-base-shells` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (296 passed, 0 new) | Passed |

## Files

| File | Purpose |
|------|---------|
| `base/reset.css` | Box-sizing, antialiasing, Lyra dark/light token blocks |
| `base/layout.css` | Nav, tabs, panels, cards grid, responsive breakpoint |
| `base/typography.css` | IBM Plex fonts, type scale, heading/paragraph/code styles |
| `base/components.css` | Cards, tables, semantic color tokens, anti-pattern block |
| `base/tab-loader.js` | `loadPanel()`/`activate()` with `{NAME}` placeholder |
| `base/mermaid-init.js` | `__postLoad` + `__initPanZoom` (inline verbatim) |
| `shells/single.html` | Self-contained diagram shell (`file://` safe) |
| `shells/split.html` | Multi-tab shell with tab-loader injection slot |

## Test Plan
- [ ] `cat base/reset.css base/layout.css base/typography.css base/components.css` produces valid concatenated CSS
- [ ] All hex color values appear only in `:root`/`[data-theme]` token blocks — no hardcoded colors in component rules
- [ ] `shells/single.html` contains all 13 placeholders from spec
- [ ] `shells/split.html` contains all 15 placeholders, theme toggle appears before `{TAB_LOADER_JS}`
- [ ] `gallery-templates/` directory is unchanged (zero modifications)
- [ ] Anti-pattern block present at top of `components.css` with 6 rules

Closes #78

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`