### PR TITLE
feat(forge): add editorial.css aesthetic (S6)

### DIFF
--- a/plugins/dev-core/cli/commands/issues.ts
+++ b/plugins/dev-core/cli/commands/issues.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { formatJson, formatTable, formatTree } from '../../skills/issues/lib/table-formatter'
-import { ISSUES_QUERY, buildBatchedQuery, buildBatchedVariables } from '../../skills/shared/queries'
+import { buildBatchedQuery, buildBatchedVariables, ISSUES_QUERY } from '../../skills/shared/queries'
 import type { RawItem } from '../../skills/shared/types'
 import { readWorkspace } from '../lib/workspace'
 
@@ -64,14 +64,11 @@ async function fetchProjectItems(projectId: string, token: string): Promise<RawI
 }
 
 /** Match cwd against localPath entries in workspace. Returns the first match or null. */
-function resolveCurrentProject(
-  projects: IssuesCommandProject[],
-  cwd: string,
-): IssuesCommandProject | null {
+function resolveCurrentProject(projects: IssuesCommandProject[], cwd: string): IssuesCommandProject | null {
   // Exact match first, then prefix match (cwd is inside localPath)
   return (
     projects.find((p) => p.localPath && cwd === p.localPath) ??
-    projects.find((p) => p.localPath && cwd.startsWith(p.localPath + '/')) ??
+    projects.find((p) => p.localPath && cwd.startsWith(`${p.localPath}/`)) ??
     null
   )
 }

--- a/plugins/dev-core/skills/issues/show.ts
+++ b/plugins/dev-core/skills/issues/show.ts
@@ -10,7 +10,7 @@ import { unlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-const issueNum = parseInt(process.argv[2] ?? '')
+const issueNum = parseInt(process.argv[2] ?? '', 10)
 if (!issueNum) {
   console.error('Usage: bun show.ts <issue-number>')
   process.exit(1)
@@ -46,7 +46,7 @@ function parseBlockedBy(body: string | null): number[] {
     }
     if (inSection && /^##/.test(line)) break
     if (inSection) {
-      for (const m of line.matchAll(/#(\d+)/g)) nums.push(parseInt(m[1]))
+      for (const m of line.matchAll(/#(\d+)/g)) nums.push(parseInt(m[1], 10))
     }
   }
   return nums
@@ -167,7 +167,7 @@ const meta: string[] = []
 if (otherLabels.length) meta.push(`Labels: ${otherLabels.join(', ')}`)
 meta.push(`Size: ${size}`)
 meta.push(`Priority: ${priority}`)
-if (issue.assignees.length) meta.push(`Assignees: ${issue.assignees.map((a) => '@' + a.login).join(', ')}`)
+if (issue.assignees.length) meta.push(`Assignees: ${issue.assignees.map((a) => `@${a.login}`).join(', ')}`)
 if (issue.milestone) meta.push(`Milestone: ${issue.milestone.title}`)
 lines.push(meta.join(' | '))
 

--- a/plugins/forge/references/aesthetics/editorial.css
+++ b/plugins/forge/references/aesthetics/editorial.css
@@ -1,0 +1,167 @@
+/* ══════════════════════════════════════════════════════════════════
+   editorial.css — warm technical document aesthetic (S6)
+   Inspired by nats-arch-roadmap.html. Overrides base tokens.
+
+   Fonts (add to <head>):
+     <link rel="preconnect" href="https://fonts.googleapis.com">
+     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Inter:wght@300;400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+
+   Identity: rich roadmap / guide / architecture document
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Baseline Tokens — Editorial Dark ── */
+:root, [data-theme="dark"] {
+  --bg:         #0d1117;
+  --surface:    #13191f;
+  --border:     #21262d;
+  --border-bright: #2d333b;
+  --text:       #fafafa;
+  --text-muted: #6b7280;
+  --text-dim:   #9ca3af;
+  --accent:     #fbbf24;
+  --accent-dim: rgba(251,191,36,0.15);
+}
+
+/* ── Baseline Tokens — Editorial Light ── */
+[data-theme="light"] {
+  --bg:         #f4f6f9;
+  --surface:    #ffffff;
+  --border:     #d1d5db;
+  --border-bright: #9ca3af;
+  --text:       #111827;
+  --text-muted: #6b7280;
+  --text-dim:   #374151;
+  --accent:     #d97706;
+  --accent-dim: rgba(217,119,6,0.12);
+}
+
+/* ── Semantic Color Tokens — Editorial Dark ── */
+:root, [data-theme="dark"] {
+  --success:     #4ade80;
+  --success-dim: rgba(74,222,128,0.10);
+  --warning:     #fbbf24;
+  --warning-dim: rgba(251,191,36,0.10);
+  --error:       #f87171;
+  --error-dim:   rgba(248,113,113,0.12);
+  --info:        #22d3ee;
+  --info-dim:    rgba(34,211,238,0.12);
+
+  /* Extended palette */
+  --cyan:        #22d3ee;
+  --cyan-dim:    rgba(34,211,238,0.12);
+  --green:       #4ade80;
+  --green-dim:   rgba(74,222,128,0.10);
+  --amber:       #fbbf24;
+  --amber-dim:   rgba(251,191,36,0.10);
+  --red:         #f87171;
+  --red-dim:     rgba(248,113,113,0.12);
+  --purple:      #c084fc;
+  --purple-dim:  rgba(192,132,252,0.10);
+}
+
+/* ── Semantic Color Tokens — Editorial Light ── */
+[data-theme="light"] {
+  --success:     #16a34a;
+  --success-dim: rgba(22,163,74,0.10);
+  --warning:     #d97706;
+  --warning-dim: rgba(217,119,6,0.10);
+  --error:       #dc2626;
+  --error-dim:   rgba(220,38,38,0.10);
+  --info:        #0891b2;
+  --info-dim:    rgba(8,145,178,0.10);
+
+  /* Extended palette */
+  --cyan:        #0891b2;
+  --cyan-dim:    rgba(8,145,178,0.10);
+  --green:       #16a34a;
+  --green-dim:   rgba(22,163,74,0.10);
+  --amber:       #d97706;
+  --amber-dim:   rgba(217,119,6,0.10);
+  --red:         #dc2626;
+  --red-dim:     rgba(220,38,38,0.10);
+  --purple:      #7c3aed;
+  --purple-dim:  rgba(124,58,237,0.10);
+}
+
+/* ── Typography Overrides ── */
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Outfit', sans-serif;
+}
+
+code, pre, .mono {
+  font-family: 'Space Mono', monospace;
+}
+
+/* ── Header Pattern ── */
+.header-eyebrow {
+  font-family: 'Space Mono', monospace;
+  font-size: 0.68rem;
+  color: var(--amber);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+header h1, .guide-title {
+  font-family: 'Outfit', sans-serif;
+  font-weight: 800;
+  font-size: clamp(1.3rem, 4vw, 1.9rem);
+  color: var(--text);
+  line-height: 1.15;
+}
+
+header h1 .accent { color: var(--amber); }
+
+.header-subtitle {
+  font-family: 'Space Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+/* ── Section Divider ── */
+.section-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.section-title::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(to right, var(--border-bright), transparent);
+}
+
+/* ── Card Color Borders ── */
+.card.high   { border-left: 3px solid var(--red);    }
+.card.medium { border-left: 3px solid var(--amber);  }
+.card.low    { border-left: 3px solid var(--green);  }
+.card.info   { border-left: 3px solid var(--cyan);   }
+.card.tech   { border-left: 3px solid var(--purple); }
+
+/* ── Badge / Pill Colors ── */
+.badge.green,  .pill.green  { background: var(--green-dim);  color: var(--green);  border: 1px solid rgba(74,222,128,0.35);  }
+.badge.amber,  .pill.amber  { background: var(--amber-dim);  color: var(--amber);  border: 1px solid rgba(251,191,36,0.35);  }
+.badge.cyan,   .pill.cyan   { background: var(--cyan-dim);   color: var(--cyan);   border: 1px solid rgba(34,211,238,0.35);   }
+.badge.red,    .pill.red    { background: var(--red-dim);    color: var(--red);    border: 1px solid rgba(248,113,113,0.35);    }
+.badge.purple, .pill.purple { background: var(--purple-dim); color: var(--purple); border: 1px solid rgba(192,132,252,0.35); }
+
+/* ── ASCII Diagram Colors ── */
+pre .c-green  { color: var(--green);  }
+pre .c-amber  { color: var(--amber);  }
+pre .c-cyan   { color: var(--cyan);   }
+pre .c-purple { color: var(--purple); }
+pre .c-red    { color: var(--red);    }
+pre .c-dim    { color: var(--text-muted); }
+pre .c-bright { color: var(--text); }

--- a/plugins/forge/references/base/mermaid-init.js
+++ b/plugins/forge/references/base/mermaid-init.js
@@ -19,7 +19,7 @@ window.__postLoad = async (id, panel) => {
     theme: 'base',
     flowchart: { useMaxWidth: false, curve: 'basis' },
   })
-  var { svg, bindFunctions } = await mermaid.render('mermaid-' + id, srcEl.textContent.trim())
+  var { svg, bindFunctions } = await mermaid.render(`mermaid-${id}`, srcEl.textContent.trim())
   container.innerHTML = svg
   if (bindFunctions) bindFunctions(container.querySelector('svg'))
   if (typeof window.__initPanZoom === 'function') window.__initPanZoom(container)

--- a/plugins/forge/references/base/tab-loader.js
+++ b/plugins/forge/references/base/tab-loader.js
@@ -11,9 +11,9 @@
 
 ;(() => {
   function loadPanel(id) {
-    var panel = document.querySelector('[data-panel="' + id + '"]')
+    var panel = document.querySelector(`[data-panel="${id}"]`)
     if (!panel || panel._loaded) return
-    fetch('tabs/{NAME}/tab-' + id + '.html')
+    fetch(`tabs/{NAME}/tab-${id}.html`)
       .then((r) => (r.ok ? r.text() : Promise.reject(r.status)))
       .then((html) => {
         panel.innerHTML = html
@@ -23,7 +23,7 @@
       .catch((e) => {
         var err = document.createElement('p')
         err.style.cssText = 'padding:2rem;color:var(--text-muted)'
-        err.textContent = 'Failed to load (' + e + ')'
+        err.textContent = `Failed to load (${e})`
         panel.innerHTML = ''
         panel.appendChild(err)
       })


### PR DESCRIPTION
## Summary
- Add `plugins/forge/references/aesthetics/editorial.css` — warm technical document aesthetic (S6)
- Inspired by nats-arch-roadmap.html: dark bg (#0d1117), warm surfaces (#13191f)
- Full semantic color palette: cyan, green, amber, red, purple with -dim variants
- Fonts: Outfit (display/headings) + Inter (body) + Space Mono (code)
- Header pattern, section dividers, card borders, badge/pill colors

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #81: forge: editorial aesthetic (S6) | OPEN |
| Implementation | 1 commit on `worktree-81-editorial-aesthetic` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (296 passed) | Passed |

## Test Plan
- [ ] Visual inspection: editorial.css matches nats-arch-roadmap visual quality
- [ ] Token contract: all base tokens defined (bg, surface, border, text, accent)
- [ ] Semantic colors: all 5 colors (cyan, green, amber, red, purple) with -dim variants
- [ ] Fonts: Outfit, Inter, Space Mono loaded via Google Fonts

Closes #81

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`