### PR TITLE
fix(dev-core): #125 hub-enroll pushes workflow to repo's default branch

### DIFF
--- a/artifacts/analyses/125-review-findings-disposition-consensus.mdx
+++ b/artifacts/analyses/125-review-findings-disposition-consensus.mdx
@@ -1,0 +1,69 @@
+---
+title: "PR #126 Review Findings Disposition — Expert Consensus"
+issue: 125
+status: consensus-reached
+date: 2026-04-22
+panel: architect, backend-dev, tester
+confidence: high
+---
+
+## Problem
+
+PR #126 fixes the `hub-enroll` default-branch bug (#125). Code review produced 4 findings across 3 agents. No blockers, CI green. Question: which findings to fix inline vs. defer to follow-up issues.
+
+## Panel
+
+| α | Focus |
+|---|-------|
+| architect | arch soundness, root-cause policy |
+| backend-dev | API design, scope discipline |
+| tester | test quality, coverage gaps |
+
+## Findings
+
+| # | Label | Source | Summary | C |
+|---|-------|--------|---------|---|
+| 1 | issue | backend-dev | `pushWorkflows` / `pushGenericWorkflows` still default `branch='main'` — same latent bug one level up | 85% |
+| 2 | issue | tester | Test mock dispatches on `query.includes('defaultBranchRef')` — fragile | 70% |
+| 3 | suggestion | tester | Redundant `state.defaultBranch = 'staging'` + misleading comment in test 1 | 60% |
+| 4 | suggestion | tester | Missing `repository: null` test case | 50% |
+
+## Consensus ρ
+
+**Option A — Apply #1 + #3 inline, defer #2 + #4 to follow-up issues.**
+
+### Rationale
+
+- **#1 shares the exact root cause the PR was opened to fix.** Leaving two sibling callers with the same silent-failure pattern violates the "fix the class, not the instance" policy. Cost: ~2 lines + minor test touch.
+- **#3 is zero-risk cleanup** (redundant assignment, misleading comment). Trivial; deferring creates tech debt.
+- **#2 is a test-infra decision** (stub at transport layer vs. query constants) with cross-file impact — deserves its own issue.
+- **#4 is additive coverage**, not a regression guard for this fix — belongs in a follow-up.
+
+### Trade-offs
+
+- Slight scope expansion over strict S-tier minimum (3 files → 3 files, but 2 extra lines).
+- Adds a `getRepoDefaultBranch`-equivalent call to `pushWorkflows` / `pushGenericWorkflows` call path (or pushes resolution responsibility up to their callers).
+- Two follow-up issues to track (minor admin cost).
+
+## Alternatives
+
+| ω | Rejected because |
+|---|------------------|
+| B — Apply all 4 inline | #2 is a test-architecture decision (not mechanical); #4 adds behavior coverage outside fix scope. Both expand review surface. |
+| C — Apply #3 only | Leaves #1 (2-line root-cause recurrence) open — violates policy. |
+| D — Merge as-is | Same as C plus leaves #3 noise. No upside. |
+
+## Dissent
+
+None — unanimous.
+
+## Implementation Notes
+
+1. **#1 fix:** Remove `branch = 'main'` defaults from `pushWorkflows` and `pushGenericWorkflows`. Require callers to pass `branch` explicitly. Audit the 2 internal call sites — if any, swap to resolved default branch via `getRepoDefaultBranch` (could be hoisted to a shared helper or re-exported from `hub-enroll`). No external callers exist.
+2. **#3 fix:** Delete the redundant `state.defaultBranch = 'staging'` assignment and the misleading comment in the "detected default branch" test.
+3. **#2 follow-up:** File issue — "Refactor hub-enroll.test.ts mock dispatch to use query constants or typed request stubs."
+4. **#4 follow-up:** File issue — "Add `repository: null` (missing-repo) test case to `getRepoDefaultBranch`."
+
+## Next
+
+Apply #1 + #3 inline (in current PR #126), then file follow-up issues for #2 + #4. Re-review minimal (mechanical changes only), then merge.

--- a/plugins/dev-core/skills/init/__tests__/hub-enroll.test.ts
+++ b/plugins/dev-core/skills/init/__tests__/hub-enroll.test.ts
@@ -215,9 +215,6 @@ describe('hub-enroll', () => {
     })
 
     it("pushes the workflow to the repo's detected default branch (not hardcoded 'main')", async () => {
-      // Arrange — repo default branch is 'staging' (set by beforeEach)
-      state.defaultBranch = 'staging'
-
       // Act
       await enrollRepo({
         org: 'Roxabi',

--- a/plugins/dev-core/skills/init/__tests__/hub-enroll.test.ts
+++ b/plugins/dev-core/skills/init/__tests__/hub-enroll.test.ts
@@ -13,10 +13,12 @@ const state: {
   issueTypes: Array<{ id: string; name: string; color: string; isEnabled: boolean }>
   milestonesMissing: string[]
   testIssueInHub: boolean
+  defaultBranch: string | null
 } = {
   issueTypes: [],
   milestonesMissing: [],
   testIssueInHub: true,
+  defaultBranch: 'staging',
 }
 
 // All 10 required issue type names
@@ -28,6 +30,16 @@ const ALL_TEN_ISSUE_TYPES = ['fix', 'feat', 'docs', 'test', 'chore', 'ci', 'perf
 
 vi.mock('../../shared/adapters/github-adapter', () => ({
   ghGraphQL: vi.fn(async (query: string, _vars: Record<string, unknown>) => {
+    // default branch query
+    if (query.includes('defaultBranchRef')) {
+      return {
+        data: {
+          repository: state.defaultBranch
+            ? { defaultBranchRef: { name: state.defaultBranch } }
+            : { defaultBranchRef: null },
+        },
+      }
+    }
     // milestone query
     if (query.includes('milestone')) {
       const ALL_MILESTONES = ['M0', 'M1', 'M2']
@@ -102,6 +114,7 @@ beforeEach(() => {
   }))
   state.milestonesMissing = []
   state.testIssueInHub = true
+  state.defaultBranch = 'staging'
   vi.clearAllMocks()
 })
 
@@ -199,6 +212,62 @@ describe('hub-enroll', () => {
         milestonesMissing: [],
         verified: true,
       })
+    })
+
+    it("pushes the workflow to the repo's detected default branch (not hardcoded 'main')", async () => {
+      // Arrange — repo default branch is 'staging' (set by beforeEach)
+      state.defaultBranch = 'staging'
+
+      // Act
+      await enrollRepo({
+        org: 'Roxabi',
+        repo: 'test-repo',
+        projectUrl: 'https://github.com/orgs/Roxabi/projects/42',
+        projectId: 'PVT_test42',
+      })
+
+      // Assert — pushWorkflowFile called with branch: 'staging'
+      expect(pushWorkflowMock).toHaveBeenCalledWith(
+        'Roxabi',
+        'test-repo',
+        '.github/workflows/hub-add.yml',
+        expect.any(String),
+        expect.objectContaining({ branch: 'staging' }),
+      )
+    })
+
+    it('threads non-standard default branches (e.g. trunk) through to pushWorkflowFile', async () => {
+      state.defaultBranch = 'trunk'
+
+      await enrollRepo({
+        org: 'Roxabi',
+        repo: 'weird-repo',
+        projectUrl: 'https://github.com/orgs/Roxabi/projects/42',
+        projectId: 'PVT_test42',
+      })
+
+      expect(pushWorkflowMock).toHaveBeenCalledWith(
+        'Roxabi',
+        'weird-repo',
+        '.github/workflows/hub-add.yml',
+        expect.any(String),
+        expect.objectContaining({ branch: 'trunk' }),
+      )
+    })
+
+    it('throws when default branch cannot be resolved', async () => {
+      state.defaultBranch = null
+
+      await expect(
+        enrollRepo({
+          org: 'Roxabi',
+          repo: 'ghost-repo',
+          projectUrl: 'https://github.com/orgs/Roxabi/projects/42',
+          projectId: 'PVT_test42',
+        }),
+      ).rejects.toThrow(/default branch/i)
+
+      expect(pushWorkflowMock).not.toHaveBeenCalled()
     })
 
     it('dry-run emits planned actions without executing', async () => {

--- a/plugins/dev-core/skills/init/lib/hub-enroll.ts
+++ b/plugins/dev-core/skills/init/lib/hub-enroll.ts
@@ -9,8 +9,19 @@
  */
 
 import { ghGraphQL, listOrgIssueTypes } from '../../shared/adapters/github-adapter'
-import { MILESTONE_QUERY, VERIFY_PROJECT_ITEMS_QUERY } from '../../shared/queries'
+import { MILESTONE_QUERY, REPO_DEFAULT_BRANCH_QUERY, VERIFY_PROJECT_ITEMS_QUERY } from '../../shared/queries'
 import { generateAutoAddToProjectYml, pushWorkflowFile } from './workflows'
+
+async function getRepoDefaultBranch(owner: string, repo: string): Promise<string> {
+  const res = (await ghGraphQL(REPO_DEFAULT_BRANCH_QUERY, { owner, repo })) as {
+    data?: { repository?: { defaultBranchRef?: { name?: string } | null } | null }
+  }
+  const name = res?.data?.repository?.defaultBranchRef?.name
+  if (!name) {
+    throw new Error(`Unable to resolve default branch for ${owner}/${repo}`)
+  }
+  return name
+}
 
 export interface EnrollResult {
   enrolled: boolean
@@ -58,8 +69,13 @@ export async function enrollRepo(opts: {
     return { enrolled: true, dryRun: true, milestonesMissing: [], verified: false }
   }
 
-  // Step 3: Push auto-add workflow (idempotent create-or-update)
-  await pushWorkflowFile(org, repo, '.github/workflows/hub-add.yml', generateAutoAddToProjectYml(projectUrl))
+  // Step 3: Push auto-add workflow (idempotent create-or-update) to the repo's default branch.
+  // GitHub Actions reads issue-scoped workflows from the default branch only — pushing to any
+  // other branch is a silent failure.
+  const defaultBranch = await getRepoDefaultBranch(org, repo)
+  await pushWorkflowFile(org, repo, '.github/workflows/hub-add.yml', generateAutoAddToProjectYml(projectUrl), {
+    branch: defaultBranch,
+  })
 
   // Step 4: Check milestones M0/M1/M2 — warn only, no mutation
   const milestonesResult = (await ghGraphQL(MILESTONE_QUERY, { owner: org, repo })) as {

--- a/plugins/dev-core/skills/init/lib/workflows.ts
+++ b/plugins/dev-core/skills/init/lib/workflows.ts
@@ -306,10 +306,10 @@ export async function pushWorkflowFile(
   repo: string,
   path: string,
   content: string,
-  opts?: { message?: string; branch?: string },
+  opts: { branch: string; message?: string },
 ): Promise<'created' | 'updated'> {
   const token = await getToken()
-  const branch = opts?.branch ?? 'main'
+  const { branch } = opts
   const b64 = Buffer.from(content).toString('base64')
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`
   const headers: Record<string, string> = {

--- a/plugins/dev-core/skills/init/lib/workflows.ts
+++ b/plugins/dev-core/skills/init/lib/workflows.ts
@@ -352,7 +352,7 @@ export async function pushWorkflows(
   owner: string,
   repo: string,
   opts: WorkflowOpts,
-  branch = 'main',
+  branch: string,
 ): Promise<PushResult[]> {
   const files: Array<{ name: string; content: string }> = [
     { name: 'auto-merge.yml', content: generateAutoMergeYml() },
@@ -372,7 +372,7 @@ export async function pushWorkflows(
 }
 
 /** Push a specific subset of workflow files (e.g. only the generic ones). */
-export async function pushGenericWorkflows(owner: string, repo: string, branch = 'main'): Promise<PushResult[]> {
+export async function pushGenericWorkflows(owner: string, repo: string, branch: string): Promise<PushResult[]> {
   const files = [
     { name: 'auto-merge.yml', content: generateAutoMergeYml() },
     { name: 'pr-title.yml', content: generatePrTitleYml() },

--- a/plugins/dev-core/skills/shared/queries.ts
+++ b/plugins/dev-core/skills/shared/queries.ts
@@ -385,6 +385,15 @@ export const MILESTONE_QUERY = `
   }
 `
 
+/** Fetch a repository's default branch name. */
+export const REPO_DEFAULT_BRANCH_QUERY = `
+  query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+      defaultBranchRef { name }
+    }
+  }
+`
+
 /** Lightweight probe: fetch first item of a ProjectV2 node. */
 export const VERIFY_PROJECT_ITEMS_QUERY = `
   # projectV2 item probe


### PR DESCRIPTION
## Summary

Resolves the repo's default branch via GraphQL and threads it to `pushWorkflowFile`, removing the hardcoded `'main'` fallback. Closes #125.

## Root cause

\`pushWorkflowFile\` defaulted \`branch\` to \`'main'\` when \`opts.branch\` was omitted. \`hub-enroll\` never passed one → workflow always landed on \`main\`. Issue-scoped GitHub Actions workflows read only from the default branch, so any \`staging\`-default repo in the org silently failed activation (surfaced during T17 pilot on \`roxabi-plugins\` + \`lyra\`).

## Changes

- \`queries.ts\`: add \`REPO_DEFAULT_BRANCH_QUERY\`.
- \`hub-enroll.ts\`: \`getRepoDefaultBranch()\` helper → resolve default branch → pass to \`pushWorkflowFile\`.
- \`workflows.ts\`: \`pushWorkflowFile.opts.branch\` is now required (no \`'main'\` fallback). Other callers already pass \`branch\` explicitly.
- Tests: 3 new cases (staging default, trunk default, unresolvable branch throws).

## Test Plan
- [x] \`bun run lint\` ✓
- [x] \`bun run typecheck\` ✓
- [x] \`bun run test\` — 400 passed (8 for hub-enroll)
- [ ] Manual re-enrollment of a \`staging\`-default repo → workflow lands on \`staging\`, not \`main\`

Closes #125

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`