### PR TITLE
feat(dev-core): generate release-please workflow in /release-setup

### DIFF
--- a/plugins/dev-core/skills/checkup/cookbooks/stack-checks.md
+++ b/plugins/dev-core/skills/checkup/cookbooks/stack-checks.md
@@ -74,6 +74,11 @@ Config ∄ → ⚠️. Config ∃ ∧ hook ∄ → ⚠️ "needs `{install-cmd}`
 - exit 1 → ⚠️ "N violations". Policy ∄ → auto-fixable. ∃ → ⚠️ "update policy".
 - exit 2 → ⚠️ "run checker to debug"
 
+**Release automation:** Only check if `release-please-config.json` ∃ ∨ `release.config.cjs` ∃.
+- `release-please-config.json` ∃ → also require `.github/workflows/release-please.yml` ∃ → ✅ | ⚠️ "Release Please config present but no workflow — config alone is a no-op. Run `/release-setup` or copy the workflow template from the cookbook." (auto-fixable)
+- `release.config.cjs` ∃ → semantic-release; `package.json` `scripts.release = "semantic-release"` → ✅ | ⚠️.
+- Neither → ⏭ (release automation not configured).
+
 **VS Code MDX preview:** Only if `.mdx` files ∃ ∨ `docs.format: mdx`. `.vscode/settings.json` has `"*.mdx": "markdown"` → ✅ | ⚠️. ∄ .mdx → ⏭.
 
 **LSP support:** `lsp.enabled: false` → ⏭. Else:
@@ -132,6 +137,7 @@ Ask: **Fix all** | **Select** | **Skip**
 | `pre-commit config missing` | Write `.pre-commit-config.yaml`; install hooks |
 | `pre-commit not activated` | `uv run pre-commit install` |
 | `VS Code MDX preview missing` | Merge `"*.mdx": "markdown"` into `.vscode/settings.json` |
+| `release-please workflow missing` | `mkdir -p .github/workflows`; write the workflow template from the release-setup cookbook (Release Please block, step 4) |
 | `ENABLE_LSP_TOOL not set` | `echo 'ENABLE_LSP_TOOL=1' >> .env && grep -q '^ENABLE_LSP_TOOL=' .env.example 2>/dev/null \|\| echo 'ENABLE_LSP_TOOL=1' >> .env.example` |
 | `LSP server not installed` | TS→ bun: `bun add -d typescript-language-server typescript` / pnpm: `pnpm add -D typescript-language-server typescript` / npm: `npm install --save-dev typescript-language-server typescript` / yarn: `yarn add --dev typescript-language-server typescript`. Python→`uv tool install pyright`. Rust→`rustup component add rust-analyzer`. Go→`go install golang.org/x/tools/gopls@latest` |
 | `LSP plugin not installed` | Ask: **Global** | **Project** | **Skip**. Global→`claude plugin install <plugin-name>`. Project→`claude plugin install <plugin-name> --scope project` |

--- a/plugins/dev-core/skills/release-setup/README.md
+++ b/plugins/dev-core/skills/release-setup/README.md
@@ -27,10 +27,10 @@ Triggers: `"release setup"` | `"setup releases"` | `"commit standards"` | `"setu
 
 **Phase 4 — Release automation** — choice of:
 - **semantic-release** — `release.config.cjs` for automatic versioning from commit history
-- **Release Please** — `release-please-config.json` for PR-based release flow
+- **Release Please** — `release-please-config.json` + `.release-please-manifest.json` **and** the runner `.github/workflows/release-please.yml` (config alone is a no-op — config-without-workflow was a known gap in versions ≤ 0.1.0)
 
 **Phase 5 — Summary** — lists all generated files and the suggested commit command. Does NOT auto-commit.
 
 ## Generated files
 
-`.lefthook.yml` | `.commitlintrc.cjs` | `release.config.cjs` | `release-please-config.json` | `.release-please-manifest.json`
+`.lefthook.yml` | `.commitlintrc.cjs` | `release.config.cjs` | `release-please-config.json` | `.release-please-manifest.json` | `.github/workflows/release-please.yml`

--- a/plugins/dev-core/skills/release-setup/SKILL.md
+++ b/plugins/dev-core/skills/release-setup/SKILL.md
@@ -38,12 +38,13 @@ Check prerequisites and per-component state before any installation.
    test -f .commitlintrc.cjs && echo "has_commits" || echo "no_commits"
    test -f release.config.cjs && echo "has_sr" || echo "no_sr"
    test -f release-please-config.json && echo "has_rp" || echo "no_rp"
+   test -f .github/workflows/release-please.yml && echo "has_rp_wf" || echo "no_rp_wf"
    ```
 
 3. Set booleans from results:
    - `has_hook_runner` := `has_lefthook` ∨ `has_husky`
    - `has_commits` := `.commitlintrc.cjs` ∃
-   - `has_releases` := `release.config.cjs` ∃ ∨ `release-please-config.json` ∃
+   - `has_releases` := `release.config.cjs` ∃ ∨ (`release-please-config.json` ∃ ∧ `.github/workflows/release-please.yml` ∃). Release Please config without the workflow is **not** complete — Phase 4 will add the missing workflow.
    - `has_lefthook` := `.lefthook.yml` ∃
 
 4. F overrides all guards → treat all booleans as false (re-run all components).
@@ -100,6 +101,7 @@ Display results and generated files. Do NOT run `git add` or `git commit`.
      release.config.cjs            (semantic-release chosen)
      release-please-config.json    (Release Please chosen)
      .release-please-manifest.json (Release Please chosen)
+     .github/workflows/release-please.yml  (Release Please chosen)
    ```
 
 3. Display suggested commit command:

--- a/plugins/dev-core/skills/release-setup/cookbooks/release-automation.md
+++ b/plugins/dev-core/skills/release-setup/cookbooks/release-automation.md
@@ -66,6 +66,30 @@ AskUserQuestion: **semantic-release** | **Release Please** | **Skip**
    ```json
    {}
    ```
-4. D✅("Release automation — Release Please")
+4. Generate `.github/workflows/release-please.yml` (the runner — config alone is a no-op):
+   ```yaml
+   name: release-please
+
+   on:
+     push:
+       branches:
+         - main
+
+   permissions:
+     contents: write
+     pull-requests: write
+
+   jobs:
+     release-please:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: googleapis/release-please-action@v4
+           with:
+             config-file: release-please-config.json
+             manifest-file: .release-please-manifest.json
+             token: ${{ secrets.PAT }}
+   ```
+   `mkdir -p .github/workflows` first. Use `secrets.PAT` (set during `/init` Phase 3) so the release PR can trigger `ci.yml` — the default `GITHUB_TOKEN` can't fan out to other workflows. Existing file + ¬F → skip with D⏭. `.github/workflows/release-please.yml` already present, but no config → restore config and keep workflow.
+5. D✅("Release automation — Release Please (config + workflow)")
 
 **Skip:** D⏭("Release automation")


### PR DESCRIPTION
## Summary

Release Please config without `.github/workflows/release-please.yml` is a silent no-op — and that's the shape **all** five repos in `~/projects` that used `/release-setup` → Release Please ended up in: config present, no workflow, no releases ever happen.

Audit across `~/projects` (16 repos):

| | Repos | `release-please-config.json` | workflow |
|---|---|:---:|:---:|
| Config present, no workflow | voiceCLI, roxabi-forge, roxabi-vault, roxabi-intel, roxabi-idna | ✅ | ❌ |
| Nothing | everyone else | ❌ | ❌ |
| **Working pipeline** | — | — | **0** |

## What changed

| File | Change |
|---|---|
| `plugins/dev-core/skills/release-setup/cookbooks/release-automation.md` | Release Please block now writes `.github/workflows/release-please.yml` as step 4 (renumber). Template uses `googleapis/release-please-action@v4` with `token: ${{ secrets.PAT }}` so the release PR triggers `ci.yml` (default `GITHUB_TOKEN` can't fan out to other workflows). |
| `plugins/dev-core/skills/release-setup/SKILL.md` | Phase 0 idempotency check reads the workflow file too. `has_releases` now requires **both** config and workflow for Release Please. Summary lists the workflow. |
| `plugins/dev-core/skills/release-setup/README.md` | Phase description + generated-files list call out the workflow; flags the gap in versions ≤ 0.1.0 so upgraders know to re-run `/release-setup`. |
| `plugins/dev-core/skills/checkup/cookbooks/stack-checks.md` | New audit: "Release Please config present but workflow missing" → ⚠️ auto-fixable, with a fix row pointing to the cookbook template. |

No `init.ts` change — `/release-setup` writes config files locally (not via REST) per its existing "no auto-commit" safety rule. Users commit the workflow alongside config in the same PR.

## Why PAT and not GITHUB_TOKEN

`GITHUB_TOKEN` from one workflow cannot trigger another workflow — that's a GitHub Actions security rule. Release Please's release PR is created by `release-please.yml`; if we use `GITHUB_TOKEN`, the PR won't trigger `ci.yml`, so branch protection's required `ci` check will block the merge forever. `/init` already provisions `PAT` during `/ci-setup`, so this is consistent.

## Migration

5 existing repos need the workflow added. After this merges, run `/checkup` in each — the new audit surfaces the missing workflow and offers to write it.

## Test plan

- [ ] `/release-setup` on a fresh repo → workflow appears in `.github/workflows/`
- [ ] `/release-setup` on a repo with config but no workflow → writes the workflow, keeps existing config
- [ ] `/release-setup --force` → overwrites all three (config, manifest, workflow)
- [ ] `/checkup` on a repo with config but no workflow → new audit fires with auto-fix
- [ ] `/checkup` on a repo with neither → ⏭ "Release automation not configured"

🤖 Generated with [Claude Code](https://claude.com/claude-code)