### PR TITLE
docs(dev-core): commit .claude/stack.yml by convention

### DIFF
--- a/plugins/dev-core/skills/checkup/cookbooks/stack-checks.md
+++ b/plugins/dev-core/skills/checkup/cookbooks/stack-checks.md
@@ -13,7 +13,7 @@ Run all checks. Collect fixable items. Apply fixes at end (Phase 2 Fix).
 | `.claude/stack.yml.example` ∃ | ✅ | ⚠️ "stack.yml.example missing" |
 
 σ missing → Ask: **Set up now** (recommended) | **Continue with warnings** (stack checks → ⏭).
-Set up → O_stackSetup { `cp "${Φ}/stack.yml.example" .claude/stack.yml`; Ask ∀ critical field (Runtime, Backend path, Frontend path, Test command); write values; prepend @import to CLAUDE.md if missing; ensureGitignore(`.claude/stack.yml`); ¬example → copy; D✅("stack.yml — fill remaining fields") }. Continue checks against new file.
+Set up → O_stackSetup { `cp "${Φ}/stack.yml.example" .claude/stack.yml`; Ask ∀ critical field (Runtime, Backend path, Frontend path, Test command); write values; prepend @import to CLAUDE.md if missing; ¬example → copy; D✅("stack.yml — fill remaining fields; commit alongside code") }. Continue checks against new file.
 
 **Schema:** ∀ field ∈ {`schema_version`, `commands.test`, `commands.lint`, `commands.typecheck`}: chk(∃, ✅, ⚠️ "Missing {field}").
 Contextual (warn only if parent section ∃ but field blank): `backend.path`, `frontend.path`, `standards.testing`, `standards.backend`, `standards.frontend`.
@@ -101,7 +101,6 @@ Show list:
 Auto-fixable issues:
   [ ] stack.yml missing
   [ ] CLAUDE.md import missing
-  [ ] stack.yml not in .gitignore
   [ ] artifacts/analyses dir missing
   [ ] hooks.tool not set
   [ ] lefthook not installed
@@ -122,7 +121,6 @@ Ask: **Fix all** | **Select** | **Skip**
 | `stack.yml.example missing` | `cp "${Φ}/stack.yml.example" .claude/stack.yml.example` |
 | `CLAUDE.md import missing` | Prepend `@.claude/stack.yml\n` to CLAUDE.md |
 | `Critical Rules missing/incomplete` | Run `bun $I_TS scaffold-rules`, then append/merge generated markdown into CLAUDE.md (same logic as `/init` Phase 2c) |
-| `stack.yml not in .gitignore` | ensureGitignore(`.claude/stack.yml`) |
 | `dev-core.yml not in .gitignore` | ensureGitignore(`.claude/dev-core.yml`) |
 | `dev-core.yml missing` | Run `/init` |
 | `artifacts.* dir missing` | `mkdir -p {path}` ∀ missing |

--- a/plugins/dev-core/skills/env-setup/README.md
+++ b/plugins/dev-core/skills/env-setup/README.md
@@ -17,7 +17,7 @@ Triggers: `"env setup"` | `"setup environment"` | `"configure stack"` | `"scaffo
 
 ## Phases
 
-**Phase 1 — Stack configuration** — copies `stack.yml.example` to `.claude/stack.yml`, asks for critical fields (runtime, backend/frontend paths, test command), prepends `@.claude/stack.yml` import to CLAUDE.md, adds to `.gitignore`.
+**Phase 1 — Stack configuration** — copies `stack.yml.example` to `.claude/stack.yml`, asks for critical fields (runtime, backend/frontend paths, test command), prepends `@.claude/stack.yml` import to CLAUDE.md. `stack.yml` is committed (project conventions, no secrets); only `.env` and `.claude/dev-core.yml` are gitignored.
 
 **Phase 1b — Global patterns** — copies `global-patterns.md` (decision protocol, agent discipline, git conventions) to `~/.claude/shared/` and references it from CLAUDE.md.
 
@@ -32,5 +32,5 @@ Triggers: `"env setup"` | `"setup environment"` | `"configure stack"` | `"scaffo
 ## Safety
 
 - Never overwrites existing `stack.yml` values without `--force` or confirmation
-- Never commits `stack.yml` — only `.claude/stack.yml.example`
+- Commits `stack.yml` (project conventions); gitignores `.env` and `.claude/dev-core.yml` (per-machine secrets)
 - Idempotent — all phases skip already-configured items

--- a/plugins/dev-core/skills/env-setup/SKILL.md
+++ b/plugins/dev-core/skills/env-setup/SKILL.md
@@ -32,9 +32,10 @@ Set up σ early — later phases read runtime, package manager, commands, deploy
    - Ask ∀ critical field: **Runtime** → bun|node|python → `runtime`+`package_manager` | **Backend path** (e.g. `apps/api`, blank=none) | **Frontend path** (e.g. `apps/web`, blank=none) | **Test command** → `commands.test`
    - Write values into σ. Inform: "Fill in remaining fields in σ before running agents."
 4. `head -1 CLAUDE.md` → ¬`@.claude/stack.yml` → prepend `@.claude/stack.yml\n`. D✅("@import").
-5. ensureGitignore(`.claude/stack.yml`). D✅(".gitignore").
-6. ¬`.claude/stack.yml.example` → `cp "${Φ}/stack.yml.example" .claude/stack.yml.example`. D("stack.yml.example", "✅ Created (commit this file)").
-7. existing → D("stack.yml", "✅ Already exists"), skip.
+5. ¬`.claude/stack.yml.example` → `cp "${Φ}/stack.yml.example" .claude/stack.yml.example`. D("stack.yml.example", "✅ Created (reference template)").
+6. existing → D("stack.yml", "✅ Already exists"), skip.
+
+Note: `.claude/stack.yml` is **committed** (project stack conventions — no secrets). Only `.env` and `.claude/dev-core.yml` are gitignored by dev-core.
 
 ### Phase 1b — Global Patterns Injection
 
@@ -161,7 +162,7 @@ Next: run /seed-docs to populate docs stubs, or /github-setup to connect GitHub 
 
 1. **Never overwrite existing `.claude/stack.yml` values** without F or explicit confirmation
 2. **Always present decisions via protocol** before any write operation
-3. **Never commit `.claude/stack.yml`** — only `.claude/stack.yml.example`
+3. **Commit `.claude/stack.yml`** — it holds project stack conventions, not secrets. Gitignore `.env` and `.claude/dev-core.yml` instead.
 4. **Idempotent** — skip already-configured items unless F
 
 $ARGUMENTS

--- a/plugins/dev-core/skills/init/templates/docs/standards/configuration.md
+++ b/plugins/dev-core/skills/init/templates/docs/standards/configuration.md
@@ -19,8 +19,10 @@ TODO: Document environment variables.
 <!-- Document configuration files and their purpose. Example:
   | File | Purpose | Committed? |
   |------|---------|:---:|
-  | .claude/stack.yml | Dev-core stack config | No (.gitignored) |
-  | .claude/dev-core.yml | Dev-core plugin config | No (.gitignored) |
+  | .claude/stack.yml | Dev-core stack config | Yes |
+  | .claude/stack.yml.example | Reference template for fresh clones | Yes |
+  | .claude/dev-core.yml | Dev-core plugin config (GitHub IDs, Vercel) | No (.gitignored) |
+  | .env | Per-machine secrets / env vars | No (.gitignored) |
   | biome.json | Linter/formatter config | Yes |
   | tsconfig.json | TypeScript config | Yes |
 -->

--- a/plugins/dev-core/skills/stack-setup/README.md
+++ b/plugins/dev-core/skills/stack-setup/README.md
@@ -29,7 +29,7 @@ Triggers: `"stack setup"` | `"setup stack"` | `"configure stack"` | `"fill stack
    - Build orchestrator (Turbo, Nx)
    - Docs path
 3. **Confirm** — displays detected configuration table; lets you edit any field before writing.
-4. **Write** — creates `.claude/stack.yml`, prepends `@.claude/stack.yml` to CLAUDE.md, adds to `.gitignore`, creates `.claude/stack.yml.example` (safe to commit).
+4. **Write** — creates `.claude/stack.yml` (committed with project), prepends `@.claude/stack.yml` to CLAUDE.md, creates `.claude/stack.yml.example` (reference template).
 
 ## Mixed-stack monorepos
 

--- a/plugins/dev-core/skills/stack-setup/SKILL.md
+++ b/plugins/dev-core/skills/stack-setup/SKILL.md
@@ -154,8 +154,7 @@ Assemble σ. Omit `none`/empty keys entirely.
 
 ```yaml
 # .claude/stack.yml — dev-core stack configuration
-# DO NOT commit this file. Add .claude/stack.yml to .gitignore.
-# Commit .claude/stack.yml.example instead.
+# Commit this file with the project. Secrets live in .env / .claude/dev-core.yml.
 schema_version: "1.0"
 
 runtime: {RUNTIME}
@@ -222,11 +221,12 @@ artifacts:
 #   contributing: {docs}/contributing.md
 ```
 
-## Phase 5 — CLAUDE.md and .gitignore
+## Phase 5 — CLAUDE.md and reference template
 
 1. **@import:** `head -1 CLAUDE.md` ≠ `@.claude/stack.yml` → prepend; else already present.
-2. **Gitignore:** `grep -q '\.claude/stack\.yml' .gitignore 2>/dev/null` → ∄ → append `.claude/stack.yml`; ∃ → skip.
-3. **Example:** `.claude/stack.yml.example` ∄ → copy σ → "Created — commit this file as reference."
+2. **Example:** `.claude/stack.yml.example` ∄ → copy σ → "Created as reference template."
+
+Note: `.claude/stack.yml` itself is committed (project stack conventions — no secrets). Only `.env` and `.claude/dev-core.yml` are gitignored by dev-core.
 
 ## Phase 6 — Summary
 

--- a/plugins/dev-core/stack.yml.example
+++ b/plugins/dev-core/stack.yml.example
@@ -1,12 +1,16 @@
 # .claude/stack.yml — dev-core stack configuration
-# DO NOT commit this file. Add `.claude/stack.yml` to .gitignore.
-# Commit stack.yml.example instead (no sensitive values).
+# COMMIT this file — it declares project stack conventions (paths, commands,
+# formatter, test runner). No secrets go here; `.env` and `.claude/dev-core.yml`
+# hold per-machine credentials and stay gitignored.
+#
+# stack.yml.example remains as a reference template for fresh clones.
 #
 # Usage:
 #   1. Copy to your project: cp stack.yml.example .claude/stack.yml
 #   2. Add as first line of CLAUDE.md: @.claude/stack.yml
 #   3. Fill in the values below for your project's stack.
-#   4. Run /init to verify setup, /doctor to health-check.
+#   4. Commit .claude/stack.yml alongside code.
+#   5. Run /init to verify setup, /checkup to health-check.
 
 schema_version: "1.0"
 


### PR DESCRIPTION
## Summary

- Flip dev-core guidance: `.claude/stack.yml` should be **committed** with the project, matching the convention already used by flagship Roxabi repos (lyra, voiceCLI, imageCLI).
- `stack.yml` holds project stack conventions (runtime, package manager, paths, commands, formatter, test runner) — no secrets. Secrets stay in `.env` + `.claude/dev-core.yml` (both gitignored).
- Touches seven files across `env-setup`, `stack-setup`, `checkup`, `init` templates, and the `stack.yml.example` header.

## Why

Three of the five Roxabi projects that use dev-core already commit `stack.yml`; only `roxabi-plugins` and `roxabi-forge` followed the plugin's stated "DO NOT commit" guidance. Plugin docs were misaligned with the convention that agents + `/dev` actually rely on. Running `/init` on a fresh repo currently adds `.claude/stack.yml` to `.gitignore`, which is the wrong default — fresh clones then miss project-level config until someone manually copies from the example.

## What changed

| File | Change |
|---|---|
| `plugins/dev-core/stack.yml.example` | Header: "COMMIT this file" (was "DO NOT commit") |
| `plugins/dev-core/skills/env-setup/SKILL.md` | Drop step 5 `ensureGitignore(.claude/stack.yml)`; flip Safety Rule 3 |
| `plugins/dev-core/skills/env-setup/README.md` | Drop gitignore step from phase summary + safety bullet |
| `plugins/dev-core/skills/checkup/cookbooks/stack-checks.md` | Drop `ensureGitignore(stack.yml)` from O_stackSetup; remove "stack.yml not in .gitignore" audit row + auto-fix row |
| `plugins/dev-core/skills/stack-setup/SKILL.md` | Remove Phase 5 gitignore step; update generated header comment |
| `plugins/dev-core/skills/stack-setup/README.md` | Drop "adds to .gitignore" from Write phase description |
| `plugins/dev-core/skills/init/templates/docs/standards/configuration.md` | Flip Config Files table: `stack.yml` = Yes committed; add `.env` row |

`ensureGitignore` is still used for `.env` and `.claude/dev-core.yml` — those remain gitignored.

## Test plan

- [ ] Fresh repo: run `/env-setup`, verify `.gitignore` does **not** get `.claude/stack.yml` appended
- [ ] Existing repo with `stack.yml` tracked: run `/checkup`, verify no "stack.yml not in .gitignore" warning
- [ ] Existing repo without tracked `stack.yml`: `/checkup` still passes (no regression — audit rule is gone)
- [ ] `stack.yml.example` copied into a repo reads "COMMIT this file" in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)