### PR TITLE
fix(dev-core): #116 backport quality-gate shell fixes (macOS bash compat + awk exemption)

### DIFF
--- a/plugins/dev-core/tools/check_file_length.sh
+++ b/plugins/dev-core/tools/check_file_length.sh
@@ -25,9 +25,10 @@ fi
 
 is_exempt() {
     [ ! -f "$EXEMPT_FILE" ] && return 1
-    # grep -F (fixed-string): path may contain regex metacharacters (., *, [, +).
-    # Exemption format: '<path> <issue-url>' — trailing space anchors the path.
-    grep -qF -- "$1 " "$EXEMPT_FILE"
+    # Exact match on the first whitespace-delimited field — no regex, no escaping,
+    # left-anchored (awk field split) so a path substring elsewhere on the line
+    # cannot cause a false positive. Exemption format: '<path> <issue-url>'.
+    awk -v p="$1" '$1 == p { found = 1 } END { exit !found }' "$EXEMPT_FILE"
 }
 
 while IFS= read -r -d '' f; do

--- a/plugins/dev-core/tools/check_folder_size.sh
+++ b/plugins/dev-core/tools/check_folder_size.sh
@@ -24,16 +24,19 @@ fi
 
 is_exempt() {
     [ ! -f "$EXEMPT_FILE" ] && return 1
-    # grep -F (fixed-string): path may contain regex metacharacters (., *, [, +).
-    # Exemption format: '<path> <issue-url>' — trailing space anchors the path.
-    grep -qF -- "$1 " "$EXEMPT_FILE"
+    # Exact match on the first whitespace-delimited field — no regex, no escaping,
+    # left-anchored (awk field split) so a path substring elsewhere on the line
+    # cannot cause a false positive. Exemption format: '<path> <issue-url>'.
+    awk -v p="$1" '$1 == p { found = 1 } END { exit !found }' "$EXEMPT_FILE"
 }
 
 while IFS= read -r -d '' d; do
     is_exempt "$d" && continue
-    # -print0 + mapfile keeps the array consistent with the outer loop's NUL-delimited pattern.
-    mapfile -d '' files < <(find "$d" -maxdepth 1 -name "*.py" -type f -print0)
-    COUNT=${#files[@]}
+    # Portable NUL-delimited count — works on macOS bash 3.2 (no mapfile/readarray).
+    COUNT=0
+    while IFS= read -r -d '' _; do
+        COUNT=$((COUNT + 1))
+    done < <(find "$d" -maxdepth 1 -name "*.py" -type f -print0)
     if [ "$COUNT" -gt "$MAX" ]; then
         echo "$d - $COUNT files (max $MAX)"
         FAIL=1


### PR DESCRIPTION
## Summary

Backports two quality-gate shell fixes from [voiceCLI PR #84](https://github.com/Roxabi/voiceCLI/pull/84) (closes voiceCLI#79) into the canonical `plugins/dev-core/tools/` sources. Without these, the next `/release-setup --force` on any consumer repo would silently re-introduce the bugs.

## Fix 1 — macOS bash 3.2 compat (`check_folder_size.sh`)

Replace `mapfile -d ''` (bash ≥4.4) with a portable `while IFS= read -r -d '' _; do COUNT=$((COUNT+1)); done` counter. macOS ships bash 3.2.57 (GPLv2, frozen), so contributors without Homebrew bash hit `bash: mapfile: command not found` under `set -euo pipefail`.

## Fix 2 — left-anchored exemption match (both scripts)

Replace `grep -qF -- "$1 " "$EXEMPT_FILE"` with `awk -v p="$1" '$1 == p { found = 1 } END { exit !found }'`. Exact match on the first whitespace-delimited field — no regex, no escaping, left-anchored by definition. Closes the theoretical false-positive where an exemption line containing a path substring with trailing space could match unrelated paths (security-auditor flagged at 62% confidence on voiceCLI #79).

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] Smoke test on isolated repo: 3 .py files, max=2 — exempt path passes, non-exempt fails with correct count
- [ ] CI green
- [ ] After merge: cut release so consumer repos can `/release-setup --force` to pull the fixes

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)