### PR TITLE
feat(roxabi-sdk): #93 extract browser bootstrap to roxabi_sdk.browser

### DIFF
--- a/plugins/linkedin-apply/scripts/scraper.py
+++ b/plugins/linkedin-apply/scripts/scraper.py
@@ -187,6 +187,7 @@ class ScraperTimeoutError(LinkedInScraperError):
 # launcher will carry self.url=None, which is harmless but non-obvious.
 from roxabi_sdk.browser import (  # noqa: E402
     PlaywrightNotAvailableError as _SdkPlaywrightNotAvailableError,
+    launch_stealth_async as _sdk_launch_stealth_async,
 )
 
 
@@ -295,17 +296,12 @@ async def get_browser_context(
         PlaywrightNotAvailableError: If playwright or playwright-stealth is
             not installed (catchable as :class:`LinkedInScraperError` too).
     """
-    from roxabi_sdk.browser import (
-        PlaywrightNotAvailableError as _SdkPWError,
-        launch_stealth_async,
-    )
-
     try:
-        playwright, context, _page = await launch_stealth_async(
+        playwright, context, _page = await _sdk_launch_stealth_async(
             user_data_dir=LINKEDIN_PROFILE_DIR,
             headless=headless,
         )
-    except _SdkPWError as exc:
+    except _SdkPlaywrightNotAvailableError as exc:
         raise PlaywrightNotAvailableError(str(exc)) from exc
 
     logger.info("Browser context created with stealth mode")

--- a/plugins/linkedin-apply/scripts/scraper.py
+++ b/plugins/linkedin-apply/scripts/scraper.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 # Type checking imports
 if TYPE_CHECKING:
-    from playwright.async_api import Page, BrowserContext
+    from playwright.async_api import BrowserContext, Page, Playwright as AsyncPlaywright
 
 
 # ============================================================================
@@ -187,6 +187,7 @@ class ScraperTimeoutError(LinkedInScraperError):
 # launcher will carry self.url=None, which is harmless but non-obvious.
 from roxabi_sdk.browser import (  # noqa: E402
     PlaywrightNotAvailableError as _SdkPlaywrightNotAvailableError,
+    close_stealth_async as _sdk_close_stealth_async,
     launch_stealth_async as _sdk_launch_stealth_async,
 )
 
@@ -284,11 +285,11 @@ def validate_linkedin_url(url: str) -> bool:
 
 async def get_browser_context(
     headless: bool = False,
-) -> tuple[Any, "BrowserContext"]:
+) -> tuple[AsyncPlaywright, BrowserContext, Page]:
     """Create a stealth-patched persistent LinkedIn browser context.
 
     Delegates to :func:`roxabi_sdk.browser.launch_stealth_async` with the
-    LinkedIn profile directory. Returns ``(playwright, context)`` — the
+    LinkedIn profile directory. Returns ``(playwright, context, page)`` — the
     caller owns the lifecycle and must call
     :func:`roxabi_sdk.browser.close_stealth_async` when done.
 
@@ -297,7 +298,7 @@ async def get_browser_context(
             not installed (catchable as :class:`LinkedInScraperError` too).
     """
     try:
-        playwright, context, _page = await _sdk_launch_stealth_async(
+        playwright, context, page = await _sdk_launch_stealth_async(
             user_data_dir=LINKEDIN_PROFILE_DIR,
             headless=headless,
         )
@@ -305,7 +306,7 @@ async def get_browser_context(
         raise PlaywrightNotAvailableError(str(exc)) from exc
 
     logger.info("Browser context created with stealth mode")
-    return playwright, context
+    return playwright, context, page
 
 
 async def check_login(page: "Page") -> bool:
@@ -398,12 +399,8 @@ async def scrape_job(
     context = None
 
     try:
-        # Get browser context
-        playwright, context = await get_browser_context(headless=headless)
-
-        # Get or create page
-        pages = context.pages
-        page = pages[0] if pages else await context.new_page()
+        # Get browser context + stealth-patched page from SDK
+        playwright, context, page = await get_browser_context(headless=headless)
 
         # Navigate to job page
         logger.debug("Navigating to job page...")
@@ -526,17 +523,11 @@ async def scrape_job(
         return job
 
     finally:
-        # Cleanup
-        if context:
+        if playwright and context:
             try:
-                await context.close()
+                await _sdk_close_stealth_async(playwright, context)
             except Exception as e:
-                logger.warning(f"Error closing context: {e}")
-        if playwright:
-            try:
-                await playwright.stop()
-            except Exception as e:
-                logger.warning(f"Error stopping playwright: {e}")
+                logger.warning(f"Error during browser cleanup: {e}")
 
 
 async def scrape_job_with_retry(

--- a/plugins/linkedin-apply/scripts/scraper.py
+++ b/plugins/linkedin-apply/scripts/scraper.py
@@ -181,10 +181,29 @@ class ScraperTimeoutError(LinkedInScraperError):
     pass
 
 
-class PlaywrightNotAvailableError(LinkedInScraperError):
-    """Raised when Playwright is not installed."""
+# Import the SDK error so the local alias can be caught from both
+# hierarchies (see #93 spec S3a). MRO is left-first, so __init__ resolves
+# to LinkedInScraperError(message, url=None) — instances raised by the SDK
+# launcher will carry self.url=None, which is harmless but non-obvious.
+from roxabi_sdk.browser import (  # noqa: E402
+    PlaywrightNotAvailableError as _SdkPlaywrightNotAvailableError,
+)
 
-    pass
+
+class PlaywrightNotAvailableError(
+    LinkedInScraperError, _SdkPlaywrightNotAvailableError
+):
+    """Alias error catchable from both LinkedIn and SDK exception hierarchies.
+
+    Allows ``except PlaywrightNotAvailableError`` and
+    ``except LinkedInScraperError`` clauses to both catch the same instance,
+    so existing LinkedIn callers keep working while cross-cutting SDK
+    callers (e.g. dashboards that aggregate browser-bootstrap failures)
+    can also handle it uniformly with web-intel.
+
+    ``self.url`` will be ``None`` for errors raised by the SDK launcher
+    (the SDK does not know which URL the caller was about to fetch).
+    """
 
 
 # ============================================================================
@@ -265,57 +284,29 @@ def validate_linkedin_url(url: str) -> bool:
 async def get_browser_context(
     headless: bool = False,
 ) -> tuple[Any, "BrowserContext"]:
-    """
-    Create browser context with persistent profile and stealth mode.
+    """Create a stealth-patched persistent LinkedIn browser context.
 
-    Returns:
-        Tuple of (playwright instance, browser context)
+    Delegates to :func:`roxabi_sdk.browser.launch_stealth_async` with the
+    LinkedIn profile directory. Returns ``(playwright, context)`` — the
+    caller owns the lifecycle and must call
+    :func:`roxabi_sdk.browser.close_stealth_async` when done.
 
     Raises:
-        PlaywrightNotAvailableError: If playwright or playwright-stealth not installed
-
-    TODO(#93): The Playwright + stealth bootstrap below duplicates the sync
-    variant in ``plugins/web-intel/scripts/fetchers/stealth.py`` and
-    ``plugins/web-intel/scripts/screenshot.py``. Extract to
-    ``roxabi_sdk/browser.py`` as ``launch_stealth_async(user_data_dir=...)``
-    so all three sites share one primitive. See Roxabi/roxabi-plugins#93
-    for the full refactor plan.
+        PlaywrightNotAvailableError: If playwright or playwright-stealth is
+            not installed (catchable as :class:`LinkedInScraperError` too).
     """
+    from roxabi_sdk.browser import (
+        PlaywrightNotAvailableError as _SdkPWError,
+        launch_stealth_async,
+    )
+
     try:
-        from playwright.async_api import async_playwright
-        from playwright_stealth import Stealth
-    except ImportError as e:
-        raise PlaywrightNotAvailableError(
-            f"Playwright or playwright-stealth not installed: {e}\n"
-            "Run: pip install playwright playwright-stealth && playwright install chromium"
+        playwright, context, _page = await launch_stealth_async(
+            user_data_dir=LINKEDIN_PROFILE_DIR,
+            headless=headless,
         )
-
-    # Ensure profile directory exists
-    os.makedirs(LINKEDIN_PROFILE_DIR, exist_ok=True)
-
-    # Create stealth instance
-    stealth = Stealth(
-        navigator_webdriver=True,
-        chrome_runtime=True,
-        navigator_plugins=True,
-        navigator_permissions=True,
-        webgl_vendor=True,
-    )
-
-    # Use stealth-instrumented playwright
-    playwright = await stealth.use_async(async_playwright()).start()
-
-    # Launch persistent context
-    context = await playwright.chromium.launch_persistent_context(
-        user_data_dir=LINKEDIN_PROFILE_DIR,
-        headless=headless,
-        viewport={"width": 1280, "height": 900},
-        args=[
-            "--disable-blink-features=AutomationControlled",
-            "--no-first-run",
-            "--no-default-browser-check",
-        ],
-    )
+    except _SdkPWError as exc:
+        raise PlaywrightNotAvailableError(str(exc)) from exc
 
     logger.info("Browser context created with stealth mode")
     return playwright, context

--- a/plugins/linkedin-apply/tests/test_alias.py
+++ b/plugins/linkedin-apply/tests/test_alias.py
@@ -52,3 +52,9 @@ def test_alias_has_url_attribute_none() -> None:
     """
     exc = PlaywrightNotAvailableError("test msg")
     assert exc.url is None
+
+
+def test_alias_url_kwarg_stored() -> None:
+    """When a ``url`` is provided, the LinkedIn-side ``__init__`` must store it."""
+    exc = PlaywrightNotAvailableError("test msg", url="https://linkedin.com/jobs/123")
+    assert exc.url == "https://linkedin.com/jobs/123"

--- a/plugins/linkedin-apply/tests/test_alias.py
+++ b/plugins/linkedin-apply/tests/test_alias.py
@@ -1,0 +1,54 @@
+"""Alias catchability tests for ``PlaywrightNotAvailableError``.
+
+After #93, ``plugins.linkedin-apply.scripts.scraper.PlaywrightNotAvailableError``
+must be catchable as both:
+
+* :class:`scripts.scraper.LinkedInScraperError` — for callers that
+  ``except LinkedInScraperError`` to handle every scraper failure uniformly.
+* :class:`roxabi_sdk.browser.PlaywrightNotAvailableError` — for callers that
+  ``except PlaywrightNotAvailableError`` to handle the missing-dep case
+  cross-cutting all browser users.
+
+The pre-refactor class only inherited from ``LinkedInScraperError``, so the
+SDK-side ``isinstance`` check below is the RED phase: it must fail before
+T4.2 introduces the multiple-inheritance alias and pass after.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Match the sys.path bootstrapping used by tests/test_adapters.py.
+_plugin_root = str(Path(__file__).resolve().parents[1])
+_repo_root = str(Path(__file__).resolve().parents[3])
+for _p in (_plugin_root, _repo_root):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from roxabi_sdk.browser import PlaywrightNotAvailableError as SdkPWError
+from scripts.scraper import (
+    LinkedInScraperError,
+    PlaywrightNotAvailableError,
+)
+
+
+def test_alias_is_catchable_as_linkedin_error() -> None:
+    """The alias must still satisfy ``except LinkedInScraperError``."""
+    exc = PlaywrightNotAvailableError("test msg")
+    assert isinstance(exc, LinkedInScraperError)
+
+
+def test_alias_is_catchable_as_sdk_error() -> None:
+    """The alias must also satisfy ``except SdkPWError`` after T4.2."""
+    exc = PlaywrightNotAvailableError("test msg")
+    assert isinstance(exc, SdkPWError)
+
+
+def test_alias_has_url_attribute_none() -> None:
+    """MRO is left-first → ``LinkedInScraperError.__init__(message, url=None)``.
+
+    The alias does not pass a ``url`` so ``self.url`` should be ``None``.
+    Documented in plan T4.2: harmless but non-obvious for SDK errors.
+    """
+    exc = PlaywrightNotAvailableError("test msg")
+    assert exc.url is None

--- a/plugins/web-intel/scripts/fetchers/stealth.py
+++ b/plugins/web-intel/scripts/fetchers/stealth.py
@@ -8,12 +8,6 @@ fallback utility invoked by ``generic.py`` when the fast path (plain HTTP
 via ``safe_fetch`` + Trafilatura) fails to extract meaningful content or
 hits an anti-bot signature.
 
-TODO(#93): The Playwright + stealth bootstrap below (launch → context →
-page → apply stealth patches) duplicates the async variant in
-``plugins/linkedin-apply/scripts/scraper.py:get_browser_context``. Extract
-to ``roxabi_sdk/browser.py`` as ``launch_stealth_sync()`` so both plugins
-share one primitive. See Roxabi/roxabi-plugins#93 for the full refactor plan.
-
 Triggers for a stealth retry:
   - HTTP 403 / 429 / 503 from the fast path
   - Cloudflare / generic anti-bot challenge markers in the body
@@ -35,7 +29,6 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from typing import Optional, Tuple
 
 # Add _shared to path for sibling imports (consistent with other fetchers)
 SHARED_DIR = Path(__file__).resolve().parents[1] / "_shared"
@@ -97,9 +90,9 @@ except ImportError:
 
 
 def has_antibot_signature(
-    status_code: Optional[int] = None,
-    html: Optional[str] = None,
-    text_length: Optional[int] = None,
+    status_code: int | None = None,
+    html: str | None = None,
+    text_length: int | None = None,
 ) -> bool:
     """Detect whether a fast-path fetch looks like it hit anti-bot protection.
 
@@ -126,7 +119,7 @@ def has_antibot_signature(
 def fetch_html_stealth(
     url: str,
     timeout_ms: int = DEFAULT_TIMEOUT_MS,
-) -> Tuple[Optional[str], Optional[str]]:
+) -> tuple[str | None, str | None]:
     """Fetch a URL's rendered HTML using headless Chromium + stealth patches.
 
     Intended as a fallback for anti-bot protected pages. Returns a

--- a/plugins/web-intel/scripts/fetchers/stealth.py
+++ b/plugins/web-intel/scripts/fetchers/stealth.py
@@ -77,15 +77,27 @@ _DEFAULT_USER_AGENT = (
 )
 _DEFAULT_VIEWPORT = {"width": 1280, "height": 900}
 
+from roxabi_sdk.browser import (
+    PlaywrightNotAvailableError,
+    close_stealth,
+    launch_stealth_sync,
+)
+
+# These two probe flags stay independent of the SDK so the existing
+# test suite (test_stealth.py:104) can keep monkey-patching
+# PLAYWRIGHT_AVAILABLE to drive the "missing dep" branch without having
+# to reach into roxabi_sdk internals. They serve a different role from
+# roxabi_sdk.browser._raise_if_unavailable: this is a module-level
+# pre-flight gate, not the eager import probe used by the launcher.
 try:
-    from playwright.sync_api import sync_playwright
+    import playwright  # noqa: F401
 
     PLAYWRIGHT_AVAILABLE = True
 except ImportError:
     PLAYWRIGHT_AVAILABLE = False
 
 try:
-    from playwright_stealth import Stealth as _Stealth
+    import playwright_stealth  # noqa: F401
 
     PLAYWRIGHT_STEALTH_AVAILABLE = True
 except ImportError:
@@ -153,47 +165,45 @@ def fetch_html_stealth(
         logger.warning("Stealth fetch refused: %s", msg)
         return None, msg
 
+    pw = ctx = None
     try:
-        with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True)
-            try:
-                context = browser.new_context(
-                    user_agent=_DEFAULT_USER_AGENT,
-                    viewport=_DEFAULT_VIEWPORT,
-                    locale="en-US",
-                )
-                page = context.new_page()
+        try:
+            pw, ctx, page = launch_stealth_sync(
+                user_agent=_DEFAULT_USER_AGENT,
+                viewport=_DEFAULT_VIEWPORT,
+                locale="en-US",
+            )
+        except PlaywrightNotAvailableError as exc:
+            # SDK probe failed even though our PLAYWRIGHT_AVAILABLE flag passed
+            # — surface the SDK install hint verbatim so the user can act on it.
+            logger.info("Stealth fallback unavailable: %s", exc)
+            return None, str(exc)
 
-                if PLAYWRIGHT_STEALTH_AVAILABLE:
-                    _Stealth().use_sync(page)
-                    logger.debug("playwright-stealth patches applied")
-                else:
-                    logger.info(
-                        "playwright-stealth not installed; stealth fetch running "
-                        "without fingerprint patches (less effective)"
-                    )
+        page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
+        # Let dynamic content settle — CF challenge pages typically
+        # auto-redirect after ~1-2s when the stealth patches work
+        page.wait_for_timeout(POST_LOAD_WAIT_MS)
 
-                page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
-                # Let dynamic content settle — CF challenge pages typically
-                # auto-redirect after ~1-2s when the stealth patches work
-                page.wait_for_timeout(POST_LOAD_WAIT_MS)
+        html = page.content()
 
-                html = page.content()
-            finally:
-                browser.close()
+        # If we STILL see a challenge marker, stealth didn't bypass it —
+        # don't pretend success, let the caller surface a clear error
+        for marker in CF_CHALLENGE_MARKERS:
+            if marker in html:
+                msg = f"still blocked by anti-bot challenge after stealth retry ({marker!r})"
+                logger.info("Stealth fetch: %s", msg)
+                return None, msg
 
-            # If we STILL see a challenge marker, stealth didn't bypass it —
-            # don't pretend success, let the caller surface a clear error
-            for marker in CF_CHALLENGE_MARKERS:
-                if marker in html:
-                    msg = f"still blocked by anti-bot challenge after stealth retry ({marker!r})"
-                    logger.info("Stealth fetch: %s", msg)
-                    return None, msg
-
-            return html, None
+        return html, None
 
     except Exception as exc:
         # Preserve exception type so callers can see e.g. "TimeoutError: ..."
         msg = f"{type(exc).__name__}: {exc}"
         logger.warning("Stealth fetch failed for %s: %s", url, msg)
         return None, msg
+    finally:
+        if pw is not None and ctx is not None:
+            try:
+                close_stealth(pw, ctx)
+            except Exception:
+                logger.debug("close_stealth raised during cleanup", exc_info=True)

--- a/plugins/web-intel/scripts/fetchers/stealth.py
+++ b/plugins/web-intel/scripts/fetchers/stealth.py
@@ -69,14 +69,6 @@ DEFAULT_TIMEOUT_MS = 30_000
 # Wait after domcontentloaded for dynamic content / CF auto-redirect
 POST_LOAD_WAIT_MS = 2_500
 
-# Viewport + UA tuned to match a common desktop Chrome fingerprint
-_DEFAULT_USER_AGENT = (
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/120.0.0.0 Safari/537.36"
-)
-_DEFAULT_VIEWPORT = {"width": 1280, "height": 900}
-
 from roxabi_sdk.browser import (
     PlaywrightNotAvailableError,
     close_stealth,
@@ -168,15 +160,11 @@ def fetch_html_stealth(
     pw = ctx = None
     try:
         try:
-            pw, ctx, page = launch_stealth_sync(
-                user_agent=_DEFAULT_USER_AGENT,
-                viewport=_DEFAULT_VIEWPORT,
-                locale="en-US",
-            )
+            pw, ctx, page = launch_stealth_sync()
         except PlaywrightNotAvailableError as exc:
             # SDK probe failed even though our PLAYWRIGHT_AVAILABLE flag passed
             # — surface the SDK install hint verbatim so the user can act on it.
-            logger.info("Stealth fallback unavailable: %s", exc)
+            logger.info("Stealth fallback unavailable: %s", exc, exc_info=True)
             return None, str(exc)
 
         page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")

--- a/plugins/web-intel/scripts/screenshot.py
+++ b/plugins/web-intel/scripts/screenshot.py
@@ -28,9 +28,12 @@ Security:
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 from typing import Tuple
+
+logger = logging.getLogger(__name__)
 
 # Add _shared to path for sibling imports (consistent with fetchers/*.py)
 SHARED_DIR = Path(__file__).resolve().parent / "_shared"
@@ -44,13 +47,6 @@ DEFAULT_TIMEOUT_MS = 30_000
 
 # Wait after domcontentloaded for dynamic content / fonts to settle
 POST_LOAD_WAIT_MS = 2_500
-
-_DEFAULT_USER_AGENT = (
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/120.0.0.0 Safari/537.36"
-)
-_DEFAULT_VIEWPORT = {"width": 1280, "height": 900}
 
 from roxabi_sdk.browser import (  # noqa: E402
     PlaywrightNotAvailableError,
@@ -106,11 +102,7 @@ def capture_full_page(
     pw = ctx = None
     try:
         try:
-            pw, ctx, page = launch_stealth_sync(
-                user_agent=_DEFAULT_USER_AGENT,
-                viewport=_DEFAULT_VIEWPORT,
-                locale="en-US",
-            )
+            pw, ctx, page = launch_stealth_sync()
         except PlaywrightNotAvailableError as exc:
             return False, str(exc)
 
@@ -127,7 +119,7 @@ def capture_full_page(
             try:
                 close_stealth(pw, ctx)
             except Exception:
-                pass
+                logger.debug("close_stealth raised during screenshot cleanup", exc_info=True)
 
 
 def main() -> int:

--- a/plugins/web-intel/scripts/screenshot.py
+++ b/plugins/web-intel/scripts/screenshot.py
@@ -6,12 +6,6 @@ Used as a fallback by ``/roast`` and ``/benchmark`` when the agent-browser
 CLI is not installed. Reuses the Playwright stack already required for X
 articles — no new dependencies.
 
-TODO(#93): The Playwright + stealth bootstrap below duplicates
-``fetchers/stealth.py`` (sync) and ``plugins/linkedin-apply/scripts/scraper.py``
-(async). Extract to ``roxabi_sdk/browser.py`` so all three sites share one
-``launch_stealth_sync()`` / ``launch_stealth_async()`` primitive.
-See Roxabi/roxabi-plugins#93 for the full refactor plan.
-
 Usage:
     uv run python scripts/screenshot.py <url> <output_path>
 
@@ -31,7 +25,6 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from typing import Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +70,7 @@ def capture_full_page(
     url: str,
     output_path: str,
     timeout_ms: int = DEFAULT_TIMEOUT_MS,
-) -> Tuple[bool, str]:
+) -> tuple[bool, str]:
     """Capture a full-page PNG screenshot to disk.
 
     Args:

--- a/plugins/web-intel/scripts/screenshot.py
+++ b/plugins/web-intel/scripts/screenshot.py
@@ -52,15 +52,25 @@ _DEFAULT_USER_AGENT = (
 )
 _DEFAULT_VIEWPORT = {"width": 1280, "height": 900}
 
+from roxabi_sdk.browser import (  # noqa: E402
+    PlaywrightNotAvailableError,
+    close_stealth,
+    launch_stealth_sync,
+)
+
+# Independent module-level pre-flight flags — kept separate from
+# roxabi_sdk.browser._raise_if_unavailable so any future test that
+# wants to monkey-patch them (mirroring tests/test_stealth.py:104) can
+# still drive the "missing dep" branch without reaching into SDK internals.
 try:
-    from playwright.sync_api import sync_playwright
+    import playwright  # noqa: F401
 
     PLAYWRIGHT_AVAILABLE = True
 except ImportError:
     PLAYWRIGHT_AVAILABLE = False
 
 try:
-    from playwright_stealth import Stealth as _Stealth
+    import playwright_stealth  # noqa: F401
 
     PLAYWRIGHT_STEALTH_AVAILABLE = True
 except ImportError:
@@ -93,28 +103,31 @@ def capture_full_page(
     if not is_valid:
         return False, f"URL rejected by SSRF validation: {err}"
 
+    pw = ctx = None
     try:
-        with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True)
-            context = browser.new_context(
+        try:
+            pw, ctx, page = launch_stealth_sync(
                 user_agent=_DEFAULT_USER_AGENT,
                 viewport=_DEFAULT_VIEWPORT,
                 locale="en-US",
             )
-            page = context.new_page()
+        except PlaywrightNotAvailableError as exc:
+            return False, str(exc)
 
-            if PLAYWRIGHT_STEALTH_AVAILABLE:
-                _Stealth().use_sync(page)
-
-            page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
-            # Let fonts, lazy images, and CF auto-redirects settle
-            page.wait_for_timeout(POST_LOAD_WAIT_MS)
-            page.screenshot(path=output_path, full_page=True)
-            browser.close()
-            return True, output_path
+        page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
+        # Let fonts, lazy images, and CF auto-redirects settle
+        page.wait_for_timeout(POST_LOAD_WAIT_MS)
+        page.screenshot(path=output_path, full_page=True)
+        return True, output_path
 
     except Exception as exc:
         return False, f"Screenshot failed: {exc}"
+    finally:
+        if pw is not None and ctx is not None:
+            try:
+                close_stealth(pw, ctx)
+            except Exception:
+                pass
 
 
 def main() -> int:

--- a/roxabi_sdk/browser.py
+++ b/roxabi_sdk/browser.py
@@ -1,0 +1,241 @@
+"""Stealth-patched Chromium launcher for Roxabi plugins.
+
+Contract source: artifacts/specs/93-extract-browser-bootstrap-spec.mdx
+
+This module deduplicates the playwright + playwright-stealth bootstrap that
+used to live in three call sites (web-intel × 2 sync, linkedin-apply × 1 async).
+It exposes:
+
+* :func:`launch_stealth_sync` / :func:`launch_stealth_async` — uniform
+  ``(playwright, context, page)`` returners that handle ephemeral and
+  persistent (``user_data_dir``) launches identically and apply
+  ``Stealth().apply_stealth_{sync,async}(context)`` BEFORE any page is
+  created (the only idiom that actually patches in playwright-stealth==2.0.2;
+  see V0 probe in PR description).
+* :func:`close_stealth` / :func:`close_stealth_async` — paired teardown
+  helpers that close the right object (``browser`` for ephemeral, ``context``
+  for persistent) and always stop the Playwright driver.
+* :class:`PlaywrightNotAvailableError` — typed sentinel raised when either
+  playwright or playwright-stealth is missing. Subclasses ``RuntimeError``
+  so it stays catchable as a generic runtime failure too.
+
+Playwright is imported lazily inside each entrypoint so this module remains
+importable in environments where the optional ``[twitter]`` extra is not
+installed (CI guard test SC-17).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Forward references only; never imported at runtime.
+    from playwright.async_api import (
+        BrowserContext as AsyncBrowserContext,
+        Page as AsyncPage,
+        Playwright as AsyncPlaywright,
+    )
+    from playwright.sync_api import (
+        BrowserContext as SyncBrowserContext,
+        Page as SyncPage,
+        Playwright as SyncPlaywright,
+    )
+
+__all__ = [
+    "PlaywrightNotAvailableError",
+    "launch_stealth_sync",
+    "launch_stealth_async",
+    "close_stealth",
+    "close_stealth_async",
+]
+
+_INSTALL_HINT = (
+    "playwright or playwright-stealth not installed. Install with: "
+    "uv sync --extra twitter && uv run playwright install chromium "
+    "(or: pip install playwright playwright-stealth && playwright install chromium)"
+)
+
+
+class PlaywrightNotAvailableError(RuntimeError):
+    """Raised when playwright/playwright-stealth cannot be imported.
+
+    Subclasses :class:`RuntimeError` (not :class:`ImportError`) so callers
+    that already catch ``RuntimeError`` keep working, while still getting a
+    typed sentinel for targeted handling.
+    """
+
+
+def _raise_if_unavailable() -> None:
+    """Eagerly import playwright + playwright-stealth or raise typed error."""
+    try:
+        import playwright  # noqa: F401
+        import playwright_stealth  # noqa: F401
+    except ImportError as exc:
+        raise PlaywrightNotAvailableError(f"{_INSTALL_HINT} ({exc})") from exc
+
+
+_DEFAULT_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+_DEFAULT_VIEWPORT = {"width": 1280, "height": 900}
+_DEFAULT_LAUNCH_ARGS = [
+    "--disable-blink-features=AutomationControlled",
+    "--no-first-run",
+    "--no-default-browser-check",
+]
+_DEFAULT_STEALTH_FLAGS = dict(
+    navigator_webdriver=True,
+    chrome_runtime=True,
+    navigator_plugins=True,
+    navigator_permissions=True,
+    webgl_vendor=True,
+)
+
+
+def launch_stealth_sync(
+    *,
+    user_data_dir: str | None = None,
+    headless: bool = True,
+    user_agent: str | None = None,
+    viewport: dict | None = None,
+    locale: str = "en-US",
+    stealth_flags: dict | None = None,
+    launch_args: list[str] | None = None,
+) -> "tuple[SyncPlaywright, SyncBrowserContext, SyncPage]":
+    """Launch a stealth-patched Chromium and return ``(playwright, context, page)``.
+
+    Either ephemeral (``user_data_dir=None``, default) or persistent (when
+    ``user_data_dir`` is set, the directory is created on demand and a
+    ``launch_persistent_context`` is used). In both shapes the stealth
+    patches are applied to the **context** before any page is opened — this
+    is the only idiom that actually patches in playwright-stealth==2.0.2
+    (the V0 probe in #93 verified that ``Stealth().use_sync(page)`` called
+    after ``context.new_page()`` is a no-op).
+
+    The caller owns the returned tuple and must call :func:`close_stealth`
+    in a ``finally`` block to release the Chromium process and Playwright
+    driver.
+
+    Raises:
+        PlaywrightNotAvailableError: if playwright or playwright-stealth
+            cannot be imported.
+    """
+    _raise_if_unavailable()
+    from playwright.sync_api import sync_playwright
+    from playwright_stealth import Stealth
+
+    ua = user_agent or _DEFAULT_UA
+    vp = viewport or _DEFAULT_VIEWPORT
+    la = launch_args if launch_args is not None else _DEFAULT_LAUNCH_ARGS
+    sf = stealth_flags if stealth_flags is not None else _DEFAULT_STEALTH_FLAGS
+
+    pw = sync_playwright().start()
+    try:
+        if user_data_dir is not None:
+            import os
+
+            os.makedirs(user_data_dir, exist_ok=True)
+            ctx = pw.chromium.launch_persistent_context(
+                user_data_dir=user_data_dir,
+                headless=headless,
+                viewport=vp,
+                locale=locale,
+                user_agent=ua,
+                args=la,
+            )
+        else:
+            browser = pw.chromium.launch(headless=headless, args=la)
+            ctx = browser.new_context(user_agent=ua, viewport=vp, locale=locale)
+        Stealth(**sf).apply_stealth_sync(ctx)
+        page = ctx.pages[0] if ctx.pages else ctx.new_page()
+        return pw, ctx, page
+    except Exception:
+        pw.stop()
+        raise
+
+
+async def launch_stealth_async(
+    *,
+    user_data_dir: str | None = None,
+    headless: bool = True,
+    user_agent: str | None = None,
+    viewport: dict | None = None,
+    locale: str = "en-US",
+    stealth_flags: dict | None = None,
+    launch_args: list[str] | None = None,
+) -> "tuple[AsyncPlaywright, AsyncBrowserContext, AsyncPage]":
+    """Async mirror of :func:`launch_stealth_sync`.
+
+    Must run inside the caller's existing event loop. This function does
+    NOT call :func:`asyncio.run` or :func:`asyncio.get_event_loop` — callers
+    like ``linkedin-apply.scripts.scraper.get_browser_context`` already own
+    a running loop and ``await`` this entrypoint directly.
+    """
+    _raise_if_unavailable()
+    from playwright.async_api import async_playwright
+    from playwright_stealth import Stealth
+
+    ua = user_agent or _DEFAULT_UA
+    vp = viewport or _DEFAULT_VIEWPORT
+    la = launch_args if launch_args is not None else _DEFAULT_LAUNCH_ARGS
+    sf = stealth_flags if stealth_flags is not None else _DEFAULT_STEALTH_FLAGS
+
+    pw = await async_playwright().start()
+    try:
+        if user_data_dir is not None:
+            import os
+
+            os.makedirs(user_data_dir, exist_ok=True)
+            ctx = await pw.chromium.launch_persistent_context(
+                user_data_dir=user_data_dir,
+                headless=headless,
+                viewport=vp,
+                locale=locale,
+                user_agent=ua,
+                args=la,
+            )
+        else:
+            browser = await pw.chromium.launch(headless=headless, args=la)
+            ctx = await browser.new_context(user_agent=ua, viewport=vp, locale=locale)
+        await Stealth(**sf).apply_stealth_async(ctx)
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+        return pw, ctx, page
+    except Exception:
+        await pw.stop()
+        raise
+
+
+def close_stealth(playwright, context) -> None:
+    """Tear down a sync stealth session.
+
+    Closes the right object based on context shape:
+
+    * **Ephemeral** (``context.browser`` is a real ``Browser`` instance):
+      close the browser, which closes the context implicitly.
+    * **Persistent** (``context.browser is None``, the persistent context
+      owns its browser process directly): close the context.
+
+    Always stops the Playwright driver in the ``finally`` clause so a
+    misbehaving close still releases the supervisor process.
+    """
+    try:
+        browser = context.browser
+        if browser is not None:
+            browser.close()
+        else:
+            context.close()
+    finally:
+        playwright.stop()
+
+
+async def close_stealth_async(playwright, context) -> None:
+    """Async mirror of :func:`close_stealth`."""
+    try:
+        browser = context.browser
+        if browser is not None:
+            await browser.close()
+        else:
+            await context.close()
+    finally:
+        await playwright.stop()

--- a/roxabi_sdk/browser.py
+++ b/roxabi_sdk/browser.py
@@ -25,6 +25,7 @@ installed (CI guard test SC-17).
 """
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -70,7 +71,7 @@ def _raise_if_unavailable() -> None:
         import playwright  # noqa: F401
         import playwright_stealth  # noqa: F401
     except ImportError as exc:
-        raise PlaywrightNotAvailableError(f"{_INSTALL_HINT} ({exc})") from exc
+        raise PlaywrightNotAvailableError(_INSTALL_HINT) from exc
 
 
 _DEFAULT_UA = (
@@ -84,13 +85,13 @@ _DEFAULT_LAUNCH_ARGS = [
     "--no-first-run",
     "--no-default-browser-check",
 ]
-_DEFAULT_STEALTH_FLAGS = dict(
-    navigator_webdriver=True,
-    chrome_runtime=True,
-    navigator_plugins=True,
-    navigator_permissions=True,
-    webgl_vendor=True,
-)
+_DEFAULT_STEALTH_FLAGS = {
+    "navigator_webdriver": True,
+    "chrome_runtime": True,
+    "navigator_plugins": True,
+    "navigator_permissions": True,
+    "webgl_vendor": True,
+}
 
 
 def launch_stealth_sync(
@@ -102,7 +103,7 @@ def launch_stealth_sync(
     locale: str = "en-US",
     stealth_flags: dict | None = None,
     launch_args: list[str] | None = None,
-) -> "tuple[SyncPlaywright, SyncBrowserContext, SyncPage]":
+) -> tuple[SyncPlaywright, SyncBrowserContext, SyncPage]:
     """Launch a stealth-patched Chromium and return ``(playwright, context, page)``.
 
     Either ephemeral (``user_data_dir=None``, default) or persistent (when
@@ -133,8 +134,6 @@ def launch_stealth_sync(
     pw = sync_playwright().start()
     try:
         if user_data_dir is not None:
-            import os
-
             os.makedirs(user_data_dir, exist_ok=True)
             ctx = pw.chromium.launch_persistent_context(
                 user_data_dir=user_data_dir,
@@ -148,7 +147,7 @@ def launch_stealth_sync(
             browser = pw.chromium.launch(headless=headless, args=la)
             ctx = browser.new_context(user_agent=ua, viewport=vp, locale=locale)
         Stealth(**sf).apply_stealth_sync(ctx)
-        page = ctx.pages[0] if ctx.pages else ctx.new_page()
+        page = ctx.new_page()
         return pw, ctx, page
     except Exception:
         pw.stop()
@@ -164,7 +163,7 @@ async def launch_stealth_async(
     locale: str = "en-US",
     stealth_flags: dict | None = None,
     launch_args: list[str] | None = None,
-) -> "tuple[AsyncPlaywright, AsyncBrowserContext, AsyncPage]":
+) -> tuple[AsyncPlaywright, AsyncBrowserContext, AsyncPage]:
     """Async mirror of :func:`launch_stealth_sync`.
 
     Must run inside the caller's existing event loop. This function does
@@ -184,8 +183,6 @@ async def launch_stealth_async(
     pw = await async_playwright().start()
     try:
         if user_data_dir is not None:
-            import os
-
             os.makedirs(user_data_dir, exist_ok=True)
             ctx = await pw.chromium.launch_persistent_context(
                 user_data_dir=user_data_dir,
@@ -199,14 +196,16 @@ async def launch_stealth_async(
             browser = await pw.chromium.launch(headless=headless, args=la)
             ctx = await browser.new_context(user_agent=ua, viewport=vp, locale=locale)
         await Stealth(**sf).apply_stealth_async(ctx)
-        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+        page = await ctx.new_page()
         return pw, ctx, page
     except Exception:
         await pw.stop()
         raise
 
 
-def close_stealth(playwright, context) -> None:
+def close_stealth(
+    playwright: SyncPlaywright, context: SyncBrowserContext
+) -> None:
     """Tear down a sync stealth session.
 
     Closes the right object based on context shape:
@@ -229,7 +228,9 @@ def close_stealth(playwright, context) -> None:
         playwright.stop()
 
 
-async def close_stealth_async(playwright, context) -> None:
+async def close_stealth_async(
+    playwright: AsyncPlaywright, context: AsyncBrowserContext
+) -> None:
     """Async mirror of :func:`close_stealth`."""
     try:
         browser = context.browser

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import sys
 import types
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -126,7 +126,7 @@ async def test_close_stealth_async_persistent_awaits_close():
 # ---------------------------------------------------------------------------
 
 
-def _install_fake_playwright(monkeypatch) -> tuple[MagicMock, MagicMock, MagicMock]:
+def _install_fake_playwright(monkeypatch) -> tuple[MagicMock, MagicMock, MagicMock, MagicMock, MagicMock, MagicMock]:
     """Inject minimal fake ``playwright.sync_api`` and ``playwright_stealth``.
 
     Returns ``(launch_mock, new_context_mock, stealth_cls)`` so the test
@@ -173,12 +173,21 @@ def _install_fake_playwright(monkeypatch) -> tuple[MagicMock, MagicMock, MagicMo
     # and braces: short-circuit it so the test never depends on import resolution.
     monkeypatch.setattr(browser, "_raise_if_unavailable", lambda: None)
 
-    return fake_chromium.launch, fake_browser.new_context, fake_stealth_cls
+    return (
+        fake_chromium.launch,
+        fake_browser.new_context,
+        fake_stealth_cls,
+        fake_pw,
+        fake_context,
+        fake_page,
+    )
 
 
 def test_launch_kwargs_defaults_applied(monkeypatch):
     """Default launch must pass the 3 anti-detection args + UA / viewport / locale."""
-    launch_mock, new_context_mock, stealth_cls = _install_fake_playwright(monkeypatch)
+    launch_mock, new_context_mock, stealth_cls, fake_pw, fake_context, fake_page = (
+        _install_fake_playwright(monkeypatch)
+    )
 
     pw, ctx, page = launch_stealth_sync()
 
@@ -204,6 +213,88 @@ def test_launch_kwargs_defaults_applied(monkeypatch):
     stealth_instance = stealth_cls.return_value
     stealth_instance.apply_stealth_sync.assert_called_once_with(ctx)
 
-    # 4) The 3-tuple shape is honoured and the page came from new_page()
-    assert (pw, ctx, page) == (pw, ctx, page)
-    assert page is not None
+    # 4) The 3-tuple shape is honoured and values are the fakes we injected
+    assert pw is fake_pw
+    assert ctx is fake_context
+    assert page is fake_page
+
+
+def test_close_stealth_ephemeral_still_stops_when_browser_close_raises():
+    """Ephemeral: ``browser.close()`` raises → ``playwright.stop()`` still fires."""
+    pw = MagicMock(name="playwright")
+    ctx = MagicMock(name="context")
+    ctx.browser = MagicMock(name="browser")
+    ctx.browser.close.side_effect = RuntimeError("chromium crashed")
+
+    with pytest.raises(RuntimeError, match="chromium crashed"):
+        close_stealth(pw, ctx)
+
+    pw.stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 7. Async launch path (mirrors sync defaults test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_launch_stealth_async_defaults_applied(monkeypatch):
+    """Async launcher must await apply_stealth_async and use the same defaults."""
+    from roxabi_sdk.browser import launch_stealth_async
+
+    fake_page = MagicMock(name="page")
+    fake_context = MagicMock(name="context")
+    fake_context.pages = []
+    fake_context.new_page = AsyncMock(return_value=fake_page)
+
+    fake_browser = MagicMock(name="browser")
+    fake_browser.new_context = AsyncMock(return_value=fake_context)
+
+    fake_chromium = MagicMock(name="chromium")
+    fake_chromium.launch = AsyncMock(return_value=fake_browser)
+
+    fake_pw = MagicMock(name="playwright")
+    fake_pw.chromium = fake_chromium
+
+    fake_factory = MagicMock(name="async_playwright_factory")
+    fake_factory.start = AsyncMock(return_value=fake_pw)
+
+    fake_async_playwright = MagicMock(name="async_playwright", return_value=fake_factory)
+
+    async_api_mod = types.ModuleType("playwright.async_api")
+    async_api_mod.async_playwright = fake_async_playwright
+
+    fake_stealth_cls = MagicMock(name="StealthClass")
+    fake_stealth_instance = MagicMock(name="StealthInstance")
+    fake_stealth_instance.apply_stealth_async = AsyncMock()
+    fake_stealth_cls.return_value = fake_stealth_instance
+
+    stealth_mod = types.ModuleType("playwright_stealth")
+    stealth_mod.Stealth = fake_stealth_cls
+
+    pw_root = types.ModuleType("playwright")
+    pw_root.async_api = async_api_mod
+
+    monkeypatch.setitem(sys.modules, "playwright", pw_root)
+    monkeypatch.setitem(sys.modules, "playwright.async_api", async_api_mod)
+    monkeypatch.setitem(sys.modules, "playwright_stealth", stealth_mod)
+    monkeypatch.setattr(browser, "_raise_if_unavailable", lambda: None)
+
+    pw, ctx, page = await launch_stealth_async()
+
+    # apply_stealth_async must be awaited (not just called)
+    fake_stealth_instance.apply_stealth_async.assert_awaited_once_with(fake_context)
+
+    # Same default launch args as sync
+    fake_chromium.launch.assert_awaited_once()
+    _, launch_kwargs = fake_chromium.launch.await_args
+    assert launch_kwargs["args"] == [
+        "--disable-blink-features=AutomationControlled",
+        "--no-first-run",
+        "--no-default-browser-check",
+    ]
+
+    # 3-tuple shape honoured
+    assert pw is fake_pw
+    assert ctx is fake_context
+    assert page is fake_page

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,0 +1,209 @@
+"""Tests for roxabi_sdk.browser — mock-based, no live Playwright.
+
+These tests verify the SDK launcher contract from issue #93 without
+requiring playwright or playwright-stealth to be installed at test time.
+The lazy imports inside ``launch_stealth_*`` are intercepted by injecting
+fake modules into ``sys.modules`` before the call.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from roxabi_sdk import browser
+from roxabi_sdk.browser import (
+    PlaywrightNotAvailableError,
+    close_stealth,
+    close_stealth_async,
+    launch_stealth_sync,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Missing-playwright path
+# ---------------------------------------------------------------------------
+
+
+def test_missing_playwright_raises_typed_error(monkeypatch):
+    """When the import probe trips, the typed error must surface verbatim."""
+
+    def boom() -> None:
+        raise PlaywrightNotAvailableError(browser._INSTALL_HINT)
+
+    monkeypatch.setattr(browser, "_raise_if_unavailable", boom)
+
+    with pytest.raises(PlaywrightNotAvailableError) as excinfo:
+        launch_stealth_sync()
+
+    msg = str(excinfo.value).lower()
+    assert "playwright" in msg
+    assert "uv sync" in msg or "pip install" in msg
+
+
+# ---------------------------------------------------------------------------
+# 2-3. Sync close paths
+# ---------------------------------------------------------------------------
+
+
+def test_close_stealth_ephemeral_closes_browser():
+    """Ephemeral: ``context.browser`` is truthy → close the browser."""
+    pw = MagicMock(name="playwright")
+    ctx = MagicMock(name="context")
+    ctx.browser = MagicMock(name="browser")  # truthy → ephemeral
+
+    close_stealth(pw, ctx)
+
+    ctx.browser.close.assert_called_once()
+    ctx.close.assert_not_called()
+    pw.stop.assert_called_once()
+
+
+def test_close_stealth_persistent_closes_context():
+    """Persistent: ``context.browser`` is ``None`` → close the context."""
+    pw = MagicMock(name="playwright")
+    ctx = MagicMock(name="context")
+    ctx.browser = None  # persistent
+
+    close_stealth(pw, ctx)
+
+    ctx.close.assert_called_once()
+    pw.stop.assert_called_once()
+
+
+def test_close_stealth_persistent_still_stops_when_close_raises():
+    """``finally`` must run ``playwright.stop()`` even if close raises."""
+    pw = MagicMock(name="playwright")
+    ctx = MagicMock(name="context")
+    ctx.browser = None
+    ctx.close.side_effect = RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        close_stealth(pw, ctx)
+
+    pw.stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 4-5. Async close paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_stealth_async_ephemeral_awaits_close():
+    pw = MagicMock(name="playwright")
+    pw.stop = AsyncMock()
+    ctx = MagicMock(name="context")
+    ctx.browser = MagicMock(name="browser")
+    ctx.browser.close = AsyncMock()
+    ctx.close = AsyncMock()
+
+    await close_stealth_async(pw, ctx)
+
+    ctx.browser.close.assert_awaited_once()
+    ctx.close.assert_not_awaited()
+    pw.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_stealth_async_persistent_awaits_close():
+    pw = MagicMock(name="playwright")
+    pw.stop = AsyncMock()
+    ctx = MagicMock(name="context")
+    ctx.browser = None
+    ctx.close = AsyncMock()
+
+    await close_stealth_async(pw, ctx)
+
+    ctx.close.assert_awaited_once()
+    pw.stop.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 6. Default launch kwargs
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_playwright(monkeypatch) -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Inject minimal fake ``playwright.sync_api`` and ``playwright_stealth``.
+
+    Returns ``(launch_mock, new_context_mock, stealth_cls)`` so the test
+    can inspect what the launcher passed downstream.
+    """
+    fake_page = MagicMock(name="page")
+    fake_context = MagicMock(name="context")
+    fake_context.pages = []
+    fake_context.new_page.return_value = fake_page
+
+    fake_browser = MagicMock(name="browser")
+    fake_browser.new_context = MagicMock(return_value=fake_context)
+
+    fake_chromium = MagicMock(name="chromium")
+    fake_chromium.launch = MagicMock(return_value=fake_browser)
+
+    fake_pw = MagicMock(name="playwright")
+    fake_pw.chromium = fake_chromium
+
+    fake_factory = MagicMock(name="sync_playwright_factory")
+    fake_factory.start.return_value = fake_pw
+
+    fake_sync_playwright = MagicMock(name="sync_playwright", return_value=fake_factory)
+
+    sync_api_mod = types.ModuleType("playwright.sync_api")
+    sync_api_mod.sync_playwright = fake_sync_playwright
+
+    pw_root = types.ModuleType("playwright")
+    pw_root.sync_api = sync_api_mod
+
+    fake_stealth_cls = MagicMock(name="StealthClass")
+    fake_stealth_instance = MagicMock(name="StealthInstance")
+    fake_stealth_cls.return_value = fake_stealth_instance
+
+    stealth_mod = types.ModuleType("playwright_stealth")
+    stealth_mod.Stealth = fake_stealth_cls
+
+    monkeypatch.setitem(sys.modules, "playwright", pw_root)
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", sync_api_mod)
+    monkeypatch.setitem(sys.modules, "playwright_stealth", stealth_mod)
+
+    # _raise_if_unavailable performs its own real imports of playwright /
+    # playwright_stealth — those will succeed against the fakes above. Belt
+    # and braces: short-circuit it so the test never depends on import resolution.
+    monkeypatch.setattr(browser, "_raise_if_unavailable", lambda: None)
+
+    return fake_chromium.launch, fake_browser.new_context, fake_stealth_cls
+
+
+def test_launch_kwargs_defaults_applied(monkeypatch):
+    """Default launch must pass the 3 anti-detection args + UA / viewport / locale."""
+    launch_mock, new_context_mock, stealth_cls = _install_fake_playwright(monkeypatch)
+
+    pw, ctx, page = launch_stealth_sync()
+
+    # 1) chromium.launch was called with default headless + the 3 anti-detection args
+    launch_mock.assert_called_once()
+    _, launch_kwargs = launch_mock.call_args
+    assert launch_kwargs["headless"] is True
+    assert launch_kwargs["args"] == [
+        "--disable-blink-features=AutomationControlled",
+        "--no-first-run",
+        "--no-default-browser-check",
+    ]
+
+    # 2) new_context received the default UA, viewport and locale
+    new_context_mock.assert_called_once()
+    _, ctx_kwargs = new_context_mock.call_args
+    assert ctx_kwargs["user_agent"] == browser._DEFAULT_UA
+    assert ctx_kwargs["viewport"] == browser._DEFAULT_VIEWPORT
+    assert ctx_kwargs["locale"] == "en-US"
+
+    # 3) Stealth was instantiated with the 5 default flags and applied to the context
+    stealth_cls.assert_called_once_with(**browser._DEFAULT_STEALTH_FLAGS)
+    stealth_instance = stealth_cls.return_value
+    stealth_instance.apply_stealth_sync.assert_called_once_with(ctx)
+
+    # 4) The 3-tuple shape is honoured and the page came from new_page()
+    assert (pw, ctx, page) == (pw, ctx, page)
+    assert page is not None


### PR DESCRIPTION
## Summary
- **New shared module** `roxabi_sdk/browser.py` deduplicates the playwright + playwright-stealth bootstrap that previously lived in three call sites (web-intel × 2 sync, linkedin-apply × 1 async). Exports `launch_stealth_{sync,async}`, `close_stealth{,_async}`, and the typed `PlaywrightNotAvailableError(RuntimeError)`.
- **Three latent bugs fixed** in the same diff (see V0 probe below): linkedin-apply's never-worked `use_async(...).start()` AttributeError path, and web-intel's silently-no-op `use_sync(page)` stealth in both `stealth.py` and `screenshot.py`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #93: Extract browser bootstrap (playwright + stealth) to roxabi_sdk/browser.py | OPEN |
| Frame | [93-extract-browser-bootstrap-frame.mdx](artifacts/frames/93-extract-browser-bootstrap-frame.mdx) | Approved (F-full) |
| Analysis | [93-extract-browser-bootstrap-analysis.mdx](artifacts/analyses/93-extract-browser-bootstrap-analysis.mdx) | Present |
| Spec | [93-extract-browser-bootstrap-spec.mdx](artifacts/specs/93-extract-browser-bootstrap-spec.mdx) | Approved |
| Plan | [93-extract-browser-bootstrap-plan.mdx](artifacts/plans/93-extract-browser-bootstrap-plan.mdx) | Approved (26 micro-tasks) |
| Implementation | 3 commits on `feat/93-extract-browser-bootstrap` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ⚠️ (see notes) | See "Test Plan" |

## Behavior-equivalence probe

_V0 probe — Settled Decision #4 validation (SC-19)_

Before any code was written, a behavior-equivalence probe ran against `playwright-stealth==2.0.2` to confirm that `Stealth().apply_stealth_sync(context)` (the spec's chosen idiom) actually patches the navigator surface. Output:

```
======================================================================
Revised V0 probe — #93 browser-bootstrap extraction
======================================================================

[GATE] apply_stealth_sync(context) — spec idiom (Settled Decision #4):
   navigator.webdriver            = False
   navigator.plugins.length       = 3
   navigator.languages            = ['en-US', 'en']
   typeof window.chrome           = 'object'

[INFO] use_sync(page) post-creation — current web-intel pattern:
   navigator.webdriver            = True
   navigator.plugins.length       = 0
   navigator.languages            = ['en-US']
   typeof window.chrome           = 'undefined'
   → NOT patched (placebo). Failures: 4

======================================================================
PASS — apply_stealth_sync(context) produces stealth-patched surface.
Settled Decision #4 is validated. T0.1 is GREEN.
======================================================================
```

The `[INFO]` block is the crucial side-finding: `Stealth().use_sync(page)` called **after** `context.new_page()` is a **no-op** in `playwright-stealth==2.0.2`. That is exactly the pattern web-intel was using on lines 168 (stealth.py) and 107 (screenshot.py). So the existing web-intel anti-bot fallback has been running effectively unpatched. Both call sites are now actually stealth-patched via the SDK launcher, which calls `apply_stealth_sync(context)` **before** `new_page()`.

## Latent bugs fixed

1. **`linkedin-apply/scripts/scraper.py:306`** — `await stealth.use_async(async_playwright()).start()` raises `AttributeError: 'AsyncWrappingContextManager' object has no attribute 'start'` in `playwright-stealth==2.0.2`. This code path has **never worked** since the v2 upgrade. Now uses `launch_stealth_async(user_data_dir=…)`.
2. **`web-intel/scripts/fetchers/stealth.py:168`** — `_Stealth().use_sync(page)` after `context.new_page()` is a no-op (probe-verified). Now applied to context before page creation.
3. **`web-intel/scripts/screenshot.py:107`** — same pattern, same fix.

## Architecture (target → ref)

```
roxabi_sdk/browser.py
  ├─ launch_stealth_sync(user_data_dir, headless, ua, viewport, locale, stealth_flags, launch_args)  → (pw, ctx, page)
  ├─ launch_stealth_async(...)                                                                       → (pw, ctx, page)
  ├─ close_stealth(pw, ctx)         — picks browser.close vs context.close based on shape
  ├─ close_stealth_async(pw, ctx)
  ├─ PlaywrightNotAvailableError(RuntimeError)
  └─ _raise_if_unavailable()        — eager probe used by both launchers

plugins/web-intel/scripts/fetchers/stealth.py     → launch_stealth_sync + close_stealth
plugins/web-intel/scripts/screenshot.py            → launch_stealth_sync + close_stealth
plugins/linkedin-apply/scripts/scraper.py          → launch_stealth_async + alias class
```

Both web-intel files keep their `PLAYWRIGHT_AVAILABLE` / `PLAYWRIGHT_STEALTH_AVAILABLE` module flags **independent** of the SDK probe so the existing `tests/test_stealth.py:104` monkey-patch keeps working unchanged (SC-5).

The linkedin-apply alias is multiple-inheritance:

```python
class PlaywrightNotAvailableError(LinkedInScraperError, _SdkPlaywrightNotAvailableError):
    ...
```

Left-first MRO → `__init__` resolves to `LinkedInScraperError(message, url=None)`, so `self.url` will be `None` for SDK-raised instances. Documented in the class docstring.

## Test Plan

- [x] `roxabi_sdk/browser.py` — 7 mock-based tests in `tests/test_browser.py` (no live Playwright). Covers missing-dep typed error, ephemeral vs persistent close in sync + async, finally-clause invariant, default launch kwargs.
- [x] `plugins/web-intel/tests/test_stealth.py` — 23 passed, file untouched (T2.3 SC-5).
- [x] `plugins/web-intel/tests/test_screenshot.py` — 6 passed.
- [x] **CLI smoke**: `python scripts/screenshot.py https://example.com /tmp/shot_93.png` → 20 KB PNG written.
- [x] `plugins/linkedin-apply/tests/test_alias.py` — 3 new tests: catchable as `LinkedInScraperError`, catchable as SDK error, `self.url is None`. RED before T4.2, all green after.
- [x] **Grep assertion**: `grep -c 'use_async\|.start()' plugins/linkedin-apply/scripts/scraper.py` → `0` (SC-11).
- [x] **Non-bootstrap grep counts unchanged** (SC-14): web-intel/stealth.py 8↔8, linkedin-apply/scraper.py 21↔21.
- [x] **Import guard** (SC-17): `from roxabi_sdk.browser import PlaywrightNotAvailableError` works in a venv with playwright + playwright_stealth blocked from `sys.meta_path`. Typed error raises with install hint.
- [x] **Packaging** (SC-18): `rsync -avn roxabi_sdk/ ~/.claude/.../web-intel/0.1.0/roxabi_sdk/` shows `browser.py` would land via the existing line 71-72 of `sync-plugins.sh` (no script changes — SC-16: `git diff staging -- sync-plugins.sh` → 0).
- [ ] **LinkedIn manual smoke (T4.5)** — `cd plugins/linkedin-apply && python scripts/scraper.py <real-job-url>` against an authenticated profile. Confirm JSON has non-null `job_id`/`title`/`company`. Paste full JSON below before merging.

### LinkedIn smoke

> ⏸ Pending — needs human attestation. See checklist item above.

## Notes for the reviewer

- **bun test on this branch: 329 pass / 9 fail / 2 errors.** All failures are in `plugins/dev-core` TS suites (`issues` GraphQL batching, `scaffoldFumadocs`, `config`). Branch diff is **Python-only** — zero TS files touched. Failures exist on `staging` baseline, not introduced by this PR. Verified with `git diff staging --stat` (6 files, all `.py`).
- **CI runs `python3 -m pytest tests/`** at the repo root. `tests/test_browser.py` is included and green. `plugins/web-intel/tests/` and `plugins/linkedin-apply/tests/` are NOT run by CI today — they were verified locally only (gap noted, not in scope for #93).
- **Plan drift**: the `## Task IDs` section in `artifacts/plans/93-...` was reattached this session (commit `95f73dd` on staging) because the previous task ids had been reclaimed by the fresh `/dev` pipeline. The actual implementation is unchanged.
- **Plan T1.4 snippet had a missing `await`** on `apply_stealth_async(ctx)` — the function is a coroutine in 2.0.2 (`inspect.iscoroutinefunction == True`). Fixed in the actual code; plan doc nit only.

Closes #93

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
