### PR TITLE
fix(release): apply Convention A tag format (roxabi-plugins/vX.Y.Z)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,10 @@
   "release-type": "node",
   "target-branch": "main",
   "packages": {
-    ".": {}
+    ".": {
+      "component": "roxabi-plugins",
+      "package-name": "roxabi-plugins",
+      "tag-separator": "/"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Sets `component`, `package-name`, and `tag-separator: "/"` in `release-please-config.json`
- Ensures release-please creates tags as `roxabi-plugins/v0.3.0` instead of `roxabi-plugins-v0.3.0`
- Supersedes PR #109, which was closed because it carried the old hyphen-prefix default

## Changes

`release-please-config.json` — added three fields to the root package entry:
- `"component": "roxabi-plugins"`
- `"package-name": "roxabi-plugins"`
- `"tag-separator": "/"`

## Test plan

- [ ] CI passes on this PR
- [ ] Squash-merge to staging
- [ ] Promote staging → main via merge commit
- [ ] Confirm release-please opens new PR with compare link `roxabi-plugins/v0.2.0...roxabi-plugins/v0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)