### PR TITLE
feat(forge): add blueprint + terminal aesthetics

### DIFF
--- a/plugins/dev-core/skills/shared/__tests__/config.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/config.test.ts
@@ -1,12 +1,18 @@
+import * as fs from 'node:fs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Mock node:fs so loadDevCoreConfig doesn't read .claude/dev-core.yml at import time.
+// Store the original readFileSync before we spy on it
+const originalReadFileSync = fs.readFileSync
+
+// Spy on fs.readFileSync to prevent loading .claude/dev-core.yml at import time.
 // This ensures tests see the "no config" defaults, not values from the repo's YAML file.
-vi.mock('node:fs', () => ({
-  readFileSync: () => {
+// Using spy instead of mock preserves real fs behavior for other tests (docs.ts, etc).
+const readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockImplementation((path, encoding) => {
+  if (path === '.claude/dev-core.yml') {
     throw new Error('ENOENT')
-  },
-}))
+  }
+  return originalReadFileSync(path as string, encoding as BufferEncoding | undefined)
+})
 
 // Clear option env vars before config module loads so defaults apply (not .env values)
 delete process.env.STATUS_OPTIONS_JSON
@@ -213,10 +219,16 @@ describe('BRANCH_PROTECTION_PAYLOAD', () => {
 describe('detectGitHubRepo', () => {
   const originalEnv = process.env.GITHUB_REPO
   let spawnSyncSpy: ReturnType<typeof vi.spyOn>
+  let execSyncSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     delete process.env.GITHUB_REPO
     spawnSyncSpy = vi.spyOn(Bun, 'spawnSync')
+    // Mock execSync to throw (simulating gh CLI not available)
+    // This forces the code to use git detection path
+    execSyncSpy = vi.spyOn(require('node:child_process'), 'execSync').mockImplementation(() => {
+      throw new Error('gh: command not found')
+    })
   })
 
   afterEach(() => {
@@ -226,6 +238,7 @@ describe('detectGitHubRepo', () => {
       delete process.env.GITHUB_REPO
     }
     spawnSyncSpy.mockRestore()
+    execSyncSpy.mockRestore()
   })
 
   it('prefers GITHUB_REPO env var when set', () => {
@@ -246,14 +259,16 @@ describe('detectGitHubRepo', () => {
   })
 
   it('parses HTTPS remote URL', () => {
+    const stdout = new TextEncoder().encode('https://github.com/Roxabi/roxabi-plugins.git\n')
     spawnSyncSpy.mockReturnValue({
-      stdout: new TextEncoder().encode('https://github.com/Roxabi/roxabi-plugins.git\n'),
+      stdout,
       stderr: new Uint8Array(),
       exitCode: 0,
       success: true,
     } as unknown as ReturnType<typeof Bun.spawnSync>)
 
-    expect(detectGitHubRepo()).toBe('Roxabi/roxabi-plugins')
+    const result = detectGitHubRepo()
+    expect(result).toBe('Roxabi/roxabi-plugins')
   })
 
   it('parses HTTPS remote URL without .git suffix', () => {
@@ -268,21 +283,11 @@ describe('detectGitHubRepo', () => {
   })
 
   it('throws when no env var, no git remote, and no gh CLI', async () => {
-    // Reset module registry and mock node modules so loadDevCoreConfig's gh fallback fails
-    vi.resetModules()
-    vi.doMock('node:child_process', () => ({
-      execSync: () => {
-        throw new Error('gh: command not found')
-      },
-    }))
-    vi.doMock('node:fs', () => ({
-      readFileSync: () => {
-        throw new Error('ENOENT')
-      },
-    }))
+    // Temporarily remove GITHUB_REPO env var to force git detection
+    const originalEnv = process.env.GITHUB_REPO
+    delete process.env.GITHUB_REPO
 
-    const { detectGitHubRepo: detect } = await import('../adapters/config-helpers')
-
+    // Mock git to fail
     spawnSyncSpy.mockReturnValue({
       stdout: new Uint8Array(),
       stderr: new TextEncoder().encode('fatal: not a git repository\n'),
@@ -290,9 +295,10 @@ describe('detectGitHubRepo', () => {
       success: false,
     } as unknown as ReturnType<typeof Bun.spawnSync>)
 
-    expect(() => detect()).toThrow('Cannot detect GitHub repo')
+    // The function should throw when detection fails
+    expect(() => detectGitHubRepo()).toThrow('Cannot detect GitHub repo')
 
-    vi.doUnmock('node:child_process')
-    vi.doUnmock('node:fs')
+    // Restore env
+    process.env.GITHUB_REPO = originalEnv
   })
 })

--- a/plugins/dev-core/skills/shared/__tests__/config.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/config.test.ts
@@ -1,17 +1,33 @@
-import * as fs from 'node:fs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Store the original readFileSync before we spy on it
-const originalReadFileSync = fs.readFileSync
-
-// Spy on fs.readFileSync to prevent loading .claude/dev-core.yml at import time.
-// This ensures tests see the "no config" defaults, not values from the repo's YAML file.
-// Using spy instead of mock preserves real fs behavior for other tests (docs.ts, etc).
-const readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockImplementation((path, encoding) => {
-  if (path === '.claude/dev-core.yml') {
-    throw new Error('ENOENT')
+// Mock fs to block only .claude/dev-core.yml, pass through everything else.
+// vi.spyOn doesn't work on ESM namespace objects (non-configurable exports).
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+  return {
+    ...actual,
+    readFileSync: (path: string, encoding?: BufferEncoding) => {
+      if (path === '.claude/dev-core.yml') {
+        throw new Error('ENOENT')
+      }
+      return actual.readFileSync(path, encoding ?? 'utf-8')
+    },
   }
-  return originalReadFileSync(path as string, encoding as BufferEncoding | undefined)
+})
+
+// Mock child_process.execSync to prevent gh CLI fallback in detectGitHubRepo
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
+  return {
+    ...actual,
+    execSync: (...args: Parameters<typeof actual.execSync>) => {
+      const cmd = String(args[0])
+      if (cmd.includes('gh repo view') || cmd.includes('gh api graphql')) {
+        throw new Error('gh not available')
+      }
+      return actual.execSync(...args)
+    },
+  }
 })
 
 // Clear option env vars before config module loads so defaults apply (not .env values)
@@ -219,16 +235,10 @@ describe('BRANCH_PROTECTION_PAYLOAD', () => {
 describe('detectGitHubRepo', () => {
   const originalEnv = process.env.GITHUB_REPO
   let spawnSyncSpy: ReturnType<typeof vi.spyOn>
-  let execSyncSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     delete process.env.GITHUB_REPO
     spawnSyncSpy = vi.spyOn(Bun, 'spawnSync')
-    // Mock execSync to throw (simulating gh CLI not available)
-    // This forces the code to use git detection path
-    execSyncSpy = vi.spyOn(require('node:child_process'), 'execSync').mockImplementation(() => {
-      throw new Error('gh: command not found')
-    })
   })
 
   afterEach(() => {
@@ -238,7 +248,6 @@ describe('detectGitHubRepo', () => {
       delete process.env.GITHUB_REPO
     }
     spawnSyncSpy.mockRestore()
-    execSyncSpy.mockRestore()
   })
 
   it('prefers GITHUB_REPO env var when set', () => {

--- a/plugins/forge/references/aesthetics/blueprint.css
+++ b/plugins/forge/references/aesthetics/blueprint.css
@@ -1,0 +1,211 @@
+/* ══════════════════════════════════════════════════════════════════
+   blueprint.css — engineering spec sheet aesthetic
+   Inspired by Blueprinter (yofine/skills)
+
+   Identity: flat engineering spec sheet — NO shadows, NO gradients,
+   NO rounded corners. Clean, clinical, high-contrast.
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Fonts ──
+   Add to <head>:
+   <link rel="preconnect" href="https://fonts.googleapis.com">
+   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+*/
+
+/* ── Root Tokens (Light Default) ── */
+:root {
+  /* Surface system — light layers */
+  --bg:         #f8fafc;     /* slate-50 — base background */
+  --surface:    #ffffff;     /* white — canvas / cards */
+  --border:     #cbd5e1;     /* slate-300 — borders */
+
+  /* Text hierarchy — high contrast */
+  --text:       #0f172a;     /* slate-900 — headings, primary */
+  --text-muted: #334155;     /* slate-700 — body text */
+  --text-dim:   #64748b;     /* slate-500 — metadata, labels */
+
+  /* Accent — minimal, errors/warnings only */
+  --accent:     #dc2626;     /* red-600 — warning/error accent */
+  --accent-dim: #fef2f2;     /* red-50 — dim surface */
+}
+
+/* ── Dark Mode Override ── */
+[data-theme="dark"] {
+  /* Surface system — inverted */
+  --bg:         #0f172a;     /* slate-900 */
+  --surface:    #1e293b;     /* slate-800 */
+  --border:     #334155;     /* slate-700 */
+
+  /* Text hierarchy */
+  --text:       #f8fafc;     /* slate-50 */
+  --text-muted: #cbd5e1;     /* slate-300 */
+  --text-dim:   #64748b;     /* slate-500 */
+
+  /* Accent */
+  --accent:     #f87171;     /* red-400 */
+  --accent-dim: rgba(248,113,113,0.12);
+}
+
+/* ── Semantic Color Tokens — Light ── */
+:root {
+  --success:     #047857;     /* emerald-700 */
+  --success-dim: rgba(4,120,87,0.1);
+  --warning:     #d97706;     /* amber-600 */
+  --warning-dim: rgba(217,119,6,0.1);
+  --error:       #dc2626;     /* red-600 */
+  --error-dim:   rgba(220,38,38,0.1);
+  --info:        #2563eb;     /* blue-600 */
+  --info-dim:    rgba(37,99,235,0.1);
+}
+
+/* ── Semantic Color Tokens — Dark ── */
+[data-theme="dark"] {
+  --success:     #34d399;     /* emerald-400 */
+  --success-dim: rgba(52,211,153,0.12);
+  --warning:     #fbbf24;     /* amber-400 */
+  --warning-dim: rgba(251,191,36,0.12);
+  --error:       #f87171;     /* red-400 */
+  --error-dim:   rgba(248,113,113,0.12);
+  --info:        #60a5fa;     /* blue-400 */
+  --info-dim:    rgba(96,165,250,0.12);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   OVERRIDES — flat spec sheet aesthetic
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Typography Override ── */
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+code, pre, .mono {
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ── Flat Cards — No Radius, No Shadow ── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0;           /* flat */
+  padding: 1.25rem;
+  box-shadow: none;           /* no shadow */
+}
+
+.card.accent {
+  border-left: 3px solid var(--accent);
+  border-radius: 0;
+}
+
+/* ── Flat Tables ── */
+.table-wrap {
+  border: 1px solid var(--border);
+  border-radius: 0;
+}
+
+thead th {
+  background: var(--bg);      /* lighter header bg */
+  border-bottom: 2px solid var(--border);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.625rem;        /* 10px — smaller, more clinical */
+}
+
+/* ── Code Blocks — Flat, Monospace ── */
+code {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  padding: 0.15em 0.4em;
+  font-size: 0.8125em;
+}
+
+pre {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  padding: 1rem;
+  box-shadow: none;
+}
+
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* ── Buttons & Controls — Flat ── */
+.theme-btn {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text-dim);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6875rem;
+  padding: 0.375rem 0.75rem;
+  cursor: pointer;
+  box-shadow: none;
+}
+
+.theme-btn:hover {
+  background: var(--bg);
+  border-color: var(--text-dim);
+}
+
+.tab-btn {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  color: var(--text-dim);
+  font-family: 'Inter', system-ui, sans-serif;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.tab-btn:hover {
+  color: var(--text-muted);
+  border-bottom-color: var(--border);
+}
+
+.tab-btn[aria-selected="true"] {
+  color: var(--text);
+  border-bottom-color: var(--text);
+}
+
+/* ── Navigation — Flat ── */
+.topnav {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  box-shadow: none;
+}
+
+.nav-title {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+/* ── Accent Utilities (minimal red usage) ── */
+.accent-only {
+  /* For error/warning emphasis only */
+  color: var(--accent);
+}
+
+.badge-accent {
+  background: var(--accent-dim);
+  color: var(--accent);
+  border-radius: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.625rem;
+  padding: 0.125rem 0.375rem;
+}

--- a/plugins/forge/references/aesthetics/terminal.css
+++ b/plugins/forge/references/aesthetics/terminal.css
@@ -1,0 +1,288 @@
+/* ══════════════════════════════════════════════════════════════════
+   terminal.css — retro CLI / terminal output aesthetic
+
+   Identity: dark, monospace-heavy, green-on-black vibes with cyan
+   secondary accents. Minimal borders, low opacity, raw terminal feel.
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Fonts ──
+   Add to <head>:
+   <link rel="preconnect" href="https://fonts.googleapis.com">
+   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+*/
+
+/* ── Root Tokens (Dark Default) ── */
+:root {
+  /* Surface system — deep blacks */
+  --bg:         #0c0c0c;     /* near-black */
+  --surface:    #121212;     /* card bg */
+  --border:     rgba(255,255,255,0.08);  /* low-opacity white */
+
+  /* Text hierarchy — green/cyan tones */
+  --text:       #4af626;     /* terminal green — primary */
+  --text-muted: #a8e6a3;     /* muted green — body */
+  --text-dim:   #5a7a57;     /* dim green — metadata */
+
+  /* Accent — cyan secondary */
+  --accent:     #00d4ff;     /* cyan */
+  --accent-dim: rgba(0,212,255,0.1);
+}
+
+/* ── Light Mode Override (optional, keeps terminal feel) ── */
+[data-theme="light"] {
+  /* Surface system — inverted */
+  --bg:         #ffffff;
+  --surface:    #f5f5f5;
+  --border:     rgba(0,0,0,0.15);
+
+  /* Text hierarchy — darker greens */
+  --text:       #1a6b1a;     /* dark green */
+  --text-muted: #2d8a2d;     /* body green */
+  --text-dim:   #5a7a57;     /* metadata */
+
+  /* Accent — darker cyan */
+  --accent:     #0891b2;     /* cyan-600 */
+  --accent-dim: rgba(8,145,178,0.1);
+}
+
+/* ── Semantic Color Tokens — Dark ── */
+:root {
+  --success:     #4af626;     /* green — same as text */
+  --success-dim: rgba(74,246,38,0.1);
+  --warning:     #ffd000;     /* amber-yellow */
+  --warning-dim: rgba(255,208,0,0.1);
+  --error:       #ff3333;     /* red */
+  --error-dim:   rgba(255,51,51,0.1);
+  --info:        #00d4ff;     /* cyan — same as accent */
+  --info-dim:    rgba(0,212,255,0.1);
+}
+
+/* ── Semantic Color Tokens — Light ── */
+[data-theme="light"] {
+  --success:     #1a6b1a;
+  --success-dim: rgba(26,107,26,0.1);
+  --warning:     #b45309;
+  --warning-dim: rgba(180,83,9,0.1);
+  --error:       #b91c1c;
+  --error-dim:   rgba(185,28,28,0.1);
+  --info:        #0891b2;
+  --info-dim:    rgba(8,145,178,0.1);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   OVERRIDES — terminal aesthetic
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Typography Override — Monospace Everything ── */
+body {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: 0;
+}
+
+h1 { font-size: 1.25rem; }
+h2 { font-size: 1rem; }
+h3 { font-size: 0.875rem; }
+
+p, ul, ol, li, td, th, span, div {
+  font-family: 'JetBrains Mono', monospace;
+}
+
+code, pre {
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ── Cards — Minimal Borders, Flat ── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  padding: 1rem;
+  box-shadow: none;
+}
+
+.card.accent {
+  border-left: 2px solid var(--accent);
+  border-radius: 0;
+}
+
+.card-label {
+  color: var(--accent);
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+}
+
+.card-title {
+  color: var(--text);
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.card-body {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+/* ── Tables — Terminal Style ── */
+.table-wrap {
+  border: 1px solid var(--border);
+  border-radius: 0;
+}
+
+thead th {
+  background: var(--surface);
+  color: var(--text-dim);
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+tbody td {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+tbody tr:hover td {
+  background: var(--surface);
+}
+
+/* ── Code Blocks — Raw Terminal ── */
+code {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  padding: 0.15em 0.4em;
+  font-size: 0.8125em;
+  color: var(--accent);
+}
+
+pre {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  padding: 0.875rem;
+  box-shadow: none;
+  overflow-x: auto;
+}
+
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text);
+}
+
+/* ── Buttons & Controls ── */
+.theme-btn {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text-dim);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.625rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.theme-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.tab-btn {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid transparent;
+  border-radius: 0;
+  color: var(--text-dim);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}
+
+.tab-btn:hover {
+  color: var(--text-muted);
+  border-bottom-color: var(--border);
+}
+
+.tab-btn[aria-selected="true"] {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ── Navigation ── */
+.topnav {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  box-shadow: none;
+}
+
+.nav-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--text);
+}
+
+/* ── Terminal-Style Utilities ── */
+.prompt::before {
+  content: '$ ';
+  color: var(--accent);
+}
+
+.cursor::after {
+  content: '▌';
+  color: var(--text);
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
+}
+
+/* ── Status Badges ── */
+.badge-success {
+  color: var(--success);
+  font-size: 0.625rem;
+}
+
+.badge-warning {
+  color: var(--warning);
+  font-size: 0.625rem;
+}
+
+.badge-error {
+  color: var(--error);
+  font-size: 0.625rem;
+}
+
+.badge-info {
+  color: var(--info);
+  font-size: 0.625rem;
+}
+
+/* ── Glowing Text (optional accent) ── */
+.glow {
+  text-shadow: 0 0 8px var(--accent);
+}


### PR DESCRIPTION
## Summary
- Add `blueprint.css` — flat engineering spec sheet aesthetic with light background, high contrast text, Inter + JetBrains Mono fonts, no shadows/gradients/rounded corners
- Add `terminal.css` — retro CLI/terminal output aesthetic with dark background, green primary text, cyan accent, JetBrains Mono for all text
- Fix `config.test.ts` ESM compat — use `vi.mock` instead of `vi.spyOn` for non-configurable ESM exports

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #80: forge: blueprint + terminal aesthetics (S5) | Open |
| Implementation | 3 commits on `feat/80-blueprint-terminal-aesthetics` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (296 pass) | Passed |

## Test Plan
- [x] Both files define full token contract (bg, surface, border, text hierarchy, accent, semantic colors)
- [x] blueprint.css produces visually distinct light-bg output
- [x] terminal.css produces visually distinct monospace-heavy output
- [ ] Architecture diagram test: nats-arch-roadmap rebuilt using blueprint aesthetic (post-merge)

Closes #80

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`