### PR TITLE
feat(forge): skill rewrites for new design system (#83)

### DIFF
--- a/plugins/forge/references/split-file.md
+++ b/plugins/forge/references/split-file.md
@@ -38,6 +38,7 @@ Read `shells/split.html` for the complete template. It contains all necessary pl
 
 | Placeholder | Content |
 |-------------|---------|
+| `{NAME}` | Diagram slug (for localStorage key scoping) |
 | `{TITLE}`, `{DATE}`, `{CATEGORY}`, `{CAT_LABEL}`, `{COLOR}`, `{BADGES}` | Diagram metadata |
 | `{BASE_STYLES}` | Concatenated base CSS (reset → layout → typography → components) |
 | `{AESTHETIC_STYLES}` | Selected aesthetic CSS |

--- a/plugins/forge/references/split-file.md
+++ b/plugins/forge/references/split-file.md
@@ -4,8 +4,8 @@ Multi-tab explainers use four file groups relative to the diagram root:
 
 ```
 <name>.html              — shell: head, nav, empty panel placeholders
-css/<name>.css           — all styles
-js/<name>.js             — loadPanel + tab switching + theme toggle
+css/<name>.css           — all styles (base + aesthetic + diagram-specific)
+js/<name>.js             — tab-loader + theme toggle + optional Mermaid init
 tabs/<name>/
   tab-<id>.html          — one fragment per tab (lazy-loaded, no DOCTYPE/html/body)
 ```
@@ -32,275 +32,44 @@ For topic-named diagrams (not versioned), use `tabs/<name>/tab-<id>.html`.
 
 ---
 
-## Shell HTML Template
+## Shell Template
 
-```html
-<!DOCTYPE html>
-<html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{TITLE}</title>
-  <!-- diagram-meta:start -->
-  <meta name="diagram:title"     content="{TITLE}">
-  <meta name="diagram:date"      content="{YYYY-MM-DD}">
-  <meta name="diagram:category"  content="{category}">
-  <meta name="diagram:cat-label" content="{Label}">
-  <meta name="diagram:color"     content="{color}">
-  <meta name="diagram:badges"    content="latest">
-  <!-- diagram-meta:end -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/{NAME}.css">
-</head>
-<body>
-  <nav class="topnav">
-    <span class="nav-title">{TITLE}</span>
-    <div class="tabs" role="tablist">
-      <button class="tab-btn" data-tab="{ID1}" role="tab">{LABEL1}</button>
-      <!-- repeat per tab -->
-    </div>
-    <button class="theme-btn" id="theme-toggle">◑ light</button>
-  </nav>
-  <main>
-    <div class="panel" data-panel="{ID1}" role="tabpanel"></div>
-    <!-- repeat per tab -->
-  </main>
-  <script src="js/{NAME}.js"></script>
-</body>
-</html>
-```
+Read `shells/split.html` for the complete template. It contains all necessary placeholders:
+
+| Placeholder | Content |
+|-------------|---------|
+| `{TITLE}`, `{DATE}`, `{CATEGORY}`, `{CAT_LABEL}`, `{COLOR}`, `{BADGES}` | Diagram metadata |
+| `{BASE_STYLES}` | Concatenated base CSS (reset → layout → typography → components) |
+| `{AESTHETIC_STYLES}` | Selected aesthetic CSS |
+| `{TABS}` | Tab button elements |
+| `{PANELS}` | Panel container elements |
+| `{TAB_LOADER_JS}` | tab-loader.js with `{NAME}` substituted |
+| `{HEAD_EXTRAS}` | Optional (e.g., svg-pan-zoom CDN) |
+| `{EXTRA_STYLES}` | Diagram-specific CSS |
+| `{EXTRA_SCRIPTS}` | Optional (e.g., mermaid-init.js) |
+
+**Directive: inline, never link** — skills should read and inline all CSS/JS, not link to external files.
 
 ---
 
-## CSS Skeleton
+## Tab Fragments
 
-```css
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0 }
+Content patterns by tab type:
 
-/* ── Tokens ── (insert from references/tokens.md) ───────────── */
-:root, [data-theme="dark"] {
-  --bg:         #0a0a0f;
-  --surface:    #18181f;
-  --border:     #2a2a35;
-  --text:       #fafafa;
-  --text-muted: #9ca3af;
-  --text-dim:   #6b7280;
-  --accent:     #e85d04;
-  --accent-dim: #7c2d0e;
-}
-[data-theme="light"] {
-  --bg:         #fafaf9;
-  --surface:    #f4f4f0;
-  --border:     #d1ccc7;
-  --text:       #1c1917;
-  --text-muted: #57534e;
-  --text-dim:   #78716c;
-  --accent:     #c2410c;
-  --accent-dim: #fef2e8;
-}
-
-body {
-  background: var(--bg);
-  color: var(--text);
-  font-family: 'IBM Plex Sans', system-ui, sans-serif;
-  line-height: 1.6;
-  min-height: 100vh;
-}
-
-/* ── Nav ─────────────────────────────────────────────────────── */
-.topnav {
-  position: sticky; top: 0; z-index: 100;
-  display: flex; align-items: center; gap: 1rem;
-  padding: 0 1.5rem; height: 3rem;
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-}
-.nav-title {
-  font-size: 0.875rem; font-weight: 600;
-  color: var(--text); margin-right: auto; white-space: nowrap;
-}
-.tabs { display: flex; gap: 0.25rem; }
-.tab-btn {
-  padding: 0.375rem 0.875rem; font-size: 0.8125rem;
-  font-family: inherit; font-weight: 500;
-  color: var(--text-dim); background: transparent;
-  border: none; border-radius: 4px; cursor: pointer;
-  transition: color 0.15s, background 0.15s;
-}
-.tab-btn:hover  { color: var(--text-muted); background: var(--bg); }
-.tab-btn.active { color: var(--accent);     background: var(--bg); }
-.theme-btn {
-  padding: 0.25rem 0.5rem; font-size: 0.75rem;
-  color: var(--text-dim); background: transparent;
-  border: 1px solid var(--border); border-radius: 4px; cursor: pointer;
-}
-.theme-btn:hover { color: var(--text-muted); }
-
-/* ── Panels ──────────────────────────────────────────────────── */
-.panel { display: none; padding: 2rem 1.5rem; max-width: 960px; margin: 0 auto; }
-.panel.active { display: block; }
-
-/* ── Typography ──────────────────────────────────────────────── */
-h1, h2, h3, h4 { color: var(--text); font-weight: 600; }
-h1 { font-size: 1.75rem; margin-bottom: 0.75rem; }
-h2 { font-size: 1.25rem; margin: 2rem 0 0.75rem; }
-h3 { font-size: 1rem;    margin: 1.5rem 0 0.5rem; }
-p  { color: var(--text-muted); margin-bottom: 0.875rem; }
-ul, ol { color: var(--text-muted); padding-left: 1.5rem; margin-bottom: 0.875rem; }
-li { margin-bottom: 0.25rem; }
-code {
-  font-family: 'IBM Plex Mono', monospace; font-size: 0.875em;
-  background: var(--surface); border: 1px solid var(--border);
-  padding: 0.125em 0.35em; border-radius: 3px; color: var(--text);
-}
-pre {
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 6px; padding: 1rem; overflow-x: auto; margin-bottom: 1rem;
-}
-pre code {
-  background: none; border: none; padding: 0;
-  font-size: 0.875rem; white-space: pre-wrap;
-}
-
-/* ── Cards ───────────────────────────────────────────────────── */
-.cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1rem; margin-bottom: 1.5rem;
-}
-.card {
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 8px; padding: 1.25rem;
-}
-.card.accent { border-left: 3px solid var(--accent); }
-.card-label {
-  font-size: 0.6875rem; font-weight: 700;
-  text-transform: uppercase; letter-spacing: 0.08em;
-  color: var(--accent); margin-bottom: 0.5rem;
-}
-.card-title {
-  font-size: 0.9375rem; font-weight: 600;
-  color: var(--text); margin-bottom: 0.375rem;
-}
-.card-body { font-size: 0.875rem; color: var(--text-muted); }
-
-/* ── Tables ──────────────────────────────────────────────────── */
-.table-wrap {
-  overflow-x: auto; margin-bottom: 1.5rem;
-  border: 1px solid var(--border); border-radius: 6px;
-}
-table { width: 100%; border-collapse: collapse; }
-thead th {
-  background: var(--surface); color: var(--text-dim);
-  font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.06em;
-  padding: 0.5rem 0.75rem; text-align: left;
-  border-bottom: 1px solid var(--border);
-  position: sticky; top: 3rem;
-}
-tbody td {
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid var(--border);
-  color: var(--text-muted); font-size: 0.875rem;
-}
-tbody tr:last-child td { border-bottom: none; }
-tbody tr:hover td { background: var(--surface); }
-
-/* ── Responsive ──────────────────────────────────────────────── */
-@media (max-width: 768px) {
-  .topnav { padding: 0 1rem; flex-wrap: wrap; height: auto; padding-block: 0.5rem; }
-  .tabs { overflow-x: auto; width: 100%; }
-  .panel { padding: 1.5rem 1rem; }
-}
-```
+| Tab type | Content |
+|----------|---------|
+| Overview / intro | `<h1>`, 1–2 `<p>`, `.cards` grid (2–4 cards) |
+| Step-by-step | `<h2>` sections + `<ol>` + `<pre><code>` |
+| Architecture | Mermaid diagram + description |
+| Comparison | `.table-wrap > table` with `<thead>` |
+| Status / KPIs | `.cards` grid with stat cards |
+| Decisions / log | `<h3>` entries with date + rationale `<p>` |
 
 ---
 
-## JS Skeleton
+## Mermaid Support
 
-Replace **`{NAME}`** with the diagram's kebab-case filename slug (without `.html`).
-
-```javascript
-;(function () {
-  // ── Theme ────────────────────────────────────────────────────
-  var THEME_KEY = 'diag-{NAME}-theme'
-  var saved = localStorage.getItem(THEME_KEY) || 'dark'
-  document.documentElement.setAttribute('data-theme', saved)
-  var themeBtn = document.getElementById('theme-toggle')
-  if (themeBtn) {
-    themeBtn.textContent = saved === 'dark' ? '◑ light' : '◑ dark'
-    themeBtn.addEventListener('click', function () {
-      var cur  = document.documentElement.getAttribute('data-theme')
-      var next = cur === 'dark' ? 'light' : 'dark'
-      document.documentElement.setAttribute('data-theme', next)
-      localStorage.setItem(THEME_KEY, next)
-      this.textContent = next === 'dark' ? '◑ light' : '◑ dark'
-    })
-  }
-
-  // ── Tabs ─────────────────────────────────────────────────────
-  function loadPanel (id) {
-    var panel = document.querySelector('[data-panel="' + id + '"]')
-    if (!panel || panel._loaded) return
-    fetch('tabs/{NAME}/tab-' + id + '.html')
-      .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status) })
-      .then(function (html) {
-        panel.innerHTML = html
-        panel._loaded = true
-        if (typeof window.__postLoad === 'function') window.__postLoad(id, panel)
-      })
-      .catch(function (e) {
-        panel.innerHTML = '<p style="padding:2rem;color:var(--text-muted)">Failed to load (' + e + ')</p>'
-      })
-  }
-
-  function activate (id) {
-    document.querySelectorAll('[data-tab]').forEach(function (t) {
-      t.classList.toggle('active', t.dataset.tab === id)
-    })
-    document.querySelectorAll('[data-panel]').forEach(function (p) {
-      p.classList.toggle('active', p.dataset.panel === id)
-    })
-    loadPanel(id)
-  }
-
-  document.querySelectorAll('[data-tab]').forEach(function (t) {
-    t.addEventListener('click', function () { activate(t.dataset.tab) })
-  })
-
-  var first = document.querySelector('[data-tab]')
-  if (first) activate(first.dataset.tab)
-})()
-```
-
-### Adding Mermaid support (optional)
-
-If any tab will contain a Mermaid diagram, add before the `activate(first.dataset.tab)` line:
-
-```javascript
-  // ── Mermaid (only if tabs use it) ────────────────────────────
-  window.__postLoad = async function (id, panel) {
-    var srcEl     = panel.querySelector('[data-mermaid]')
-    var container = panel.querySelector('[data-mermaid-out]')
-    if (!srcEl || !container) return
-    var { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs')
-    mermaid.initialize({
-      startOnLoad: false, theme: 'base',
-      flowchart: { useMaxWidth: false, curve: 'basis' }
-    })
-    var { svg, bindFunctions } = await mermaid.render('mermaid-' + id, srcEl.textContent.trim())
-    container.innerHTML = svg
-    if (bindFunctions) bindFunctions(container.querySelector('svg'))
-    if (typeof window.__initPanZoom === 'function') window.__initPanZoom(container)
-  }
-```
-
-And in `<head>` of the shell HTML:
-```html
-<script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/dist/svg-pan-zoom.min.js"></script>
-```
-
-See `references/mermaid-guide.md` for the full `__initPanZoom` implementation and Mermaid checklist.
+If any tab will contain a Mermaid diagram, see `references/mermaid-guide.md` for the complete checklist (dynamic tab pitfalls, `__postLoad`, `__initPanZoom`).
 
 ---
 

--- a/plugins/forge/references/tokens.md
+++ b/plugins/forge/references/tokens.md
@@ -13,7 +13,7 @@ The gallery system extends the baseline with extra surface tiers (`--surface2`, 
 
 ## Baseline Tokens (Split-File / Chart / Epic)
 
-## Which Theme to Use
+### Which Theme to Use
 
 1. Check `~/.roxabi/forge/<project>/brand/BRAND-BOOK.md` or `~/projects/<project>/brand/BRAND-BOOK.md`
 2. Brand book found → derive tokens from its palette
@@ -31,6 +31,7 @@ Full token definitions live in dedicated aesthetic files:
 |---------|---------------|--------|
 | lyra, voicecli | `aesthetics/lyra.css` | Forge Orange `#e85d04` |
 | roxabi*, 2ndBrain | `aesthetics/roxabi.css` | Gold `#f0b429` |
+| default (unknown) | `aesthetics/editorial.css` | Slate `#64748b` |
 
 **Usage in skills:** Copy brand token blocks (`--bg`, `--surface`, `--border`, `--text*`, `--accent*`) from the aesthetic file. Semantic colors (`--success*`, `--warning*`, `--error*`, `--info*`) come from `base/components.css`. Typography comes from `base/typography.css`.
 

--- a/plugins/forge/references/tokens.md
+++ b/plugins/forge/references/tokens.md
@@ -59,15 +59,9 @@ Common trap: setting `--text-muted` and `--text-dim` to the same value (`#6b7280
 
 ## Typography (Default)
 
-```html
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono&display=swap" rel="stylesheet">
-```
+Use IBM Plex Sans + IBM Plex Mono (loaded via Google Fonts in the shell templates).
 
-```css
-body        { font-family: 'IBM Plex Sans', system-ui, sans-serif; }
-code, pre   { font-family: 'IBM Plex Mono', monospace; }
-```
+Typography rules are defined in `base/typography.css` — skills should read and inline that file.
 
-Other acceptable pairs: DM Sans + Fira Code, Plus Jakarta Sans + Azeret Mono.  
+Other acceptable pairs: DM Sans + Fira Code, Plus Jakarta Sans + Azeret Mono.
 **Forbidden as primary fonts:** Inter, Roboto, Arial, bare `system-ui`.

--- a/plugins/forge/skills/forge-chart/SKILL.md
+++ b/plugins/forge/skills/forge-chart/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: forge-chart
 description: 'Create a quick self-contained single-file HTML visual — Mermaid flowchart, dependency tree, sequence diagram, or CSS layout. No server needed, works with file://. Triggers: "draw" | "diagram" | "visualize" | "sketch" | "map" | "show the flow" | "quick visual".'
-version: 0.1.0
+version: 0.2.0
 allowed-tools: Read, Write, Bash, Glob, Grep, ToolSearch
 ---
 
@@ -15,18 +15,48 @@ Output: `~/.roxabi/forge/<project>/visuals/{slug}.html` or `~/.roxabi/forge/_sha
 **Read before generating:**
 
 ```
-${CLAUDE_PLUGIN_ROOT}/references/forge-ops.md     — brand detection, output paths, deploy commands
-${CLAUDE_PLUGIN_ROOT}/references/aesthetics/      — lyra.css, roxabi.css (copy full token blocks)
-${CLAUDE_PLUGIN_ROOT}/references/diagram-meta.md  — meta tag format + categories
+${CLAUDE_PLUGIN_ROOT}/references/forge-ops.md        — brand detection, output paths, deploy commands
+${CLAUDE_PLUGIN_ROOT}/references/base/reset.css      — concatenate first
+${CLAUDE_PLUGIN_ROOT}/references/base/layout.css     — concatenate second
+${CLAUDE_PLUGIN_ROOT}/references/base/typography.css — concatenate third
+${CLAUDE_PLUGIN_ROOT}/references/base/components.css — concatenate last
+${CLAUDE_PLUGIN_ROOT}/references/aesthetics/         — select one based on detection logic
+${CLAUDE_PLUGIN_ROOT}/references/shells/single.html  — HTML template with placeholders
+${CLAUDE_PLUGIN_ROOT}/references/diagram-meta.md     — meta tag format + categories
 ```
 
-**Aesthetic selection:**
+**Directive: inline, never link** — `base/` and `aesthetics/` files are generation source, not runtime dependencies. Read → inline into output `<style>` block.
 
-| Project | Aesthetic file |
-|---------|---------------|
-| lyra, voicecli | `aesthetics/lyra.css` |
-| roxabi*, 2ndBrain | `aesthetics/roxabi.css` |
-| Unknown | `aesthetics/lyra.css` (default) |
+---
+
+## Aesthetic Detection
+
+| Priority | Signal | Aesthetic |
+|----------|--------|-----------|
+| 1 | Explicit `--aesthetic` arg | As specified |
+| 2 | Brand book found (`BRAND-BOOK.md`) | Derived from palette |
+| 3 | Project = `lyra` / `voicecli` | `lyra.css` |
+| 4 | Project = `roxabi*` / `2ndBrain` | `roxabi.css` |
+| 5 | Content = architecture / spec | `blueprint.css` |
+| 6 | Content = CLI / terminal doc | `terminal.css` |
+| 7 | Default | `editorial.css` |
+
+---
+
+## Shell Processing
+
+1. Read `shells/single.html` template
+2. Concatenate base CSS files in order: `reset → layout → typography → components`
+3. Read selected aesthetic CSS
+4. Substitute placeholders:
+   - `{BASE_STYLES}` → concatenated base CSS
+   - `{AESTHETIC_STYLES}` → aesthetic CSS (or empty if default)
+   - `{TITLE}`, `{DATE}`, `{CATEGORY}`, `{CAT_LABEL}`, `{COLOR}`, `{BADGES}` → diagram metadata
+   - `{HEAD_EXTRAS}` → mermaid CDN script (for Mermaid diagrams)
+   - `{CONTENT}` → diagram body (Mermaid container, cards, etc.)
+   - `{EXTRA_STYLES}` → diagram-specific CSS (if any)
+   - `{EXTRA_SCRIPTS}` → theme toggle JS (from shell)
+5. Output: single self-contained HTML file (file:// safe)
 
 Mermaid note: single-file has **no dynamic-tab pitfalls** — use standard `startOnLoad: true`. No need for `mermaid.render()`, no `rgba()` restriction.
 
@@ -41,6 +71,7 @@ Let:
 2. Issue number in ARGS (`#N` or `NNN-`) → filename `{N}-{slug}.html`, set `diagram:issue` meta.
 3. Cross-project / no project → `~/.roxabi/forge/_shared/diagrams/`.
 4. Brand book — follow `forge-ops.md` brand detection.
+5. Apply aesthetic detection logic to select the correct aesthetic file.
 
 ---
 
@@ -63,115 +94,29 @@ Choose `diagram:category` + `diagram:color` from `references/diagram-meta.md`.
 
 ## Phase 3 — Generate
 
-Single HTML file. Everything inline.
+Read `shells/single.html` → substitute placeholders with content. The shell already contains:
+- Theme toggle JS
+- Diagram meta placeholders
+- CSS placeholder slots
 
+**Mermaid diagrams:** add to `{HEAD_EXTRAS}`:
 ```html
-<!DOCTYPE html>
-<html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{TITLE}</title>
-  <!-- diagram-meta:start -->
-  <meta name="diagram:title"     content="{TITLE}">
-  <meta name="diagram:date"      content="{YYYY-MM-DD}">
-  <meta name="diagram:category"  content="{category}">
-  <meta name="diagram:cat-label" content="{Label}">
-  <meta name="diagram:color"     content="{color}">
-  <meta name="diagram:badges"    content="latest">
-  <!-- optional: <meta name="diagram:issue" content="{N}"> -->
-  <!-- diagram-meta:end -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono&display=swap" rel="stylesheet">
-  <style>
-    /* Token block — copy from aesthetics/{project}.css */
-    :root, [data-theme="dark"] {
-      --bg: #0a0a0f; --surface: #18181f; --border: #2a2a35;
-      --text: #fafafa; --text-muted: #9ca3af; --text-dim: #6b7280;
-      --accent: #e85d04;
-    }
-    [data-theme="light"] {
-      --bg: #fafaf9; --surface: #f4f4f0; --border: #d1ccc7;
-      --text: #1c1917; --text-muted: #57534e; --text-dim: #78716c;
-      --accent: #c2410c;
-    }
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0 }
-    body {
-      background: var(--bg); color: var(--text);
-      font-family: 'IBM Plex Sans', system-ui, sans-serif;
-      padding: 2rem 1.5rem; line-height: 1.6;
-    }
-    header {
-      display: flex; align-items: baseline; gap: 1rem;
-      margin-bottom: 2rem; flex-wrap: wrap;
-    }
-    header h1 { font-size: 1.25rem; font-weight: 600; flex: 1; }
-    .issue-tag {
-      font-family: 'IBM Plex Mono', monospace; font-size: 0.8125rem;
-      color: var(--accent); font-weight: 600;
-    }
-    .theme-btn {
-      padding: 0.2rem 0.5rem; font-size: 0.75rem;
-      color: var(--text-dim); background: transparent;
-      border: 1px solid var(--border); border-radius: 4px; cursor: pointer;
-    }
-    .mermaid-wrap {
-      display: flex; justify-content: center; align-items: flex-start;
-      overflow: auto; padding: 1.5rem; margin-bottom: 1.5rem;
-      background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
-    }
-    .mermaid svg { max-width: none; }
-    p { color: var(--text-muted); margin-bottom: 0.75rem; }
-  </style>
-  <script type="module">
-    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'
-    mermaid.initialize({
-      startOnLoad: true, theme: 'base',
-      themeVariables: {
-        primaryColor: '#18181f', primaryTextColor: '#fafafa',
-        primaryBorderColor: '#e85d04', lineColor: '#6b7280',
-        secondaryColor: '#2a2a35', background: '#0a0a0f',
-        edgeLabelBackground: '#18181f', nodeTextColor: '#9ca3af',
-      },
-      flowchart: { useMaxWidth: false, curve: 'basis' }
-    })
-  </script>
-</head>
-<body>
-  <header>
-    <!-- include .issue-tag span only if issue-linked -->
-    <span class="issue-tag">#{ISSUE}</span>
-    <h1>{TITLE}</h1>
-    <button class="theme-btn" id="theme-toggle">◑ light</button>
-  </header>
-
-  <div class="mermaid-wrap">
-    <div class="mermaid">
-flowchart TD
-    A["Node A"] --> B["Node B"]
-    </div>
-  </div>
-
-  <script>
-    var K = 'chart-{SLUG}-theme'
-    var s = localStorage.getItem(K) || 'dark'
-    document.documentElement.setAttribute('data-theme', s)
-    var b = document.getElementById('theme-toggle')
-    b.textContent = s === 'dark' ? '◑ light' : '◑ dark'
-    b.addEventListener('click', function () {
-      var n = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'
-      document.documentElement.setAttribute('data-theme', n)
-      localStorage.setItem(K, n)
-      this.textContent = n === 'dark' ? '◑ light' : '◑ dark'
-    })
-  </script>
-</body>
-</html>
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'
+  mermaid.initialize({
+    startOnLoad: true, theme: 'base',
+    themeVariables: {
+      primaryColor: 'var(--surface)', primaryTextColor: 'var(--text)',
+      primaryBorderColor: 'var(--accent)', lineColor: 'var(--text-dim)',
+      secondaryColor: 'var(--border)', background: 'var(--bg)',
+      edgeLabelBackground: 'var(--surface)', nodeTextColor: 'var(--text-muted)',
+    },
+    flowchart: { useMaxWidth: false, curve: 'basis' }
+  })
+</script>
 ```
 
-**Token block:** read `{aesthetics/{project}.css}` and copy the full `:root` / `[data-theme]` blocks. Do not hardcode individual values.
-
-**Mermaid theme variables:** adjust `primaryBorderColor` to brand accent. Use hex colors only in `style` node directives.
+**Content:** diagram body (Mermaid container, cards, grids, etc.) goes into `{CONTENT}` placeholder.
 
 **Dark mode text:** any descriptive `<p>` → `color: var(--text-muted)`. Metadata → `color: var(--text-dim)`.
 

--- a/plugins/forge/skills/forge-chart/SKILL.md
+++ b/plugins/forge/skills/forge-chart/SKILL.md
@@ -49,8 +49,9 @@ ${CLAUDE_PLUGIN_ROOT}/references/diagram-meta.md     — meta tag format + categ
 2. Concatenate base CSS files in order: `reset → layout → typography → components`
 3. Read selected aesthetic CSS
 4. Substitute placeholders:
+   - `{NAME}` → diagram slug (for localStorage key scoping)
    - `{BASE_STYLES}` → concatenated base CSS
-   - `{AESTHETIC_STYLES}` → aesthetic CSS (or empty if default)
+   - `{AESTHETIC_STYLES}` → aesthetic CSS (editorial.css if default)
    - `{TITLE}`, `{DATE}`, `{CATEGORY}`, `{CAT_LABEL}`, `{COLOR}`, `{BADGES}` → diagram metadata
    - `{HEAD_EXTRAS}` → mermaid CDN script (for Mermaid diagrams)
    - `{CONTENT}` → diagram body (Mermaid container, cards, etc.)

--- a/plugins/forge/skills/forge-epic/SKILL.md
+++ b/plugins/forge/skills/forge-epic/SKILL.md
@@ -51,8 +51,9 @@ ${CLAUDE_PLUGIN_ROOT}/references/mermaid-guide.md    — dependency/breakdown di
 3. Read selected aesthetic CSS
 4. Read `base/tab-loader.js`, substitute `{NAME}` with `{ISSUE}-{slug}`
 5. Substitute placeholders:
+   - `{NAME}` → `{ISSUE}-{slug}` (for localStorage key scoping + tab-loader.js)
    - `{BASE_STYLES}` → concatenated base CSS
-   - `{AESTHETIC_STYLES}` → aesthetic CSS (or empty if default)
+   - `{AESTHETIC_STYLES}` → selected aesthetic CSS
    - `{TITLE}` → `{PROJ} #{ISSUE} — {Short Title}` (e.g. "Lyra #477 — Tool Registry")
    - `{DATE}`, `{CATEGORY}`, `{CAT_LABEL}`, `{COLOR}`, `{BADGES}` → diagram metadata
    - `{TABS}` → tab button elements (one per tab)

--- a/plugins/forge/skills/forge-epic/SKILL.md
+++ b/plugins/forge/skills/forge-epic/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: forge-epic
 description: 'Create an issue/epic-linked visual analysis — overview, scope breakdown, dependency graph, acceptance criteria. Filename always includes the issue number. Triggers: "visualize #N" | "preview #N" | "illustrate issue" | "map issue" | "epic preview" | "show epic".'
-version: 0.1.0
+version: 0.2.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, ToolSearch
 ---
 
@@ -14,12 +14,54 @@ Output: `~/.roxabi/forge/<project>/visuals/{N}-{slug}.html` (split-file).
 **Read before generating:**
 
 ```
-${CLAUDE_PLUGIN_ROOT}/references/forge-ops.md     — brand detection, output paths, deploy commands
-${CLAUDE_PLUGIN_ROOT}/references/split-file.md    — templates + CSS/JS skeletons
-${CLAUDE_PLUGIN_ROOT}/references/aesthetics/      — lyra.css, roxabi.css (copy full token blocks)
-${CLAUDE_PLUGIN_ROOT}/references/diagram-meta.md  — meta tag format + categories
-${CLAUDE_PLUGIN_ROOT}/references/mermaid-guide.md — dependency/breakdown diagrams
+${CLAUDE_PLUGIN_ROOT}/references/forge-ops.md        — brand detection, output paths, deploy commands
+${CLAUDE_PLUGIN_ROOT}/references/base/reset.css      — concatenate first
+${CLAUDE_PLUGIN_ROOT}/references/base/layout.css     — concatenate second
+${CLAUDE_PLUGIN_ROOT}/references/base/typography.css — concatenate third
+${CLAUDE_PLUGIN_ROOT}/references/base/components.css — concatenate last
+${CLAUDE_PLUGIN_ROOT}/references/aesthetics/         — select one based on detection logic
+${CLAUDE_PLUGIN_ROOT}/references/shells/split.html   — HTML template with placeholders
+${CLAUDE_PLUGIN_ROOT}/references/base/tab-loader.js  — substitute {NAME}, then inline
+${CLAUDE_PLUGIN_ROOT}/references/diagram-meta.md     — meta tag format + categories
+${CLAUDE_PLUGIN_ROOT}/references/mermaid-guide.md    — dependency/breakdown diagrams
 ```
+
+**Directive: inline, never link** — `base/` and `aesthetics/` files are generation source, not runtime dependencies. Read → inline into output `<style>` block.
+
+---
+
+## Aesthetic Detection
+
+| Priority | Signal | Aesthetic |
+|----------|--------|-----------|
+| 1 | Explicit `--aesthetic` arg | As specified |
+| 2 | Brand book found (`BRAND-BOOK.md`) | Derived from palette |
+| 3 | Project = `lyra` / `voicecli` | `lyra.css` |
+| 4 | Project = `roxabi*` / `2ndBrain` | `roxabi.css` |
+| 5 | Content = architecture / spec | `blueprint.css` |
+| 6 | Content = CLI / terminal doc | `terminal.css` |
+| 7 | Default | `editorial.css` |
+
+---
+
+## Shell Processing
+
+1. Read `shells/split.html` template
+2. Concatenate base CSS files in order: `reset → layout → typography → components`
+3. Read selected aesthetic CSS
+4. Read `base/tab-loader.js`, substitute `{NAME}` with `{ISSUE}-{slug}`
+5. Substitute placeholders:
+   - `{BASE_STYLES}` → concatenated base CSS
+   - `{AESTHETIC_STYLES}` → aesthetic CSS (or empty if default)
+   - `{TITLE}` → `{PROJ} #{ISSUE} — {Short Title}` (e.g. "Lyra #477 — Tool Registry")
+   - `{DATE}`, `{CATEGORY}`, `{CAT_LABEL}`, `{COLOR}`, `{BADGES}` → diagram metadata
+   - `{TABS}` → tab button elements (one per tab)
+   - `{PANELS}` → panel container elements (one per tab)
+   - `{TAB_LOADER_JS}` → tab-loader.js with `{NAME}` substituted
+   - `{HEAD_EXTRAS}` → optional (e.g., svg-pan-zoom CDN for Mermaid)
+   - `{EXTRA_STYLES}` → epic-specific CSS (epic-hero, status badges, etc.)
+   - `{EXTRA_SCRIPTS}` → optional (e.g., mermaid-init.js)
+6. Output: split-file HTML (requires HTTP serve)
 
 Let:
   ARGS   := $ARGUMENTS
@@ -43,6 +85,8 @@ Let:
 5. **Read issue context** if accessible:
    - Check `~/projects/{PROJ}/` for relevant CLAUDE.md, specs, or any `docs/` referencing `#{ISSUE}`
    - Check git log: `cd ~/projects/{PROJ} && git log --oneline --grep="#{ISSUE}" 2>/dev/null | head -10`
+
+6. **Apply aesthetic detection logic** to select the correct aesthetic file.
 
 ---
 
@@ -76,6 +120,8 @@ Adjust tabs to what the issue actually contains — simpler epics may need only 
 ~/.roxabi/forge/{PROJ}/visuals/tabs/{ISSUE}-{slug}/tab-{ID}.html
 ```
 
+Read `shells/split.html` → substitute placeholders. The shell contains all structure.
+
 **Shell HTML** — include `diagram:issue` meta:
 ```html
 <!-- diagram-meta:start -->
@@ -88,8 +134,6 @@ Adjust tabs to what the issue actually contains — simpler epics may need only 
 <meta name="diagram:issue"     content="{ISSUE}">
 <!-- diagram-meta:end -->
 ```
-
-**Page title convention:** `{PROJ} #{ISSUE} — {Short Title}` (e.g. "Lyra #477 — Tool Registry: Ecosystem Analysis").
 
 **Overview tab** — hero section with context:
 ```html
@@ -105,7 +149,7 @@ Adjust tabs to what the issue actually contains — simpler epics may need only 
 </div>
 ```
 
-CSS for epic-hero (add to `{ISSUE}-{slug}.css`):
+CSS for epic-hero (add to `{EXTRA_STYLES}`):
 ```css
 .epic-hero { margin-bottom: 2rem; }
 .epic-number { font-family: 'IBM Plex Mono', monospace; font-size: 0.875rem; color: var(--accent); font-weight: 600; margin-bottom: 0.5rem; }
@@ -120,16 +164,16 @@ CSS for epic-hero (add to `{ISSUE}-{slug}.css`):
 ```
 ```css
 .status { display: inline-block; padding: 0.125rem 0.5rem; border-radius: 3px; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; }
-.status.done { background: #14532d; color: #86efac; }
-.status.wip  { background: #78350f; color: #fcd34d; }
-.status.todo { background: #1e3a5f; color: #93c5fd; }
+.status.done { background: var(--success-dim); color: var(--success); }
+.status.wip  { background: var(--warning-dim); color: var(--warning); }
+.status.todo { background: var(--info-dim); color: var(--info); }
 ```
 
 **Deps tab** — Mermaid dependency diagram. Follow `references/mermaid-guide.md` checklist exactly (dynamic tab pitfalls).
 
 **Acceptance criteria tab** — table: | Criterion | Type | Status |
 
-Dark mode text rules always apply (see `references/tokens.md`).
+Dark mode text rules always apply — use semantic tokens from `base/components.css`.
 
 ---
 

--- a/plugins/forge/skills/forge-guide/SKILL.md
+++ b/plugins/forge/skills/forge-guide/SKILL.md
@@ -52,8 +52,9 @@ ${CLAUDE_PLUGIN_ROOT}/references/mermaid-guide.md    — only if a tab will cont
 3. Read selected aesthetic CSS
 4. Read `base/tab-loader.js`, substitute `{NAME}` with diagram slug
 5. Substitute placeholders:
+   - `{NAME}` → diagram slug (for localStorage key scoping + tab-loader.js)
    - `{BASE_STYLES}` → concatenated base CSS
-   - `{AESTHETIC_STYLES}` → aesthetic CSS (or empty if default)
+   - `{AESTHETIC_STYLES}` → aesthetic CSS (editorial.css if default)
    - `{TITLE}`, `{DATE}`, `{CATEGORY}`, `{CAT_LABEL}`, `{COLOR}`, `{BADGES}` → diagram metadata
    - `{TABS}` → tab button elements (one per tab)
    - `{PANELS}` → panel container elements (one per tab)

--- a/plugins/forge/skills/forge-guide/SKILL.md
+++ b/plugins/forge/skills/forge-guide/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: forge-guide
 description: 'Create a split-file multi-tab HTML document — user guide, architecture overview, project recap, comparison analysis, roadmap, or any rich multi-section doc. Triggers: "document" | "explain" | "illustrate" | "write a guide" | "create a guide" | "create a doc" | "make a recap" | "document this".'
-version: 0.1.0
+version: 0.2.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, ToolSearch
 ---
 
@@ -15,12 +15,53 @@ Covers: user guides, architecture overviews, project recaps, analysis/comparison
 **Read before generating:**
 
 ```
-${CLAUDE_PLUGIN_ROOT}/references/forge-ops.md     — brand detection, output paths, deploy commands
-${CLAUDE_PLUGIN_ROOT}/references/split-file.md    — templates + CSS/JS skeletons
-${CLAUDE_PLUGIN_ROOT}/references/aesthetics/      — lyra.css, roxabi.css (copy full token blocks)
-${CLAUDE_PLUGIN_ROOT}/references/diagram-meta.md  — meta tag format + categories
-${CLAUDE_PLUGIN_ROOT}/references/mermaid-guide.md — only if a tab will contain a Mermaid diagram
+${CLAUDE_PLUGIN_ROOT}/references/forge-ops.md        — brand detection, output paths, deploy commands
+${CLAUDE_PLUGIN_ROOT}/references/base/reset.css      — concatenate first
+${CLAUDE_PLUGIN_ROOT}/references/base/layout.css     — concatenate second
+${CLAUDE_PLUGIN_ROOT}/references/base/typography.css — concatenate third
+${CLAUDE_PLUGIN_ROOT}/references/base/components.css — concatenate last
+${CLAUDE_PLUGIN_ROOT}/references/aesthetics/         — select one based on detection logic
+${CLAUDE_PLUGIN_ROOT}/references/shells/split.html   — HTML template with placeholders
+${CLAUDE_PLUGIN_ROOT}/references/base/tab-loader.js  — substitute {NAME}, then inline
+${CLAUDE_PLUGIN_ROOT}/references/diagram-meta.md     — meta tag format + categories
+${CLAUDE_PLUGIN_ROOT}/references/mermaid-guide.md    — only if a tab will contain a Mermaid diagram
 ```
+
+**Directive: inline, never link** — `base/` and `aesthetics/` files are generation source, not runtime dependencies. Read → inline into output `<style>` block.
+
+---
+
+## Aesthetic Detection
+
+| Priority | Signal | Aesthetic |
+|----------|--------|-----------|
+| 1 | Explicit `--aesthetic` arg | As specified |
+| 2 | Brand book found (`BRAND-BOOK.md`) | Derived from palette |
+| 3 | Project = `lyra` / `voicecli` | `lyra.css` |
+| 4 | Project = `roxabi*` / `2ndBrain` | `roxabi.css` |
+| 5 | Content = architecture / spec | `blueprint.css` |
+| 6 | Content = CLI / terminal doc | `terminal.css` |
+| 7 | Default | `editorial.css` |
+
+---
+
+## Shell Processing
+
+1. Read `shells/split.html` template
+2. Concatenate base CSS files in order: `reset → layout → typography → components`
+3. Read selected aesthetic CSS
+4. Read `base/tab-loader.js`, substitute `{NAME}` with diagram slug
+5. Substitute placeholders:
+   - `{BASE_STYLES}` → concatenated base CSS
+   - `{AESTHETIC_STYLES}` → aesthetic CSS (or empty if default)
+   - `{TITLE}`, `{DATE}`, `{CATEGORY}`, `{CAT_LABEL}`, `{COLOR}`, `{BADGES}` → diagram metadata
+   - `{TABS}` → tab button elements (one per tab)
+   - `{PANELS}` → panel container elements (one per tab)
+   - `{TAB_LOADER_JS}` → tab-loader.js with `{NAME}` substituted
+   - `{HEAD_EXTRAS}` → optional (e.g., svg-pan-zoom CDN for Mermaid)
+   - `{EXTRA_STYLES}` → guide-specific CSS additions (if any)
+   - `{EXTRA_SCRIPTS}` → optional (e.g., mermaid-init.js)
+6. Output: split-file HTML (requires HTTP serve)
 
 Let:
   ARGS := $ARGUMENTS
@@ -41,6 +82,8 @@ Let:
    ls {ROOT}/{SLUG}*.html 2>/dev/null
    ```
    ∃ v<N> → propose vN+1 and offer to mark old version `archived` in its meta.
+
+5. **Apply aesthetic detection logic** to select the correct aesthetic file.
 
 ---
 
@@ -78,13 +121,13 @@ Let:
 {ROOT}/tabs/{SLUG}/tab-{ID}.html    ← one per tab
 ```
 
-Use exact templates from `references/split-file.md`. Replace all `{PLACEHOLDER}` values.
+Read `shells/split.html` → substitute placeholders. The shell contains all structure.
 
 **Shell HTML:** diagram-meta block, Google Fonts link, CSS link, nav with tab buttons + theme toggle, panel placeholders, JS script.
 
-**CSS:** token block (copy from `references/aesthetics/{project}.css`) + full skeleton.
+**CSS file:** write `{BASE_STYLES}` (concatenated base CSS) + `{AESTHETIC_STYLES}` (aesthetic CSS) + any guide-specific styles to `{ROOT}/css/{SLUG}.css`.
 
-**JS:** IIFE with theme, `loadPanel`, `activate`. Add `window.__postLoad` + `window.__initPanZoom` if Mermaid tabs exist (from `references/mermaid-guide.md`).
+**JS file:** write `{TAB_LOADER_JS}` (tab-loader.js with `{NAME}` substituted) + Mermaid init (if needed) to `{ROOT}/js/{SLUG}.js`.
 
 **Tab fragments** — content patterns by tab type:
 


### PR DESCRIPTION
## Summary
- Update forge-chart, forge-guide, forge-epic to read `base/*.css` + `aesthetics/*.css` + `shells/*.html` verbatim → inline into output
- Add 7-signal aesthetic detection logic to all three skills
- Add shell processing instructions with placeholder substitution (`{BASE_STYLES}`, `{AESTHETIC_STYLES}`, `{TAB_LOADER_JS}`)
- Add "inline, never link" directive to all skills
- Slim tokens.md: remove CSS code blocks, keep design rationale
- Slim split-file.md: remove CSS/JS skeletons, keep architecture + serving rules

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #83: forge: skill rewrites — reference new design system (S8) | OPEN |
| Frame | [83-forge-skill-rewrites-frame.mdx](artifacts/frames/83-forge-skill-rewrites-frame.mdx) | Present |
| Spec | [83-forge-skill-rewrites-spec.mdx](artifacts/specs/83-forge-skill-rewrites-spec.mdx) | Present |
| Plan | [83-forge-skill-rewrites-plan.mdx](artifacts/plans/83-forge-skill-rewrites-plan.mdx) | Present |
| Implementation | 1 commit on `feat/83-forge-skill-rewrites` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (349 passed) | Passed |

## Test Plan
- [ ] Verify forge-chart SKILL.md references `shells/single.html` and `base/*.css`
- [ ] Verify forge-guide SKILL.md references `shells/split.html` and `tab-loader.js`
- [ ] Verify all three skills have aesthetic detection table (7 signals)
- [ ] Verify all three skills have "inline, never link" directive
- [ ] Verify tokens.md has no CSS code fences
- [ ] Verify split-file.md has no CSS/JS skeletons

Closes #83

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`