### PR TITLE
refactor(dev-core): publish issue-taxonomy SSoT (phase 0)

### DIFF
--- a/artifacts/plans/119-issue-taxonomy-migration-plan.mdx
+++ b/artifacts/plans/119-issue-taxonomy-migration-plan.mdx
@@ -1,0 +1,192 @@
+---
+title: "Plan: issue-taxonomy migration → hub project + native Issue Types (V0 Phase 0)"
+issue: 119
+spec: artifacts/specs/119-issue-taxonomy-migration-spec.mdx
+complexity: 7
+tier: F-full
+generated: "2026-04-21T00:00:00Z"
+---
+
+## Summary
+
+Phase 0 of the 8-phase taxonomy migration: publish the SSoT reference `plugins/dev-core/references/issue-taxonomy.md`, cross-link it from the 3 consumer skills (`issue-triage`, `github-setup`, `issues`), and split the parent issue into 3 rollback-boundary children. Pure-docs slice inside an F-full parent — no code, no API calls, no schema mutations.
+
+## Architecture
+
+### Data Flow
+
+```mermaid
+flowchart TD
+    subgraph "SSoT"
+        SSOT["plugins/dev-core/references/issue-taxonomy.md"]
+    end
+
+    subgraph "Consumer Skills (SKILL.md)"
+        IT["issue-triage/SKILL.md"]
+        GS["github-setup/SKILL.md"]
+        IS["issues/SKILL.md"]
+    end
+
+    subgraph "Downstream (out of scope V0)"
+        DEP["lyra/scripts/dep-graph"]
+        CORP["lyra/scripts/corpus"]
+        DASH["roxabi-dashboard"]
+    end
+
+    SSOT -->|"## Related"| IT
+    SSOT -->|"## Related"| GS
+    SSOT -->|"## Related"| IS
+    IT -.->|"future phases"| DEP
+    GS -.->|"future phases"| CORP
+    IS -.->|"future phases"| DASH
+```
+
+### File x Function Map
+
+```mermaid
+flowchart LR
+    subgraph "plugins/dev-core/references/"
+        REF["issue-taxonomy.md (SSoT, 138 lines)"]
+    end
+
+    subgraph "plugins/dev-core/skills/issue-triage/"
+        ITMD["SKILL.md"]
+    end
+
+    subgraph "plugins/dev-core/skills/github-setup/"
+        GSMD["SKILL.md"]
+    end
+
+    subgraph "plugins/dev-core/skills/issues/"
+        ISMD["SKILL.md"]
+    end
+
+    subgraph "GitHub (Roxabi/roxabi-plugins)"
+        CHILD_A["#119.a Bootstrap+Enrollment"]
+        CHILD_B["#119.b Dual-write+Migration"]
+        CHILD_C["#119.c Cutover+Guardrail"]
+    end
+
+    REF -.->|"## Related link"| ITMD
+    REF -.->|"## Related link"| GSMD
+    REF -.->|"## Related link"| ISMD
+    CHILD_A -->|"parent"| CHILD_B
+    CHILD_B -->|"parent"| CHILD_C
+```
+
+## Bootstrap Context
+
+No analysis artifact — spec approved directly (out-of-order state, user-accepted skip). Spec 119 is SSoT for phase decomposition. V0 Phase 0 was scoped down to docs-only so the F-full parent can land incrementally along rollback-stage children.
+
+## Agents
+
+| Agent | Task count | Files |
+|-------|-----------|-------|
+| doc-writer | 3 | `plugins/dev-core/skills/issue-triage/SKILL.md`, `plugins/dev-core/skills/github-setup/SKILL.md`, `plugins/dev-core/skills/issues/SKILL.md` |
+| main ctx | 1 | GitHub issue-graph ops (create 3 children of #119) |
+
+## Consistency Report
+
+- Criteria covered: 2/8 (SC-0.1 SSoT doc + link-back, SC-0.2 child issue split). Remaining SC-1..SC-7 covered by children #119.a/#119.b/#119.c across subsequent V1..V7 slices.
+- Uncovered criteria: none for V0 scope.
+- Tasks without spec backing: none.
+- Gold plating exemptions applied: 0.
+
+## Micro-Tasks
+
+### Slice V0: Phase 0 — Discoverability (docs-only)
+
+#### Task 1: Create 3 children under #119 (a/b/c) via `dev-core:issue-triage` → main ctx
+- **Files:** GitHub (Roxabi/roxabi-plugins) — no repo files
+- **Snippet:**
+  ```bash
+  # each child created with parent=119, size=L, priority=High, status=Backlog
+  bun triage.ts create \
+    --title "refactor(dev-core): #119.a bootstrap + enrollment (phases 1+2)" \
+    --parent 119 --size L --priority High
+  bun triage.ts create \
+    --title "refactor(dev-core): #119.b dual-write + migration (phases 3+4+5)" \
+    --parent 119 --size L --priority High
+  bun triage.ts create \
+    --title "refactor(dev-core): #119.c cutover + guardrail (phases 6+7)" \
+    --parent 119 --size L --priority High
+  ```
+- **Verify:** `bun /home/mickael/.claude/plugins/cache/roxabi-marketplace/dev-core/0.1.0/skills/issue-triage/triage.ts list --json | jq '[.[] | select(.parent == 119)] | length'`
+- **Expected:** `3`
+- **Time:** 5 min
+- **Difficulty:** 2
+- **Traces:** SC-0.2
+- **Phase:** GREEN
+- **Parallel:** N (single actor, main ctx)
+
+#### Task 2: Add `## Related` → SSoT link in `issue-triage/SKILL.md` [P] → doc-writer
+- **File:** `plugins/dev-core/skills/issue-triage/SKILL.md`
+- **Snippet:**
+  ```markdown
+  ## Related
+
+  - Taxonomy SSoT → `plugins/dev-core/references/issue-taxonomy.md`
+  ```
+- **Verify:** `grep -c "references/issue-taxonomy.md" plugins/dev-core/skills/issue-triage/SKILL.md`
+- **Expected:** `>= 1`
+- **Time:** 3 min
+- **Difficulty:** 1
+- **Traces:** SC-0.1
+- **Phase:** GREEN
+- **Parallel:** Y
+
+#### Task 3: Add `## Related` → SSoT link in `github-setup/SKILL.md` [P] → doc-writer
+- **File:** `plugins/dev-core/skills/github-setup/SKILL.md`
+- **Snippet:**
+  ```markdown
+  ## Related
+
+  - Taxonomy SSoT → `plugins/dev-core/references/issue-taxonomy.md`
+  ```
+- **Verify:** `grep -c "references/issue-taxonomy.md" plugins/dev-core/skills/github-setup/SKILL.md`
+- **Expected:** `>= 1`
+- **Time:** 3 min
+- **Difficulty:** 1
+- **Traces:** SC-0.1
+- **Phase:** GREEN
+- **Parallel:** Y
+
+#### Task 4: Add `## Related` → SSoT link in `issues/SKILL.md` [P] → doc-writer
+- **File:** `plugins/dev-core/skills/issues/SKILL.md`
+- **Snippet:**
+  ```markdown
+  ## Related
+
+  - Taxonomy SSoT → `plugins/dev-core/references/issue-taxonomy.md`
+  ```
+- **Verify:** `grep -c "references/issue-taxonomy.md" plugins/dev-core/skills/issues/SKILL.md`
+- **Expected:** `>= 1`
+- **Time:** 3 min
+- **Difficulty:** 1
+- **Traces:** SC-0.1
+- **Phase:** GREEN
+- **Parallel:** Y
+
+### Slice V0 Exit Gate
+
+- `git ls-files plugins/dev-core/references/issue-taxonomy.md` → 1 hit (staged/committed)
+- `grep -l "references/issue-taxonomy.md" plugins/dev-core/skills/{issue-triage,github-setup,issues}/SKILL.md | wc -l` → 3
+- `bun triage.ts list --json | jq '[.[] | select(.parent == 119)] | length'` → 3
+
+## Out-of-Scope (future slices)
+
+| Slice | Child issue | Spec phases | Tier |
+|---|---|---|---|
+| V1 | #119.a | Phase 1 (bootstrap hub) + Phase 2 (opt-in enroll) | F-lite |
+| V2 | #119.b | Phase 3 (dual-write) + Phase 4 (backfill) + Phase 5 (title rewrite) | F-full |
+| V3 | #119.c | Phase 6 (cutover) + Phase 7 (guardrail) | F-lite |
+
+Each child gets its own spec + plan when its parent unblocks.
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 8 — Create 3 children under #119 (a/b/c)
+- T2: 9 — Add SSoT link to issue-triage/SKILL.md
+- T3: 10 — Add SSoT link to github-setup/SKILL.md
+- T4: 11 — Add SSoT link to issues/SKILL.md

--- a/artifacts/plans/119-issue-taxonomy-migration-plan.mdx
+++ b/artifacts/plans/119-issue-taxonomy-migration-plan.mdx
@@ -70,8 +70,8 @@ flowchart LR
     REF -.->|"## Related link"| ITMD
     REF -.->|"## Related link"| GSMD
     REF -.->|"## Related link"| ISMD
-    CHILD_A -->|"parent"| CHILD_B
-    CHILD_B -->|"parent"| CHILD_C
+    CHILD_A -->|"blocks"| CHILD_B
+    CHILD_B -->|"blocks"| CHILD_C
 ```
 
 ## Bootstrap Context
@@ -111,7 +111,7 @@ No analysis artifact — spec approved directly (out-of-order state, user-accept
     --title "refactor(dev-core): #119.c cutover + guardrail (phases 6+7)" \
     --parent 119 --size L --priority High
   ```
-- **Verify:** `bun /home/mickael/.claude/plugins/cache/roxabi-marketplace/dev-core/0.1.0/skills/issue-triage/triage.ts list --json | jq '[.[] | select(.parent == 119)] | length'`
+- **Verify:** `bun ${CLAUDE_SKILL_DIR}/triage.ts list --json | jq '[.[] | select(.parent == 119)] | length'`
 - **Expected:** `3`
 - **Time:** 5 min
 - **Difficulty:** 2

--- a/artifacts/specs/119-issue-taxonomy-migration-spec.mdx
+++ b/artifacts/specs/119-issue-taxonomy-migration-spec.mdx
@@ -1,0 +1,417 @@
+---
+title: "Issue taxonomy migration — hub project + native Issue Types"
+issue: 119
+status: approved
+tier: F-full
+date: 2026-04-21
+---
+
+## Context
+
+Spike 2026-04-21 validated two critical paths before this spec was written:
+
+- **Spike 1 (hub project + read path):** `Roxabi Hub` project (#23) created with 3 custom `single_select` fields — `Lane` (20 options: `a1..a3`, `b`, `c1..c3`, `d`, `e`, `f`, `g`, `h`, `i`, `j`, `k`, `l`, `m`, `n`, `o`, `standalone`), `Priority` (P0..P3), `Size` (S, F-lite, F-full). One paginated GraphQL query on `organization.projectV2(number:N).items` returns `fieldValues` + `content.milestone` + `content.blockedBy` + `content.blocking` + `content.parent` + `content.subIssues` + `content.issueType` in one shot. No preview APIs. Cross-repo edges native. Project #23 torn down post-spike.
+- **Spike 2 (Issue Types bootstrap):** `createIssueType(name:"refactor", color:PURPLE, isEnabled:true)` works with current `project` token scope — no `admin:org` refresh needed. `updateIssueIssueType` on `#717` verified. Type `refactor` (ID `IT_kwDOB8J6DM4B92gZ`) kept on org; `#717` retains the assignment pending migration.
+
+**Existing org Issue Types (2026-04-21):**
+
+| Name | Color | ID | Action |
+|---|---|---|---|
+| `Task` | YELLOW | `IT_kwDOB8J6DM4BJQ3W` | disable |
+| `Bug` | RED | `IT_kwDOB8J6DM4BJQ3X` | rename → `fix` |
+| `Feature` | BLUE | `IT_kwDOB8J6DM4BJQ3Z` | rename → `feat` |
+| `refactor` | PURPLE | `IT_kwDOB8J6DM4B92gZ` | keep (created in spike) |
+
+**Preview API risk:** retired. GraphQL `projectV2.items` is GA. No preview APIs in the hot path.
+
+**Taxonomy SSoT:** `plugins/dev-core/references/issue-taxonomy.md` — this spec implements its migration order; do not re-derive field definitions from here.
+
+## Goal
+
+Execute a phased migration from label-based taxonomy (`graph:lane/*`, `size:*`, title-prefix) to hub project fields + org-level Issue Types. End state: every open issue in 8 repos has `Lane`, `Priority`, `Size`, `issueType` set via `Roxabi Hub`; title prefixes stripped; legacy labels deleted.
+
+## Users
+
+| User | Role |
+|---|---|
+| Mickael | sole executor; runs migration scripts + toggles dual-write |
+| `dev-core:issue-triage` | primary writer post-migration (reads hub fields, sets issueType) |
+| `dev-core:issues` / dep-graph | primary readers post-migration (single GraphQL query) |
+
+## Out of scope
+
+- Building `make milestones-sync` helper — flagged as hard dependency; tracked separately.
+- Retroactive assignee backfill.
+- Enrolling experimental, archived, or new repos beyond the 8 listed.
+- Custom Status options beyond built-in (`Todo` / `Ready` / `In Progress` / `Blocked` / `Done`).
+- Cross-org `addBlockedBy` (EMU restriction — not a Roxabi concern).
+
+**8 repos in scope:** `lyra` · `voiceCLI` · `imageCLI` · `roxabi-vault` · `roxabi-forge` · `roxabi-intel` · `roxabi-idna` · `roxabi-plugins`.
+
+---
+
+## Phase 0 — Discoverability
+
+**Goal:** The taxonomy SSoT is linked from every skill that reads or writes to it, so future implementers find the contract without hunting.
+
+### Steps
+
+| # | Action | File |
+|---|---|---|
+| 0.1 | Add cross-reference to `references/issue-taxonomy.md` in triage skill | `plugins/dev-core/skills/issue-triage/SKILL.md` |
+| 0.2 | Same in github-setup skill | `plugins/dev-core/skills/github-setup/SKILL.md` |
+| 0.3 | Same in issues skill | `plugins/dev-core/skills/issues/SKILL.md` |
+
+**Link form:** one line in a `## Related` or equivalent section: `See [Issue taxonomy SSoT](../../references/issue-taxonomy.md) — canonical cross-repo taxonomy contract (field set, plugin contracts, anti-patterns).`
+
+### Exit criteria
+
+- All 3 SKILL.md files contain a resolvable link to `plugins/dev-core/references/issue-taxonomy.md`.
+- Link context makes clear the referenced doc is the SSoT (not optional reading).
+
+### Rollback
+
+Revert the PR. No runtime side-effects.
+
+### Not blocked by / does not block
+
+Runs independently of Phase 1+. Ideally lands first so subsequent phase implementers read the SSoT before touching code, but execution order is not load-bearing.
+
+---
+
+## Phase 1 — Bootstrap
+
+**Goal:** Idempotent org + project bootstrap. Safe to re-run at any time.
+
+### Steps
+
+| # | Action | GraphQL mutation / API |
+|---|---|---|
+| 1.1 | Create `Roxabi Hub` project under org | `createProjectV2` |
+| 1.2 | Create `Lane` single_select field (20 options) | `createProjectV2Field` |
+| 1.3 | Create `Priority` single_select field (P0..P3) | `createProjectV2Field` |
+| 1.4 | Create `Size` single_select field (S, F-lite, F-full) | `createProjectV2Field` |
+| 1.5 | Verify `Status` built-in field + options (Todo/Ready/In Progress/Blocked/Done) | `projectV2.fields` query |
+| 1.6 | Create 7 missing Issue Types: `feat` `docs` `test` `chore` `ci` `perf` `epic` `research` (minus `fix` and `refactor` already present) | `createIssueType` × 7 |
+| 1.7 | **Pre-flight sub-spike:** query all open issues with `issueType=Bug` and `issueType=Feature` — record counts + IDs. Verify that a test rename on a dummy issue reads back the new name before touching real data. | GraphQL query + `updateIssueType` on test issue |
+| 1.8 | Rename `Bug` → `fix` | `updateIssueType(id: IT_kwDOB8J6DM4BJQ3X, name:"fix")` |
+| 1.9 | Rename `Feature` → `feat` | `updateIssueType(id: IT_kwDOB8J6DM4BJQ3Z, name:"feat")` |
+| 1.10 | Disable `Task` type | `updateIssueType(id: IT_kwDOB8J6DM4BJQ3W, isEnabled:false)` |
+
+**Open question — rename side-effects (BLOCKER for step 1.8/1.9):** It is unknown whether existing `issueType: Bug` / `issueType: Feature` assignments on real issues survive an org-level type rename or if they become orphaned. Step 1.7 is a mandatory pre-flight sub-spike that must resolve this before 1.8/1.9 execute.
+
+**Idempotency contract:** Check existing project by name before creating; check existing field names before creating; check existing type names before creating or renaming. Skip, don't error, if already present.
+
+### Exit criteria
+
+- `Roxabi Hub` project exists with 4 fields (Lane, Priority, Size, Status).
+- Org Issue Types = `feat · fix · refactor · docs · test · chore · ci · perf · epic · research` (10 types active). `Task` disabled.
+- Sub-spike 1.7 result documented: rename preserves existing assignments (required before proceeding).
+
+### Rollback
+
+- Hub project: `deleteProjectV2`. No issue data lost — items are pointers, not copies.
+- Renames (`Bug→fix`, `Feature→feat`): `updateIssueType` back to original name. Sub-spike 1.7 snapshot (issue IDs + old type names) provides the recovery list.
+- New Issue Types: `updateIssueType(isEnabled:false)` to disable; GH does not expose a delete mutation for org types.
+- `Task` re-enable: `updateIssueType(id: ..., isEnabled:true)`.
+
+---
+
+## Phase 2 — Enrollment
+
+**Goal:** All 8 repos auto-add issues to the hub project. Consistent milestone seeds exist.
+
+### Steps
+
+| # | Action |
+|---|---|
+| 2.1 | For each of 8 repos: add auto-add workflow so every new issue is added to `Roxabi Hub` | `updateProjectV2` + workflow API |
+| 2.2 | For each of 8 repos: verify or seed milestones (`M0`, `M1`, `M2`, …) with consistent names | `make milestones-sync` (sibling task — see dependency note) |
+| 2.3 | Verify at least one test issue from each repo appears as a hub project item before proceeding | GraphQL `projectV2.items` query |
+
+**Hard dependency:** Step 2.2 requires `make milestones-sync` helper (not in scope here). This spec depends on that sibling task landing first. Do not skip 2.2 — milestone name drift across 8 repos will corrupt dep-graph band headers.
+
+**`dev-core:github-setup` change:** add `--hub-enroll` opt-in flag that automates steps 2.1 + 2.2 per repo. Verify Issue Types exist before enrolling.
+
+### Exit criteria
+
+- 8 repos enrolled; auto-add workflows verified by creating a test issue and confirming it appears in `Roxabi Hub`.
+- Consistent milestone set (`M0..MN`) present in each repo.
+- Hub project item count ≥ open issue count across all 8 repos (no drift).
+
+**Risk — item cap:** Hub project currently has ~76 items (Roadmap project reference). GH V2 projects support up to 1,200 items. At current org scale (~400 open issues across 8 repos) this is not an immediate problem, but flag as a future risk if org grows significantly. Partitioning strategy is out of scope.
+
+### Rollback
+
+- Remove auto-add workflow per repo (project settings). Issues already added as items remain; delete project items individually or delete the project (see Phase 1 rollback).
+
+---
+
+## Phase 3 — Dual-write window
+
+**Goal:** `dev-core:issue-triage` writes BOTH legacy labels (`graph:lane/*`, `size:*`, title prefix) AND new project fields + `issueType`. Safety net while backfill runs and confidence is built.
+
+### Behavior
+
+```
+issue-triage write path (dual-write mode):
+  write graph:lane/<X> label       ← legacy (keeps dep-graph functional)
+  write size:<Y> label             ← legacy
+  prepend type prefix to title     ← legacy
+  updateProjectV2ItemFieldValue(Lane, Priority, Size, Status)   ← new
+  updateIssueIssueType             ← new
+```
+
+**Sequencing across 8 repos:** Roll out dual-write starting with `roxabi-plugins` (owns the skill code), then `lyra` as pilot repo, then the remaining 6 in parallel. Per-repo rollout = deploy updated `issue-triage` skill pointing at the hub project.
+
+**Window duration:** minimum 7 days of normal triage activity after all 8 repos are writing to the hub project. Exit when Phase 3 exit criteria are met — not before.
+
+**`dev-core:issue-triage` change:** read hub project field IDs from `.claude/stack.yml` env (or skill config). Write legacy labels + title prefix as before; additionally call `updateProjectV2ItemFieldValue` + `updateIssueIssueType` for every triage operation.
+
+### Exit criteria
+
+- All 8 repos' `issue-triage` instances writing to hub project fields for ≥7 days.
+- Zero divergence between label values and project field values on any issue triaged during this window (validated by Phase 4 backfill dry-run diff before cutover).
+
+### Rollback
+
+- Revert `issue-triage` to label-only write path (feature flag or skill version pin). Hub project items remain populated — no data loss.
+
+---
+
+## Phase 4 — Backfill
+
+**Goal:** Every open issue in all 8 repos has `Lane`, `Size`, `Priority`, `issueType` populated in the hub project, derived from existing labels and title prefix. Idempotent, re-runnable, dry-run first.
+
+### Script contract
+
+**Invocation:** `python scripts/migrate/backfill_taxonomy.py [--dry-run] [--repo OWNER/REPO]`
+
+**Input per issue (in priority order):**
+1. Existing hub project field values (if already set — skip, don't overwrite).
+2. `graph:lane/<X>` label → `Lane` field value.
+3. `size:<Y>` label → `Size` field value. Map: old size labels → `S` / `F-lite` / `F-full`.
+4. Issue title prefix (conventional-commit) → `issueType`. Regex: `^(feat|fix|refactor|docs|test|chore|ci|perf)\(.+\):|^(feat|fix|refactor|docs|test|chore|ci|perf):`. No match → `chore` (default, flag for manual review).
+5. `Priority` — no legacy source; leave null if unset (flag for manual review). Do not invent values.
+
+**Mutations:**
+- `addProjectV2ItemById` — add issue to hub project if not already present.
+- `updateProjectV2ItemFieldValue` — set Lane, Size, Priority on the item.
+- `updateIssueIssueType` — assign Issue Type.
+
+**Output:**
+- `--dry-run`: print diff table (issue, field, current value, proposed value) to stdout. No mutations.
+- Live run: print progress per repo + final summary (issues processed, issues updated, issues skipped, issues flagged for manual review).
+- On completion: write `backfill-snapshot-<date>.json` — array of `{repo, number, old_title, new_lane, new_size, new_type, flagged}`.
+
+**Idempotency:** If a project item already has all 4 fields set, skip without mutation. If partially set, fill only the null fields.
+
+**Manual review flags:** Issues with no `graph:lane/*` label (Lane unknown) or no title prefix match (type defaulted to `chore`) are emitted to a `flagged.txt` for human review before cutover.
+
+### Exit criteria
+
+- Dry-run shows 0 mutations remaining (all open issues have Lane + Size + Priority + issueType populated).
+- `flagged.txt` reviewed and resolved (or explicitly accepted as `chore` / null Priority).
+- GraphQL diff query: `projectV2.items` where `Lane IS NULL OR Size IS NULL OR issueType IS NULL` returns 0 results across all 8 repos.
+
+### Rollback
+
+- Re-run Phase 3 dual-write. No data was deleted — legacy labels still exist during this phase.
+- To undo field values: use `backfill-snapshot-<date>.json` as a revert manifest; script `scripts/migrate/revert_backfill.py --snapshot <file>` clears the fields set during backfill.
+
+---
+
+## Phase 5 — Title rewrite
+
+**Goal:** Strip the conventional-commit prefix from every open issue title. `refactor(nats): foo` → `foo`. Issue Type now carries the semantic signal that was in the prefix.
+
+**Scope:** open issues only, all 8 repos.
+
+### Steps
+
+| # | Action |
+|---|---|
+| 5.1 | `--dry-run`: emit `{repo, number, old_title, new_title}` JSON array to `title-rewrite-snapshot-<date>.json`. Print diff summary. |
+| 5.2 | Human review of snapshot — confirm no false positives (titles with colons that are not prefixes). |
+| 5.3 | Live run: `gh issue edit <N> --repo <R> --title "<new_title>"` per issue. |
+| 5.4 | Commit snapshot file to repo as migration artifact (reviewable in isolation). |
+
+**Script:** `scripts/migrate/rewrite_titles.py [--dry-run] [--repo OWNER/REPO]`
+
+**Concern — external references:** PR descriptions, commit messages, and other issues may cite issue titles by text. Mitigation: issue number is the stable identifier. Title changes are annotated in the migration commit body. The snapshot JSON provides a lookup from old → new title for any external tooling.
+
+**Commit strategy:** title rewrite is a single PR per repo (or one PR in `roxabi-plugins` with cross-repo scripted changes), making the change reviewable in isolation from the rest of the migration.
+
+### Exit criteria
+
+- Zero open issues with titles matching `^(feat|fix|refactor|docs|test|chore|ci|perf)(\(.+\))?:` across all 8 repos.
+- Snapshot JSON committed and PR approved before merge.
+
+### Rollback
+
+- Restore titles from `title-rewrite-snapshot-<date>.json`: `gh issue edit <N> --repo <R> --title "<old_title>"` per row.
+
+---
+
+## Phase 6 — Cutover
+
+**Goal:** Flip readers to the hub project; stop writing legacy labels; remove legacy labels org-wide.
+
+### Steps
+
+| # | Action |
+|---|---|
+| 6.1 | Flip `scripts/dep-graph/dep_graph/fetch.py` to read `organization.projectV2.items` GraphQL (field path per §6 of taxonomy doc). |
+| 6.2 | Flip `dev-core:issues` read path to single GraphQL `projectV2.items` call (drop `gh issue list --label graph:lane/*`). |
+| 6.3 | Remove legacy label writes from `dev-core:issue-triage` (title prefix, `graph:lane/*`, `size:*`). |
+| 6.4 | For each of 8 repos: delete all `graph:*` and `size:*` labels via `gh label delete`. |
+| 6.5 | Smoke test: `make dep-graph build` renders correctly; `make issues` table shows all fields. |
+
+**`dev-core:issue-triage` final write path (post-cutover):**
+```
+updateProjectV2ItemFieldValue(Lane, Priority, Size, Status)
+updateIssueIssueType
+(no label writes for taxonomy, no title prefix)
+```
+
+### Exit criteria
+
+- `make dep-graph build` renders all 8 repos' issues with correct Lane/Priority/Size/Milestone from hub project.
+- `make issues` table shows no missing fields for any issue.
+- `gh label list --repo <R>` returns 0 `graph:*` or `size:*` labels for all 8 repos.
+- `dev-core:issue-triage` integration test: triage a new test issue → hub project field updated + issueType set + no labels written.
+
+### Rollback
+
+- Revert `fetch.py` + `issues` read path to label-based (git revert of the cutover commit).
+- Re-enable legacy label writes in `issue-triage`.
+- Labels cannot be restored automatically — if deleted, must be re-created and re-applied per issue. **Strongly recommended:** do not delete labels (step 6.4) until the smoke test (6.5) passes and a 48-hour burn-in confirms stability. Keep labels as read-only dead weight until confident.
+
+---
+
+## Phase 7 — Guardrail repurpose
+
+**Goal:** `make dep-graph audit` now validates project-field coverage (not label coverage).
+
+### New audit contract
+
+```
+make dep-graph audit
+→ query: projectV2.items where Lane IS NULL OR Size IS NULL OR Priority IS NULL OR issueType IS NULL
+→ exit 0 if 0 results
+→ exit 1 + print table of offending issues if any results
+```
+
+**Legacy behavior (retired):** label coverage check (silent pass by definition post-cutover — no labels to audit).
+
+### Steps
+
+| # | Action |
+|---|---|
+| 7.1 | Rewrite `audit` subcommand in `scripts/dep-graph/dep_graph/` to use hub project query. |
+| 7.2 | Update `Makefile` audit target to run new audit. |
+| 7.3 | Add to CI: `make dep-graph audit` as a required check on all 8 repos' PRs (or run centrally from `roxabi-plugins`). |
+
+### Exit criteria
+
+- `make dep-graph audit` exits 0 on clean hub project state.
+- `make dep-graph audit` exits 1 and prints the correct offending issues when a test issue has a null field.
+
+### Rollback
+
+- Revert audit script to previous version (label-based check). This is a tooling change only; no data is affected.
+
+---
+
+## Skill changes (implementation in separate issues)
+
+| Skill | Change |
+|---|---|
+| `dev-core:issue-triage` | Phase 0: link SSoT in SKILL.md. Phase 3: add dual-write (fields + issueType alongside labels). Phase 6: remove label + prefix writes. |
+| `dev-core:github-setup` | Phase 0: link SSoT in SKILL.md. Phase 1: org Issue Type bootstrap (create/rename/disable). Phase 2: `--hub-enroll` flag per repo (auto-add workflow + milestone seed). |
+| `dev-core:issues` | Phase 0: link SSoT in SKILL.md. Phase 6: switch read from `gh issue list --label` to single `organization.projectV2.items` GraphQL query per §6 of taxonomy doc. |
+| `scripts/dep-graph/dep_graph/fetch.py` | Phase 6: same GraphQL switch as `issues`. |
+| `scripts/dep-graph/dep_graph/audit.py` | Phase 7: field-coverage assertion replacing label-coverage check. |
+
+These are reference-only callouts. Each warrants its own implementation issue under #119 as a child.
+
+---
+
+## GraphQL mutations / queries reference
+
+| Operation | Mutation / Query |
+|---|---|
+| Create hub project | `createProjectV2` |
+| Create single_select field | `createProjectV2Field` |
+| Read project fields + items | `organization.projectV2(number:N).items` (paginated) |
+| Add issue to project | `addProjectV2ItemById` |
+| Set field value on item | `updateProjectV2ItemFieldValue` |
+| Create org Issue Type | `createIssueType` |
+| Rename / update org Issue Type | `updateIssueType` |
+| Assign Issue Type to issue | `updateIssueIssueType` |
+| Read Issue Type on issue | `issue.issueType.name` (via `projectV2.items` node) |
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Rename `Bug→fix` orphans existing `issueType:Bug` assignments | Unknown — **open question** | Sub-spike 1.7 mandatory before Phase 1.8/1.9. Do not proceed without confirmation. |
+| Title rewrite breaks stable text references | Low | Issue number is the stable id. Snapshot committed. PR reviewable in isolation. |
+| Preview API drift | Retired | GraphQL `projectV2.items` is GA. No preview APIs in hot path. |
+| Milestone name drift across 8 repos | High if unmitigated | Hard dependency on `make milestones-sync` sibling task. Do not start Phase 2.2 without it. |
+| Hub project item cap (~1200) | Low at current scale | ~400 open issues now; monitor; partitioning strategy out of scope. |
+| Multi-repo dual-write coordination | Medium | Sequencing: `roxabi-plugins` first → `lyra` pilot → 6 remaining in parallel. Per-repo rollout is independent. |
+
+---
+
+## Phase sequencing and exit gates
+
+```
+Phase 0 (Discoverability)
+  → exit: 3 SKILL.md files link the taxonomy SSoT
+  → independent; can land before or during Phase 1
+Phase 1 (Bootstrap)
+  → exit: hub project + 10 types confirmed; sub-spike 1.7 resolved
+Phase 2 (Enrollment)
+  → blocked by: milestones-sync sibling task
+  → exit: 8 repos enrolled; milestone seed verified
+Phase 3 (Dual-write)
+  → exit: all 8 repos writing to hub for ≥7 days; zero label/field divergence
+Phase 4 (Backfill)
+  → exit: dry-run shows 0 mutations; flagged.txt resolved
+Phase 5 (Title rewrite)
+  → exit: zero open issues with prefix in title; snapshot PR merged
+Phase 6 (Cutover)
+  → exit: dep-graph + issues CLI read from hub; labels deleted; smoke test passes
+Phase 7 (Guardrail)
+  → exit: audit exits 0 on clean state; exits 1 on null field
+```
+
+---
+
+## Acceptance criteria
+
+- [ ] Taxonomy SSoT linked from `issue-triage`, `github-setup`, and `issues` SKILL.md (Phase 0).
+- [ ] `Roxabi Hub` project exists with Lane (20 opts), Priority (4 opts), Size (3 opts), Status (5 opts built-in).
+- [ ] 10 Issue Types active on Roxabi org; `Task` disabled; `Bug→fix`, `Feature→feat` renamed; assignments preserved (verified by sub-spike 1.7).
+- [ ] 8 repos enrolled with auto-add workflow; consistent milestones seeded (via milestones-sync sibling).
+- [ ] Backfill dry-run returns 0 mutations needed before cutover proceeds.
+- [ ] Zero open issues with conventional-commit prefix in title across 8 repos.
+- [ ] `make dep-graph build` renders correctly from hub project data.
+- [ ] `make issues` table shows all fields (no nulls) for all open issues.
+- [ ] Zero `graph:*` or `size:*` labels remaining in any of the 8 repos.
+- [ ] `make dep-graph audit` exits 1 on null field; exits 0 on clean state.
+- [ ] `dev-core:issue-triage` writes no taxonomy labels post-cutover; writes hub project fields + issueType on every triage.
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| Issue with no `graph:lane/*` label | Backfill: Lane left null; issue added to `flagged.txt` for manual resolution before cutover |
+| Issue with no title prefix | Backfill: issueType defaults to `chore`; flagged for review |
+| Issue already in hub project with partial fields | Backfill: fill null fields only; don't overwrite existing values |
+| Repo not enrolled when backfill runs | Skip that repo; log warning; re-run after enrollment |
+| Org-level Issue Type rename preserves assignments | Must be confirmed by sub-spike 1.7 before proceeding; if not preserved, Phase 1 plan is revised before execution |
+| `--dry-run` on title rewrite includes issue with `:` in title (not a prefix) | Regex anchored to `^<type>(\(<scope>\))?:` only — no false positives for mid-title colons |

--- a/plugins/dev-core/references/issue-taxonomy.md
+++ b/plugins/dev-core/references/issue-taxonomy.md
@@ -10,12 +10,12 @@ Single fact source for issue metadata across every Roxabi repo (`lyra`, `voiceCL
 
 | Field | GH object | Values | Scope | Reader(s) | Writer(s) |
 |---|---|---|---|---|---|
-| **Lane** | Project V2 single_select | `a` `b` `c` `d` `…` `standalone` | Hub project (spans all repos) | dep-graph · dashboard | issue-triage |
+| **Lane** | Project V2 single_select | `a1` `a2` `a3` `b` `c1` `c2` `c3` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m` `n` `o` `standalone` | Hub project (spans all repos) | dep-graph · dashboard | issue-triage |
 | **Priority** | Project V2 single_select | `P0` `P1` `P2` `P3` | Hub project | dashboard · issues | issue-triage |
 | **Size** | Project V2 single_select | `S` `F-lite` `F-full` | Hub project | dep-graph · issues | issue-triage |
 | **Status** | Project V2 built-in | `Todo` `Ready` `In Progress` `Blocked` `Done` | Hub project | dep-graph · dashboard | issue-triage · auto-derived |
 | **Milestone** | Native GH milestone | `M0` `M1` `M2` `…` | **Per-repo** (names kept consistent) | dep-graph (band headers) | issue-triage · milestones-sync |
-| **Issue Type** | Org-level native | `Bug` `Feature` `Epic` `Chore` `Research` | Org (applies to every repo) | dep-graph · dashboard | issue-triage · github-setup (org bootstrap) |
+| **Issue Type** | Org-level native | Current (pre-Phase 1): `Bug` `Feature` `Epic` `Chore` `Research` → Target (post-Phase 1): `feat` `fix` `refactor` `docs` `test` `chore` `ci` `perf` `epic` `research` | Org (applies to every repo) | dep-graph · dashboard | issue-triage · github-setup (org bootstrap) |
 | **Assignees** | Native | users | Repo (GH native) | dashboard | manual · issue-triage |
 
 **Native relations (no field needed):**
@@ -74,10 +74,12 @@ Single fact source for issue metadata across every Roxabi repo (`lyra`, `voiceCL
 - **Inputs:** user triage prompt + issue context
 - **Mutates:** GH Project V2 items (field values) + native issue fields + native relations
 - **Never writes:** raw labels for taxonomy (domain tags only)
+- **Phase 3 dual-write override:** during dual-write, also writes `graph:lane/*`, `size:*`, and Conventional Commits title prefix alongside hub fields.
+- "Never writes labels for taxonomy" is the **post-Phase 6** invariant; pre-cutover, the override above applies.
 
 ### `dev-core:github-setup`
 - **One-shot org bootstrap:**
-  - Create/verify org-level Issue Types (Bug/Feature/Epic/Chore/Research)
+  - Create/verify org-level Issue Types (post-Phase 1 target set: feat/fix/refactor/docs/test/chore/ci/perf/epic/research — pre-migration names Bug/Feature/Chore/Research get renamed; Epic retained as-is)
   - Create/verify hub Project V2 + 4 custom fields (Lane/Priority/Size + Status options)
 - **Per-repo bootstrap (opt-in flag `--hub-enroll`):**
   - Add repo to hub project via auto-add workflow
@@ -116,6 +118,7 @@ Shape verified end-to-end by spike on `Roxabi/lyra#717` in hub project #23 (2026
 Fact source for the migration spec. Do not execute from this doc.
 
 ```
+0. Publish SSoT + link from consumer SKILL.md files    (discoverability)
 1. Create hub project + fields + Issue Types           (setup)
 2. Dual-write: issue-triage writes labels AND fields   (safety window)
 3. Backfill: script label → field per repo             (migrate data)
@@ -134,4 +137,5 @@ Fact source for the migration spec. Do not execute from this doc.
 - ❌ Using a custom "Phase" field **and** milestones — pick one (milestones win)
 - ❌ Setting `Lane` via label — the field is the fact source
 - ❌ `dev-core:github-setup` auto-enrolling every new org repo — opt-in only
-- ❌ Reading field values without caching — preview APIs, cache to `gh.json` / `corpus.db`
+- ❌ Reading field values without caching — always populate `gh.json` (dep-graph) / `corpus.db` (corpus) first
+- ❌ Using preview APIs in the hot read path — all fields consumed by dep-graph and `dev-core:issues` must be GA

--- a/plugins/dev-core/references/issue-taxonomy.md
+++ b/plugins/dev-core/references/issue-taxonomy.md
@@ -1,0 +1,137 @@
+# Issue Taxonomy — Roxabi SSoT
+
+Single fact source for issue metadata across every Roxabi repo (`lyra`, `voiceCLI`, `roxabi-vault`, `imageCLI`, `roxabi-forge`, `roxabi-intel`, `roxabi-idna`, `roxabi-plugins`).
+
+**Who reads this:** `dev-core:issue-triage` · `dev-core:github-setup` · `dev-core:issues` · `lyra/scripts/dep-graph` · `lyra/scripts/corpus` · future `roxabi-dashboard`.
+
+---
+
+## 1. Field set
+
+| Field | GH object | Values | Scope | Reader(s) | Writer(s) |
+|---|---|---|---|---|---|
+| **Lane** | Project V2 single_select | `a` `b` `c` `d` `…` `standalone` | Hub project (spans all repos) | dep-graph · dashboard | issue-triage |
+| **Priority** | Project V2 single_select | `P0` `P1` `P2` `P3` | Hub project | dashboard · issues | issue-triage |
+| **Size** | Project V2 single_select | `S` `F-lite` `F-full` | Hub project | dep-graph · issues | issue-triage |
+| **Status** | Project V2 built-in | `Todo` `Ready` `In Progress` `Blocked` `Done` | Hub project | dep-graph · dashboard | issue-triage · auto-derived |
+| **Milestone** | Native GH milestone | `M0` `M1` `M2` `…` | **Per-repo** (names kept consistent) | dep-graph (band headers) | issue-triage · milestones-sync |
+| **Issue Type** | Org-level native | `Bug` `Feature` `Epic` `Chore` `Research` | Org (applies to every repo) | dep-graph · dashboard | issue-triage · github-setup (org bootstrap) |
+| **Assignees** | Native | users | Repo (GH native) | dashboard | manual · issue-triage |
+
+**Native relations (no field needed):**
+- **Sub-issues** — parent/child, cross-org since 2025-09 · REST `…/sub_issues` · `…/parent`
+- **blocked_by / blocking** — cross-repo, public preview · REST `…/dependencies/*`
+
+---
+
+## 2. Cross-repo behavior
+
+| Field | Cross-repo? | Consequence |
+|---|---|---|
+| Lane · Priority · Size · Status | ✅ one hub project | set once, read everywhere |
+| Issue Type | ✅ org-level | defined once, every repo inherits |
+| Milestone | ❌ per-repo | `M3` must exist in every repo; keep names consistent; `make milestones-sync` helper bootstraps |
+| Assignees | ❌ per-repo | no cross-repo user list, but user identity is org-wide |
+| Sub-issues | ✅ cross-org | |
+| blocked_by / blocking | ✅ cross-repo | `addBlockedBy` hits EMU restrictions cross-org; not a concern for Roxabi |
+
+---
+
+## 3. What was removed
+
+| Removed | Replaced by | Reason |
+|---|---|---|
+| Label `graph:lane/*` | `Lane` project field | mutable, driftable, per-repo namespace |
+| Label `size:*` | `Size` project field | same |
+| Label `graph:standalone` | `Lane = standalone` option | one fact, one place |
+| Label `graph:defer` | Bump `Milestone` to later `M*` | "defer" was scheduling in disguise |
+| `layout.json meta.label_prefix` | — | no label discovery anymore |
+| `layout.json lanes[].epic` (lane-defining) | Lanes are field-defined; epics are issues with sub-issues | epic no longer anchors a lane |
+| Label-drift audit (`make dep-graph audit`) | **Repurpose** to validate project-field coverage | no labels to audit |
+
+**Kept as domain tags (per-repo, unchanged):** `deploy` · `ci` · `security` · `docs` · `performance` · etc. These are technical domain markers, not taxonomy.
+
+---
+
+## 4. Disambiguation
+
+| Word | Meaning |
+|---|---|
+| `lane` (lowercase, layout.json key) | Dep-graph swim-lane grouping, `lanes[]` array in layout |
+| `Lane` (Titlecase) | The GH Project V2 custom field — the SSoT for lane assignment |
+| "swim-lane" | The rendered visual concept in dep-graph HTML |
+| `epic` (lowercase, layout.json deprecated) | Old lane-anchor slot — **gone** post-migration |
+| `Epic` (Titlecase) | GH org-level Issue Type; any issue with sub-issues marked as such |
+| `Milestone` (GH native) | The field used for roadmap phase bands on dep-graph |
+| `Phase` | Not used. If you hear "phase", they mean Milestone. |
+
+---
+
+## 5. Plugin contracts
+
+### `dev-core:issue-triage`
+- **Writes:** Lane · Priority · Size · Status · Milestone · Issue Type · Assignees · sub-issue parent · blocked_by
+- **Inputs:** user triage prompt + issue context
+- **Mutates:** GH Project V2 items (field values) + native issue fields + native relations
+- **Never writes:** raw labels for taxonomy (domain tags only)
+
+### `dev-core:github-setup`
+- **One-shot org bootstrap:**
+  - Create/verify org-level Issue Types (Bug/Feature/Epic/Chore/Research)
+  - Create/verify hub Project V2 + 4 custom fields (Lane/Priority/Size + Status options)
+- **Per-repo bootstrap (opt-in flag `--hub-enroll`):**
+  - Add repo to hub project via auto-add workflow
+  - Seed milestones (`M0…MN`) with consistent names
+  - Does **not** auto-enroll experimental or archived repos
+
+### `dev-core:issues` (and `dep-graph`)
+- **Reads:** single paginated GraphQL query on `organization.projectV2.items` — one call hydrates `fieldValues` (Lane/Priority/Size/Status), `content.milestone`, `content.blockedBy`, `content.blocking`, `content.parent`, `content.subIssues`, `content.issueType`. All fields GA — no preview APIs in the hot path.
+- **Caches:** `gh.json` (dep-graph) / `~/.roxabi/corpus.db` (corpus)
+- **Fallback:** if hub project API fails, render last good cache with a stale-banner
+
+---
+
+## 6. dep-graph fetch contract
+
+**One paginated GraphQL query** on `organization.projectV2.items` hydrates every fact. No REST fan-out, no preview APIs.
+
+| Fact | Path in GraphQL response |
+|---|---|
+| **Discovery** | `organization.projectV2(number: N).items.nodes[]` (paginated) |
+| **Lane / Priority / Size** | `item.fieldValues.nodes` → `ProjectV2ItemFieldSingleSelectValue.field.name + .name` |
+| **Status** | same node type, `field.name == "Status"`; auto-derived from issue state (CLOSED → Done) |
+| **Milestone / band headers** | `item.content.milestone.title` |
+| **Edges (blocked_by/blocking)** | `item.content.blockedBy.nodes[]` + `item.content.blocking.nodes[]` — each node carries `repository.nameWithOwner`, cross-repo native |
+| **Parent/child** | `item.content.parent` + `item.content.subIssues.nodes[]` |
+| **Epic marker** | `item.content.issueType.name == "Epic"` |
+
+Shape verified end-to-end by spike on `Roxabi/lyra#717` in hub project #23 (2026-04-21). Keep `gh.json` as a versioned cache for rate-limit resilience and offline render, shape-assert first non-empty response, fail fast on schema mismatch.
+
+**Superseded REST paths** (no longer needed): `/repos/{r}/issues/{n}` per issue · `/repos/{r}/issues/{n}/dependencies/blocked_by` · `/repos/{r}/issues/{n}/dependencies/blocking` · `gh issue list --label graph:lane/*`.
+
+---
+
+## 7. Migration order (reference)
+
+Fact source for the migration spec. Do not execute from this doc.
+
+```
+1. Create hub project + fields + Issue Types           (setup)
+2. Dual-write: issue-triage writes labels AND fields   (safety window)
+3. Backfill: script label → field per repo             (migrate data)
+4. Flip dep-graph fetch to read fields                 (cutover)
+5. Stop writing labels; drop graph:* labels per repo   (cleanup)
+6. Repurpose audit to validate field coverage          (guardrail)
+7. Roll out to new repos via --hub-enroll              (default)
+```
+
+---
+
+## 8. Anti-patterns
+
+- ❌ Creating a new `graph:*` label for taxonomy — use a project field
+- ❌ Using GH milestone for "cross-repo roadmap phase" without sync — milestones are per-repo
+- ❌ Using a custom "Phase" field **and** milestones — pick one (milestones win)
+- ❌ Setting `Lane` via label — the field is the fact source
+- ❌ `dev-core:github-setup` auto-enrolling every new org repo — opt-in only
+- ❌ Reading field values without caching — preview APIs, cache to `gh.json` / `corpus.db`

--- a/plugins/dev-core/skills/github-setup/SKILL.md
+++ b/plugins/dev-core/skills/github-setup/SKILL.md
@@ -232,4 +232,8 @@ Next: run /ci-setup to configure GitHub Actions and pre-commit hooks.
 4. **Never store secrets in `.env.example`** — use empty placeholder values
 5. **Idempotent** — safe to re-run, merges rather than overwrites
 
+## Related
+
+- Taxonomy SSoT → `plugins/dev-core/references/issue-taxonomy.md` — field set, cross-repo behavior, org-bootstrap contract for hub project + Issue Types
+
 $ARGUMENTS

--- a/plugins/dev-core/skills/github-setup/SKILL.md
+++ b/plugins/dev-core/skills/github-setup/SKILL.md
@@ -234,6 +234,6 @@ Next: run /ci-setup to configure GitHub Actions and pre-commit hooks.
 
 ## Related
 
-- Taxonomy SSoT → `plugins/dev-core/references/issue-taxonomy.md` — field set, cross-repo behavior, org-bootstrap contract for hub project + Issue Types
+- [Taxonomy SSoT](../../references/issue-taxonomy.md) — field set, cross-repo behavior, org-bootstrap contract for hub project + Issue Types
 
 $ARGUMENTS

--- a/plugins/dev-core/skills/issue-triage/SKILL.md
+++ b/plugins/dev-core/skills/issue-triage/SKILL.md
@@ -191,6 +191,6 @@ Run `/init` to auto-detect and populate env vars. Field operations (status, size
 
 ## Related
 
-- Taxonomy SSoT → `plugins/dev-core/references/issue-taxonomy.md` — field set, cross-repo behavior, plugin contracts, anti-patterns
+- [Taxonomy SSoT](../../references/issue-taxonomy.md) — field set, cross-repo behavior, plugin contracts, anti-patterns
 
 $ARGUMENTS

--- a/plugins/dev-core/skills/issue-triage/SKILL.md
+++ b/plugins/dev-core/skills/issue-triage/SKILL.md
@@ -189,4 +189,8 @@ Run `/init` to auto-detect and populate env vars. Field operations (status, size
 | `SIZE_OPTIONS_JSON` | JSON map size names → option IDs | ✅ field updates |
 | `PRIORITY_OPTIONS_JSON` | JSON map priority names → option IDs | ✅ field updates |
 
+## Related
+
+- Taxonomy SSoT → `plugins/dev-core/references/issue-taxonomy.md` — field set, cross-repo behavior, plugin contracts, anti-patterns
+
 $ARGUMENTS

--- a/plugins/dev-core/skills/issues/SKILL.md
+++ b/plugins/dev-core/skills/issues/SKILL.md
@@ -169,6 +169,6 @@ Dep view only. Modify → `/issue-triage`.
 
 ## Related
 
-- Taxonomy SSoT → `plugins/dev-core/references/issue-taxonomy.md` — GraphQL fetch contract, field/Issue-Type reader conventions
+- [Taxonomy SSoT](../../references/issue-taxonomy.md) — GraphQL fetch contract, field/Issue-Type reader conventions
 
 $ARGUMENTS

--- a/plugins/dev-core/skills/issues/SKILL.md
+++ b/plugins/dev-core/skills/issues/SKILL.md
@@ -167,4 +167,8 @@ Dep view only. Modify → `/issue-triage`.
 - `GH_PROJECT_ID` — GitHub Project V2 ID (**required**)
 - `GITHUB_REPO` — `owner/repo` (auto-detected)
 
+## Related
+
+- Taxonomy SSoT → `plugins/dev-core/references/issue-taxonomy.md` — GraphQL fetch contract, field/Issue-Type reader conventions
+
 $ARGUMENTS


### PR DESCRIPTION
## Summary
- Publish the taxonomy SSoT at `plugins/dev-core/references/issue-taxonomy.md` — field set, cross-repo behavior, plugin contracts, dep-graph fetch contract, anti-patterns
- Cross-link the SSoT from `issue-triage`, `github-setup`, and `issues` SKILL.md files via new `## Related` sections
- Seed the migration spec at `artifacts/specs/119-issue-taxonomy-migration-spec.mdx` (approved, 8-phase plan with rollback semantics)
- Split Roxabi/roxabi-plugins#119 into 3 rollback-boundary children: Roxabi/roxabi-plugins#120 (bootstrap+enrollment), Roxabi/roxabi-plugins#121 (dual-write+migration), Roxabi/roxabi-dashboard#48 (cutover+guardrail), with a→b→c blocked-by chain

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | Roxabi/roxabi-plugins#119 | OPEN (parent — stays open until Roxabi/roxabi-plugins#120/#121/#122 complete) |
| Spec | [119-issue-taxonomy-migration-spec.mdx](artifacts/specs/119-issue-taxonomy-migration-spec.mdx) | Present |
| Plan | [119-issue-taxonomy-migration-plan.mdx](artifacts/plans/119-issue-taxonomy-migration-plan.mdx) | Present (V0 slice — phase 0 only) |
| Implementation | 1 commit on `feat/119-issue-taxonomy-migration` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (372/372, 0 new — docs-only slice) | Passed |

## Scope (V0 only)

This PR delivers **Phase 0 Discoverability** of the 8-phase migration. No API calls, no schema mutations, no code changes — pure documentation + issue graph seeding.

Remaining phases ship under:
- **#120** — Phases 1+2 (hub project + field bootstrap, opt-in repo enrollment)
- **#121** — Phases 3+4+5 (dual-write safety window, label→field backfill, conventional-commit title rewrite)
- **#122** — Phases 6+7 (dep-graph fetch cutover, repurposed field-coverage guardrail)

## Test Plan
- [ ] SSoT reference renders correctly on GitHub (tables, `## Related` links resolve)
- [ ] grep -l references/issue-taxonomy.md plugins/dev-core/skills/{issue-triage,github-setup,issues}/SKILL.md returns all 3 paths
- [ ] gh api graphql repository.issue(119).subIssues returns Roxabi/roxabi-plugins#120, Roxabi/roxabi-plugins#121, Roxabi/roxabi-dashboard#48
- [ ] No behavioral change expected — skill/script outputs are identical pre/post

Ref Roxabi/roxabi-plugins#119 (V0 slice — do **not** auto-close; parent tracks Roxabi/roxabi-plugins#120/#121/#122 completion)

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`