### PR TITLE
feat(release-setup): normalize tag convention to '<name>/vX.Y.Z'

### DIFF
--- a/plugins/dev-core/skills/release-setup/cookbooks/release-automation.md
+++ b/plugins/dev-core/skills/release-setup/cookbooks/release-automation.md
@@ -52,22 +52,40 @@ AskUserQuestion: **semantic-release** | **Release Please** | **Skip**
 6. D✅("Release automation — semantic-release")
 
 **Release Please chosen:**
+
+**Tag convention (Roxabi standard — Convention A):** all tags follow `<component>/vX.Y.Z` — single-package and multi-package repos alike. Tags become self-identifying when consumed across repos (e.g. `tag = "voicecli/v1.0.0"` in a downstream pyproject.toml). Existing plain `vX.Y.Z` tags are left untouched; the new convention applies to all future releases.
+
 1. Determine `package_type`: `python` → `"python"` | else → `"node"`.
-2. Generate `release-please-config.json`. Set `target-branch` to the branch releases are cut from (typically `main`). Without it, release-please defaults to the repo's default branch — which is `staging` in the staging→main promotion flow, causing release-please to open bootstrap PRs on staging instead of tagging from main:
+2. Determine `repo_name`: read from `package.json .name`, `pyproject.toml [project].name`, or derive from `git config --get remote.origin.url` (strip `.git`, take basename) as fallback.
+3. Determine `latest_tag_version`:
+   ```bash
+   git tag -l 'v*' --sort=-v:refname | head -1 | sed 's/^v//'
+   # or, if the repo already uses <component>/vX.Y.Z:
+   git tag -l "${repo_name}/v*" --sort=-v:refname | head -1 | sed "s|^${repo_name}/v||"
+   ```
+   Fall back to `0.0.0` if neither pattern matches.
+4. Generate `release-please-config.json`. Set `target-branch` to the release branch (typically `main`), and set `component` + `package-name` + `tag-separator: "/"` on the root package so tags normalize to `<name>/vX.Y.Z`:
    ```json
    {
      "release-type": "<package_type>",
      "target-branch": "main",
      "packages": {
-       ".": {}
+       ".": {
+         "component": "<repo_name>",
+         "package-name": "<repo_name>",
+         "tag-separator": "/"
+       }
      }
    }
    ```
-3. Generate `.release-please-manifest.json`:
+   Multi-package (uv workspace, monorepo): add one entry per package with the same three fields; also set top-level `"separate-pull-requests": true` so each package releases independently.
+5. Generate `.release-please-manifest.json`. **Seed with `latest_tag_version`** — an empty `{}` causes release-please to ignore existing tags on first run and propose incorrect versions (`v0.2.0` instead of `v0.3.0` after an existing `v0.2.0` tag):
    ```json
-   {}
+   {
+     ".": "<latest_tag_version>"
+   }
    ```
-4. Generate `.github/workflows/release-please.yml` (the runner — config alone is a no-op):
+6. Generate `.github/workflows/release-please.yml` (the runner — config alone is a no-op). **`target-branch: main` MUST be passed as an action input** — release-please-action v4 reads it from its own `with:` block, not the config file. Without it, the action falls back to the repo's default branch (typically `staging` in the staging→main flow) and opens release PRs on the wrong branch:
    ```yaml
    name: release-please
 
@@ -88,9 +106,17 @@ AskUserQuestion: **semantic-release** | **Release Please** | **Skip**
            with:
              config-file: release-please-config.json
              manifest-file: .release-please-manifest.json
+             target-branch: main
              token: ${{ secrets.PAT }}
    ```
    `mkdir -p .github/workflows` first. Use `secrets.PAT` (set during `/init` Phase 3) so the release PR can trigger `ci.yml` — the default `GITHUB_TOKEN` can't fan out to other workflows. Existing file + ¬F → skip with D⏭. `.github/workflows/release-please.yml` already present, but no config → restore config and keep workflow.
-5. D✅("Release automation — Release Please (config + workflow)")
+
+7. **Idempotent repair under F** — if any of these are already present but drift from the convention, patch in place:
+   - Workflow missing `target-branch: main` action input → inject it.
+   - Config `.` package missing `component` / `package-name` / `tag-separator: "/"` → add them.
+   - Manifest is `{}` but tags exist → seed with `latest_tag_version`.
+   These three are the highest-impact drifts and were the source of every release-please bug caught on Roxabi repos so far.
+
+8. D✅("Release automation — Release Please (config + workflow)")
 
 **Skip:** D⏭("Release automation")


### PR DESCRIPTION
## Why

The \`dev-core:release-setup\` skill generated release-please configs with three class-of-bugs we hit this session on both \`lyra\` (#782) and \`roxabi-plugins\` (#106):

1. **Workflow YAML missing \`target-branch: main\` action input** — release-please-action v4 reads \`target-branch\` from its own \`with:\` block, not from \`release-please-config.json\`. Without the input, it falls back to the repo default branch (usually \`staging\`) and opens release PRs on the wrong branch.
2. **Config template \`packages: { ".": {} }\`** — no \`component\` / \`package-name\` / \`tag-separator\`. Defaulted to \`<name>-vX.Y.Z\` with hyphen separator.
3. **Manifest template \`{}\`** — ignored existing tags, so release-please proposed nonsensical versions on first run (e.g. \`v0.2.0\` after \`v0.2.0\` was already tagged).

## What

**Convention A** — all Roxabi repos tag as \`<component>/vX.Y.Z\`, single-package and multi-package alike. Makes tags self-identifying for cross-repo consumption:

\`\`\`toml
voicecli = { git = "...", tag = "voicecli/v1.2.0" }   # unambiguous
\`\`\`

Changes to \`release-automation.md\`:

- Workflow template now includes \`target-branch: main\`.
- Config template sets \`component\`, \`package-name\`, \`tag-separator: "/"\` on root package.
- Manifest template seeds with \`latest_tag_version\` (detected via \`git tag -l 'v*'\`).
- New "idempotent repair under \`--force\`" step — patches existing repos in place without full rebuild.

Existing plain \`vX.Y.Z\` tags are preserved as-is; convention applies to future releases only.

## Test plan

- [x] Read through generated template — matches the manual fixes applied to lyra (#782) and roxabi-plugins (#106).
- [ ] Re-run \`/release-setup --force\` on a real repo after this merges, verify idempotent repair produces a clean diff.

## Follow-up

- Cross-repo index doc (\`~/projects/CLAUDE.md\`) updated separately with the convention statement.
- User will apply convention manually to voiceCLI / 2ndBrain / imageCLI / roxabi-forge / roxabi-intel / roxabi-idna this session.

---
Generated with [Claude Code](https://claude.com/claude-code)