### PR TITLE
feat(forge): add semantic shape primitives and arrow modifiers to fgraph-base.css

### DIFF
--- a/plugins/forge/references/graph-templates/README.md
+++ b/plugins/forge/references/graph-templates/README.md
@@ -241,7 +241,15 @@ Distribution model depends on the consumer (see "Inlined vs shared" below).
 | `.fgraph-node` | Absolute-positioned HTML card via `--x` / `--y` / `--w` custom props (all in %) |
 | `.fgraph-node.{tone}` | Node border + tint (amber/cyan/purple/green/red) |
 | `.fgraph-node.wide` / `.narrow` | Width modifier (30% / 18%, default 22%) |
-| `.fgraph-node.pill` | Pill-shaped border-radius 999px — use for the central hub |
+| `.fgraph-node.pill` | Pill-shaped — use for the central hub / bus / broker |
+| `.fgraph-node.circle` | Circle — event, trigger, start/end (`border-radius: 50%; aspect-ratio: 1`) |
+| `.fgraph-node.hexagon` | Hexagon — agent, worker, autonomous unit (`clip-path` polygon) |
+| `.fgraph-node.diamond` | Diamond — decision, gate, conditional (`clip-path` polygon) |
+| `.fgraph-node.cylinder` | Cylinder — database, storage, queue (ellipse caps via `::before`/`::after`) |
+| `.fgraph-node.folded` | Folded corner — file, config, document (`clip-path` with corner notch) |
+| `.fg-edge.dashed` | Dashed stroke — optional / async / planned path |
+| `.fg-edge.thick` | Thick stroke (2.8px) — primary data flow / critical path |
+| `.fg-edge.animated` | Animated dashes — live stream / active connection |
 | `.fgraph-title.{tone}` | Colored node title with flex for inline pills |
 | `.fgraph-pill.{tone}` | Inline badge (priority, port, status) |
 | `.fgraph-sub` / `.muted` / `.warn` / `.ok` | Node subtitles (default / muted / red / green) |
@@ -261,6 +269,32 @@ The SVG layer uses `viewBox="0 0 100 100" preserveAspectRatio="none"` so 1
 viewBox unit = 1% of container (width or height). Strokes stay crisp via
 `vector-effect: non-scaling-stroke`. Markers may render slightly stretched on
 non-square containers — use `.fgraph-wrap.square` for pixel-perfect arrowheads.
+
+### Shape vocabulary
+
+Shapes are semantic — pick by **what the node is**, not how you want it to look.
+Full reference: [`../shape-vocabulary.md`](../shape-vocabulary.md).
+
+| Shape | Class | Use when node is... |
+|-------|-------|---------------------|
+| Rounded rect | *(default)* | A service, process, or generic component |
+| Pill | `.pill` | A bus, broker, router, or relay |
+| Circle | `.circle` | An event, trigger, signal, or lifecycle point |
+| Hexagon | `.hexagon` | An agent, worker, or autonomous unit |
+| Diamond | `.diamond` | A decision, gate, or conditional branch |
+| Cylinder | `.cylinder` | A database, cache, queue, or data store |
+| Folded | `.folded` | A file, config, document, or static asset |
+
+Arrow modifiers compose with tones on `.fg-edge`:
+
+| Modifier | Class | Use when path is... |
+|----------|-------|---------------------|
+| Dashed | `.dashed` | Optional, async, planned, or fallback |
+| Thick | `.thick` | Critical path or primary data flow |
+| Animated | `.animated` | Live stream or real-time connection |
+
+Shapes compose with tones and sizes: `<div class="fgraph-node hexagon amber wide">`.
+Arrow modifiers stack: `<path class="fg-edge cyan thick animated">`.
 
 ---
 

--- a/plugins/forge/references/graph-templates/fgraph-base.css
+++ b/plugins/forge/references/graph-templates/fgraph-base.css
@@ -5,6 +5,20 @@
    with an SVG overlay layer for arrows. Inline into the output
    <style> block (forge directive: inline, never link).
 
+   Shape modifiers (semantic node shapes):
+     .pill      — bus, broker, router (border-radius 999px)
+     .circle    — event, trigger, start/end (border-radius 50%)
+     .hexagon   — agent, worker, autonomous (clip-path polygon)
+     .diamond   — decision, gate, conditional (clip-path polygon)
+     .cylinder  — database, storage, queue (ellipse caps)
+     .folded    — file, config, document (clip-path corner notch)
+   See references/shape-vocabulary.md for semantic mapping.
+
+   Arrow modifiers (compose with tone classes on .fg-edge):
+     .dashed    — optional / async / planned
+     .thick     — primary data flow / critical path
+     .animated  — live stream / active connection
+
    Authoring API:
 
      <div class="fgraph-wrap green">
@@ -136,6 +150,12 @@
 .fgraph-edges .fg-edge.red    { stroke: var(--red); }
 .fgraph-edges .fg-edge.dim    { stroke: var(--text-muted); opacity: 0.5; }
 
+/* arrow modifiers — compose with tone classes */
+.fgraph-edges .fg-edge.dashed   { stroke-dasharray: 4 3; }
+.fgraph-edges .fg-edge.thick    { stroke-width: 2.8; }
+.fgraph-edges .fg-edge.animated { stroke-dasharray: 8 4; animation: fg-dash 1s linear infinite; }
+@keyframes fg-dash { to { stroke-dashoffset: -12; } }
+
 /* arrowhead marker fill classes — apply to <path> inside <marker> */
 .fgraph-edges .mk-amber  { fill: var(--amber); }
 .fgraph-edges .mk-cyan   { fill: var(--cyan); }
@@ -164,9 +184,11 @@
   z-index: 3;
 }
 
-/* shape modifiers */
+/* size modifiers */
 .fgraph-node.wide   { --w: 30%; }
 .fgraph-node.narrow { --w: 18%; }
+
+/* ── shape: pill (bus, broker, router) ── */
 .fgraph-node.pill {
   border-radius: 999px;
   border-width: 2px;
@@ -174,7 +196,121 @@
   text-align: center;
   padding: 10px 12px;
 }
-.fgraph-node.pill .fgraph-title { justify-content: center; }
+
+/* ── shape: circle (event, trigger, start/end) ── */
+.fgraph-node.circle {
+  border-radius: 50%;
+  aspect-ratio: 1;
+  --w: 14%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 10px;
+}
+
+/* ── clip-path shape foundation ──
+   clip-path clips borders, so hexagon/diamond/folded use
+   ::before (fill) + ::after (border outline) pseudo-elements.
+   The node itself has no background — visual shape comes from pseudos. */
+.fgraph-node.hexagon,
+.fgraph-node.diamond,
+.fgraph-node.folded {
+  border: none;
+  background: none;
+  border-radius: 0;
+}
+.fgraph-node.hexagon::before,
+.fgraph-node.hexagon::after,
+.fgraph-node.diamond::before,
+.fgraph-node.diamond::after,
+.fgraph-node.folded::before,
+.fgraph-node.folded::after {
+  content: '';
+  position: absolute;
+  transition: inset 0.15s;
+}
+/* fill layer */
+.fgraph-node.hexagon::before,
+.fgraph-node.diamond::before,
+.fgraph-node.folded::before {
+  inset: 0;
+  background: var(--bg-card);
+  z-index: -1;
+}
+/* border layer (slightly larger, behind fill) */
+.fgraph-node.hexagon::after,
+.fgraph-node.diamond::after,
+.fgraph-node.folded::after {
+  inset: -2px;
+  background: var(--border-bright);
+  z-index: -2;
+}
+
+/* ── shape: hexagon (agent, worker, autonomous unit) ── */
+.fgraph-node.hexagon {
+  text-align: center;
+  padding: 14px 22px;
+}
+.fgraph-node.hexagon::before,
+.fgraph-node.hexagon::after {
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+}
+
+/* ── shape: diamond (decision, gate, conditional) ── */
+.fgraph-node.diamond {
+  --w: 18%;
+  text-align: center;
+  padding: 20px 16px;
+}
+.fgraph-node.diamond::before,
+.fgraph-node.diamond::after {
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}
+
+/* ── shape: folded (file, config, document) ── */
+.fgraph-node.folded {
+  text-align: center;
+  padding: 10px 10px 9px;
+}
+.fgraph-node.folded::before,
+.fgraph-node.folded::after {
+  clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 0 100%);
+}
+
+/* ── shape: cylinder (database, storage, queue) ──
+   Uses border-left/right for the body + ::before/::after for ellipse caps. */
+.fgraph-node.cylinder {
+  border: none;
+  border-left: 1.5px solid var(--border-bright);
+  border-right: 1.5px solid var(--border-bright);
+  border-radius: 0;
+  background: var(--bg-card);
+  text-align: center;
+  padding: 14px 10px 10px;
+}
+.fgraph-node.cylinder::before,
+.fgraph-node.cylinder::after {
+  content: '';
+  position: absolute;
+  left: -2px;
+  right: -2px;
+  height: 22%;
+  border-radius: 50%;
+  background: inherit;
+  border: 1.5px solid var(--border-bright);
+}
+.fgraph-node.cylinder::before { top: -11%; z-index: 1; }
+.fgraph-node.cylinder::after  { bottom: -11%; z-index: -1; }
+
+/* centered titles for all semantic shapes */
+.fgraph-node.pill .fgraph-title,
+.fgraph-node.circle .fgraph-title,
+.fgraph-node.hexagon .fgraph-title,
+.fgraph-node.diamond .fgraph-title,
+.fgraph-node.folded .fgraph-title,
+.fgraph-node.cylinder .fgraph-title { justify-content: center; }
 
 /* tone modifiers (border color + translucent background tint) */
 .fgraph-node.amber  { border-color: var(--amber);  background: var(--amber-dim); }
@@ -189,6 +325,47 @@
 .fgraph-node.pill.purple,
 .fgraph-node.pill.green,
 .fgraph-node.pill.red { background: var(--bg-panel); }
+
+/* clip-path tone overrides — ::after is the border layer */
+.fgraph-node.hexagon.amber::after,  .fgraph-node.diamond.amber::after,  .fgraph-node.folded.amber::after  { background: var(--amber); }
+.fgraph-node.hexagon.cyan::after,   .fgraph-node.diamond.cyan::after,   .fgraph-node.folded.cyan::after   { background: var(--cyan); }
+.fgraph-node.hexagon.purple::after, .fgraph-node.diamond.purple::after, .fgraph-node.folded.purple::after { background: var(--purple); }
+.fgraph-node.hexagon.green::after,  .fgraph-node.diamond.green::after,  .fgraph-node.folded.green::after  { background: var(--green); }
+.fgraph-node.hexagon.red::after,    .fgraph-node.diamond.red::after,    .fgraph-node.folded.red::after    { background: var(--red); }
+
+/* clip-path tone overrides — ::before is the fill layer */
+.fgraph-node.hexagon.amber::before,  .fgraph-node.diamond.amber::before,  .fgraph-node.folded.amber::before  { background: var(--amber-dim); }
+.fgraph-node.hexagon.cyan::before,   .fgraph-node.diamond.cyan::before,   .fgraph-node.folded.cyan::before   { background: var(--cyan-dim); }
+.fgraph-node.hexagon.purple::before, .fgraph-node.diamond.purple::before, .fgraph-node.folded.purple::before { background: var(--purple-dim); }
+.fgraph-node.hexagon.green::before,  .fgraph-node.diamond.green::before,  .fgraph-node.folded.green::before  { background: var(--green-dim); }
+.fgraph-node.hexagon.red::before,    .fgraph-node.diamond.red::before,    .fgraph-node.folded.red::before    { background: var(--red-dim); }
+
+/* clip-path hover: enlarge border + glow via filter (box-shadow is clipped) */
+.fgraph-node.hexagon:hover::after,
+.fgraph-node.diamond:hover::after,
+.fgraph-node.folded:hover::after { inset: -3px; }
+.fgraph-node.hexagon:hover,
+.fgraph-node.diamond:hover,
+.fgraph-node.folded:hover {
+  box-shadow: none;
+  filter: drop-shadow(0 0 10px var(--accent-glow));
+}
+
+/* cylinder tone overrides */
+.fgraph-node.cylinder.amber  { border-color: var(--amber);  background: var(--amber-dim); }
+.fgraph-node.cylinder.cyan   { border-color: var(--cyan);   background: var(--cyan-dim); }
+.fgraph-node.cylinder.purple { border-color: var(--purple); background: var(--purple-dim); }
+.fgraph-node.cylinder.green  { border-color: var(--green);  background: var(--green-dim); }
+.fgraph-node.cylinder.red    { border-color: var(--red);    background: var(--red-dim); }
+.fgraph-node.cylinder.amber::before,  .fgraph-node.cylinder.amber::after  { border-color: var(--amber);  background: var(--amber-dim); }
+.fgraph-node.cylinder.cyan::before,   .fgraph-node.cylinder.cyan::after   { border-color: var(--cyan);   background: var(--cyan-dim); }
+.fgraph-node.cylinder.purple::before, .fgraph-node.cylinder.purple::after { border-color: var(--purple); background: var(--purple-dim); }
+.fgraph-node.cylinder.green::before,  .fgraph-node.cylinder.green::after  { border-color: var(--green);  background: var(--green-dim); }
+.fgraph-node.cylinder.red::before,    .fgraph-node.cylinder.red::after    { border-color: var(--red);    background: var(--red-dim); }
+/* cylinder hover */
+.fgraph-node.cylinder:hover { border-width: 2px; }
+.fgraph-node.cylinder:hover::before,
+.fgraph-node.cylinder:hover::after { border-width: 2px; }
 
 /* ── title, subtitle ── */
 .fgraph-title {

--- a/plugins/forge/references/graph-templates/fgraph-base.css
+++ b/plugins/forge/references/graph-templates/fgraph-base.css
@@ -326,6 +326,14 @@
 .fgraph-node.pill.green,
 .fgraph-node.pill.red { background: var(--bg-panel); }
 
+/* clip-path + tone: keep transparent so pseudo-elements define the shape */
+.fgraph-node.hexagon.amber, .fgraph-node.hexagon.cyan, .fgraph-node.hexagon.purple, .fgraph-node.hexagon.green, .fgraph-node.hexagon.red,
+.fgraph-node.diamond.amber, .fgraph-node.diamond.cyan, .fgraph-node.diamond.purple, .fgraph-node.diamond.green, .fgraph-node.diamond.red,
+.fgraph-node.folded.amber,  .fgraph-node.folded.cyan,  .fgraph-node.folded.purple,  .fgraph-node.folded.green,  .fgraph-node.folded.red {
+  background: none;
+  border: none;
+}
+
 /* clip-path tone overrides — ::after is the border layer */
 .fgraph-node.hexagon.amber::after,  .fgraph-node.diamond.amber::after,  .fgraph-node.folded.amber::after  { background: var(--amber); }
 .fgraph-node.hexagon.cyan::after,   .fgraph-node.diamond.cyan::after,   .fgraph-node.folded.cyan::after   { background: var(--cyan); }

--- a/plugins/forge/references/shape-vocabulary.md
+++ b/plugins/forge/references/shape-vocabulary.md
@@ -1,0 +1,50 @@
+# Shape Vocabulary
+
+Semantic shapes for fgraph nodes. Claude reads this before generating
+diagrams to pick the right shape modifier for each node.
+
+## Node shapes
+
+All shapes compose with tones (`amber`, `cyan`, `purple`, `green`, `red`),
+sizes (`wide`, `narrow`), and content (`.fgraph-title`, `.fgraph-sub`, `.fgraph-pill`).
+
+| Shape | Class | Semantic meaning | When to use | CSS technique |
+|-------|-------|-----------------|-------------|---------------|
+| Rounded rect | *(default)* | Service, process, generic component | Default for any node without a specific role | `border-radius: 12px` |
+| Pill | `.pill` | Bus, broker, router, message queue | Central hub in radial diagrams, message-passing infrastructure | `border-radius: 999px` |
+| Circle | `.circle` | Event, trigger, signal, start/end | Lifecycle points, webhooks, cron triggers, state machine start/end | `border-radius: 50%; aspect-ratio: 1` |
+| Hexagon | `.hexagon` | Agent, worker, autonomous unit | AI agents, background workers, autonomous processes | `clip-path` polygon (6 sides) |
+| Diamond | `.diamond` | Decision, gate, conditional, branch | Routing logic, feature flags, conditional paths, approval gates | `clip-path` polygon (4 sides rotated) |
+| Cylinder | `.cylinder` | Database, storage, queue, cache | PostgreSQL, Redis, S3, any persistent data store | `border + ::before/::after` ellipse caps |
+| Folded | `.folded` | File, config, document, static asset | Config files, templates, manifests, documentation | `clip-path` with corner notch |
+
+## Arrow modifiers
+
+Compose with tone classes on `.fg-edge` paths.
+
+| Modifier | Class | Visual | When to use |
+|----------|-------|--------|-------------|
+| *(default)* | — | Solid 1.6px | Standard connection |
+| Dashed | `.dashed` | `- - -` | Optional path, async, fallback, future/planned |
+| Thick | `.thick` | Solid 2.8px | Primary data flow, critical path, hot path |
+| Animated | `.animated` | Moving dashes | Live stream, active connection, real-time data |
+
+Modifiers stack: `<path class="fg-edge amber thick animated" ...>`.
+
+## Shape selection guide
+
+When generating an fgraph diagram, pick shapes by asking:
+
+1. **What does this node store?** → `.cylinder` (database) or `.folded` (file/config)
+2. **Does this node decide or route?** → `.diamond`
+3. **Does this node act autonomously?** → `.hexagon` (agent, worker)
+4. **Is this node an event or signal?** → `.circle`
+5. **Does this node relay or broker?** → `.pill`
+6. **None of the above?** → default rounded rect
+
+When generating arrows:
+
+1. **Is this path always active in production?** → `.thick` if it's the critical path
+2. **Is this path optional or async?** → `.dashed`
+3. **Is this path a live stream?** → `.animated`
+4. **Standard connection?** → no modifier

--- a/plugins/forge/skills/forge-chart/SKILL.md
+++ b/plugins/forge/skills/forge-chart/SKILL.md
@@ -81,6 +81,10 @@ Content-driven in both tracks. Brand `structure_defaults` (if present) act as **
 
 **Decision rule:** > 8 nodes or linear → Mermaid. ≤ 6 radial with rich cards → fgraph. Tabular → HTML table. Stacked text → Grid.
 
+**Node shapes (fgraph):** When using fgraph, pick the right shape modifier for each node. Read [`${CLAUDE_PLUGIN_ROOT}/references/shape-vocabulary.md`](${CLAUDE_PLUGIN_ROOT}/references/shape-vocabulary.md) for the full semantic mapping. Quick reference: `.cylinder` = database, `.hexagon` = agent/worker, `.diamond` = decision/gate, `.circle` = event/trigger, `.folded` = file/config, `.pill` = bus/broker, default rect = service/process.
+
+**Arrow modifiers (fgraph):** `.dashed` = optional/async, `.thick` = critical path, `.animated` = live stream. Compose with tones: `<path class="fg-edge amber thick">`.
+
 **Ask:** How many nodes? Any cycles? If you sketch the content twice — once radial, once linear — which reads faster on a 1200px screen? Content that takes two sketches to understand is a signal to split the diagram, not to cram both into one.
 
 ### Style — Which components?
@@ -106,7 +110,7 @@ All classes below exist in `base/components.css` + `base/explainer-base.css`.
 | Rendering | Wrapper / component |
 |---|---|
 | Mermaid (flowchart / sequence / state / class) | `.diagram-shell` with `.zoom-controls` (never bare `<pre class="mermaid">`) |
-| fgraph radial | `.fgraph-wrap` + `.fgraph-frame` + `.fgraph-edges` + `.fgraph-node.{tone}` (see `graph-templates/`) |
+| fgraph radial | `.fgraph-wrap` + `.fgraph-frame` + `.fgraph-edges` + `.fgraph-node.{shape}.{tone}` (shapes: `.cylinder`/`.hexagon`/`.diamond`/`.circle`/`.folded`/`.pill` — see `shape-vocabulary.md`) |
 | HTML table | `.table-wrap > table` with `<thead>` (enables sticky header + horizontal scroll) |
 | CSS Grid cards | `.cards` container + `.card`/`.card.accent` per row |
 | Timeline | `.steps` container + `.step > .step-num` per entry |


### PR DESCRIPTION
## Summary
- Add 5 semantic shape modifiers (`.circle`, `.hexagon`, `.diamond`, `.cylinder`, `.folded`) and 3 arrow modifiers (`.dashed`, `.thick`, `.animated`) as CSS primitives in `fgraph-base.css`
- Shapes compose with existing tones, content elements, and coordinate system — every fgraph template benefits with zero migration
- New `shape-vocabulary.md` reference doc for Claude to select the right shape during generation

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #95: feat(forge): add semantic shape primitives and arrow modifiers | Open |
| Spec | [95-fgraph-shape-primitives-spec.mdx](artifacts/specs/95-fgraph-shape-primitives-spec.mdx) | Approved |
| Implementation | 1 commit on `feat/95-fgraph-shape-primitives` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (349 passed) | Passed |

## Test Plan
- [ ] Open any fgraph template, add `hexagon amber` to a node — renders hexagon shape with amber tone
- [ ] Add `dashed` to an `.fg-edge` path — renders dashed stroke
- [ ] Verify `.cylinder`, `.diamond`, `.circle`, `.folded` all render with all 5 tones
- [ ] Hover on clip-path shapes (hexagon/diamond/folded) — glow via `drop-shadow` filter
- [ ] Light/dark theme toggle preserves shape rendering
- [ ] Read `shape-vocabulary.md` — semantic mapping is clear and actionable

Closes #95

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`