### PR TITLE
refactor(dev-core): #121 hub taxonomy migration — soak + backfill + rewrite (Shape B)

### DIFF
--- a/artifacts/frames/121-dual-write-migration-frame.mdx
+++ b/artifacts/frames/121-dual-write-migration-frame.mdx
@@ -1,0 +1,57 @@
+---
+title: "Dual-write + migration — phases 3+4+5 of taxonomy migration"
+issue: 121
+status: approved
+tier: F-full
+date: 2026-04-22
+---
+
+## Problem
+
+Phase 0 (SSoT publish — PR #123) and Phases 1+2 (hub project + repo enrollment — PR #124) shipped the plumbing. Issues across the 8 enrolled repos are still triaged via the legacy scheme: `graph:lane/*` + `size:*` labels and conventional-commit title prefixes. The hub project exists but is empty of field values, and `dev-core:issue-triage` does not yet write to it.
+
+Until dual-write lands, every triage operation widens the divergence between legacy and new state — making backfill harder and increasing rollback cost. Phases 3+4+5 close that gap end-to-end:
+
+- **Phase 3 — Dual-write:** `issue-triage` writes both legacy labels AND project fields + `issueType` for ≥7 days of triage activity. Safety window so backfill/cutover can be verified before legacy is dropped.
+- **Phase 4 — Backfill:** every open issue in all 8 repos has `Lane`, `Size`, `Priority`, `issueType` populated in the hub project, derived from existing labels + title prefix. Idempotent, dry-run first, snapshot-recoverable.
+- **Phase 5 — Title rewrite:** strip the conventional-commit prefix from every open issue title across all 8 repos. Issue Type now carries that signal.
+
+This slice delivers both the **code** (dual-write logic, backfill script, title-rewrite script) and the **execution** (7-day window observed, backfill applied, titles rewritten on all 8 repos). Closure of #121 = real production state matches Phase 5 exit criteria, leaving #122 cleared to run cutover + guardrail repurpose.
+
+## Who
+
+- **Primary:** Mickael (sole maintainer, runs all 8 repos) — needs triage scheme stable before cutover; depends on `dev-core:issue-triage` continuing to work during the migration.
+- **Secondary:** automated consumers — `dev-core:issues` listing, `dep-graph` (still on legacy labels until #122), CI workflows that read labels. Must not break during dual-write.
+
+## Constraints
+
+- **8-repo blast radius** — `roxabi-plugins`, `lyra`, `voiceCLI`, `2ndBrain`, `imageCLI`, `llmCLI`, `roxabi-forge`, `roxabi-intel` (the hub-enrolled set from #120).
+- **Rollout order** — `roxabi-plugins` first (owns the skill), then `lyra` pilot, then remaining 6 in parallel. Per parent spec §Phase 3.
+- **Dual-write window:** minimum **7 days of normal triage activity** after all 8 repos are writing to hub. Wall-clock waiting period — cannot be compressed.
+- **Idempotency:** backfill + title rewrite must be safe to re-run. Backfill skips issues with all 4 fields already set; title rewrite skips titles without a prefix.
+- **Reversibility:** every mutation produces a snapshot JSON. `revert_backfill.py` + manual title restore from snapshot must work end-to-end. Rollback stage 2 of the parent spec.
+- **Token scope:** current `project` scope sufficient (verified in spike 2). No `admin:org` refresh.
+- **No data loss:** legacy labels remain in place for the entire #121 slice — they are only deleted in #122 (Phase 6).
+- **Reuse over add:** prefer existing deps (`PyGithub`, `httpx`, hand-rolled GraphQL via existing helpers in `scripts/dep-graph/`) over new libraries.
+- **Dependency:** blocked by #119.a (#120 — merged). Blocks #119.c (#122).
+
+## Out of Scope
+
+- **Phase 6 cutover** — flipping `dep-graph/fetch.py` to read GraphQL, removing legacy `graph:*` and `size:*` labels org-wide, switching `issue-triage` to single-write. Belongs to #122.
+- **Phase 7 guardrail repurpose** — repurposing `make dep-graph audit` to validate field coverage. Belongs to #122.
+- **Custom Status options** — built-in Todo/In Progress/Done only. Per parent spec.
+- **Retroactive assignee backfill.**
+- **Closed issues** — backfill + title rewrite scope is open issues only.
+- **Priority backfill** — no legacy source exists for `Priority`; values left null and flagged for manual review (per parent spec Phase 4 step 5). Mickael fills priorities post-backfill manually.
+- **Per-issue manual review of `chore` defaults** — flagged.txt produced; review happens during the 7-day window, not as a code deliverable.
+
+## Complexity
+
+**Tier: F-full** — multi-domain (skill code change in `dev-core:issue-triage` + two migration scripts in `scripts/migrate/` + cross-repo execution coordination + 7-day operational window), 8-repo blast radius, requires dry-run/snapshot/rollback safety nets at each step, and end-to-end execution (not code-only).
+
+Signals observed:
+- ≥3 distinct code surfaces (issue-triage skill, backfill_taxonomy.py, rewrite_titles.py + revert_backfill.py)
+- 8-repo deployment via `sync-plugins.sh`
+- New patterns: GraphQL mutation paths in skill code (currently label-only)
+- Operational gate (7-day window) — cannot be compressed; pipeline must accommodate the wait
+- Reversibility requirements at every mutation boundary

--- a/artifacts/plans/121-dual-write-migration-plan.mdx
+++ b/artifacts/plans/121-dual-write-migration-plan.mdx
@@ -1,0 +1,213 @@
+---
+title: "Plan: dual-write + migration (#121, phases 3+4+5)"
+issue: 121
+spec: artifacts/specs/121-dual-write-migration-spec.mdx
+complexity: 7/10
+tier: F-full
+generated: 2026-04-22
+---
+
+## Summary
+
+Shape B implementation: extend `issue-triage` skill with `--lane`/`--type` write paths, then add a TS-resident `migrate` subcommand with `backfill`, `rewrite-titles`, `revert`, `audit-schema`. ~600 LOC across 9 files, 16 micro-tasks, 3 agents.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph CLI [triage.ts router]
+        SET[set]
+        MIG[migrate]
+    end
+    subgraph SET_LIB [lib/set.ts]
+        APPLY_LANE[applyLane]
+        APPLY_TYPE[applyType]
+    end
+    subgraph MIG_LIB [lib/migrate.ts - new]
+        AUDIT[auditSchema]
+        BACK[backfill]
+        REW[rewriteTitles]
+        REV[revert]
+        MAP[LEGACY_LABEL_MAP]
+        SNAP[writeSnapshot]
+    end
+    subgraph CONFIG [shared/adapters/config-helpers.ts]
+        LANE_ID[LANE_FIELD_ID]
+        LANE_OPTS[LANE_OPTIONS]
+        SIZE_OPTS[DEFAULT_SIZE_OPTIONS reconciled]
+    end
+    subgraph ADAPTER [shared/adapters/github-adapter.ts]
+        UPDATE_FIELD[updateField]
+        UPDATE_TYPE[updateIssueIssueType - new export]
+    end
+    SET --> APPLY_LANE --> UPDATE_FIELD
+    SET --> APPLY_TYPE --> UPDATE_TYPE
+    APPLY_LANE --> LANE_ID
+    APPLY_LANE --> LANE_OPTS
+    MIG --> AUDIT --> LANE_OPTS
+    MIG --> BACK --> MAP
+    BACK --> UPDATE_FIELD
+    BACK --> UPDATE_TYPE
+    BACK --> SNAP
+    MIG --> REW --> SNAP
+    MIG --> REV --> UPDATE_FIELD
+    REV --> UPDATE_TYPE
+    SNAP --> FS[(artifacts/migration/*.json)]
+    FS --> REV
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph triage[triage.ts]
+        ROUTER[router switch]
+    end
+    subgraph set[lib/set.ts]
+        PARSE[parseArgs]
+        APPLY_PF[applyProjectFields]
+        AL[applyLane - new]
+        AT[applyType - new]
+    end
+    subgraph migrate[lib/migrate.ts - new]
+        AS[auditSchema]
+        BF[backfill]
+        RT[rewriteTitles]
+        RV[revert]
+        WS[writeSnapshot]
+        LLM[LEGACY_LABEL_MAP]
+    end
+    subgraph adapter[github-adapter.ts]
+        UF[updateField]
+        UIT[updateIssueIssueType - new export]
+    end
+    subgraph config[config-helpers.ts]
+        C[LANE_FIELD_ID, LANE_OPTIONS]
+    end
+    subgraph tests[__tests__]
+        ST[set.test.ts]
+        MT[migrate.test.ts - new]
+    end
+    ROUTER --> set
+    ROUTER --> migrate
+    APPLY_PF --> AL --> UF
+    APPLY_PF --> AT --> UIT
+    AL --> C
+    BF --> LLM
+    BF --> UF
+    BF --> UIT
+    BF --> WS
+    RT --> WS
+    RV --> WS
+    ST -.tests.-> AL
+    ST -.tests.-> AT
+    MT -.tests.-> AS
+    MT -.tests.-> BF
+    MT -.tests.-> RT
+    MT -.tests.-> RV
+```
+
+## Agents
+
+| Agent | Tasks | Files |
+|---|---|---|
+| backend-dev | 12 | `config-helpers.ts`, `github-adapter.ts`, `set.ts`, `triage.ts`, `lib/migrate.ts` |
+| tester | 4 | `__tests__/set.test.ts`, `__tests__/migrate.test.ts` |
+| doc-writer | 2 | `SKILL.md`, `references/issue-taxonomy.md` |
+
+## Consistency Report
+
+| Spec trace | Covered by | Status |
+|---|---|---|
+| SC: `--lane` validation | T3, T4 | ✓ |
+| SC: `--type` validation | T3, T4 | ✓ |
+| SC: `LANE_FIELD_ID`/`LANE_OPTIONS` | T1 | ✓ |
+| SC: `DEFAULT_SIZE_OPTIONS` reconciled | T1, T5 | ✓ |
+| SC: `updateIssueIssueType` exported | T2 | ✓ |
+| SC: `migrate.ts` implements 4 commands | T5, T6, T9, T12 | ✓ |
+| SC: router 4 first-class subcmds | T7, T10, T13 | ✓ |
+| SC: `LEGACY_LABEL_MAP` + unit test | T6, T8 | ✓ |
+| SC: snapshot path format | T6, T9 | ✓ |
+| SC: revert idempotent | T12, T14 | ✓ |
+| SC: unit test coverage | T4, T8, T11, T14 | ✓ |
+| SC: `SKILL.md` docs | T15 | ✓ |
+| SC: `issue-taxonomy.md` patch | T16 | ✓ |
+| SC: typecheck + test + biome clean | RED-GATEs per slice | ✓ |
+
+Operational criteria (soak, live backfill, live rewrite, GraphQL verification, snapshot commits) tracked in PR body — **not** in micro-tasks.
+
+## Slices
+
+### V1 — Write-path extension (S1)
+
+| # | Task | File | Agent | Difficulty | Phase | Dep |
+|---|---|---|---|---|---|---|
+| T1 [P] | Add `LANE_FIELD_ID`, `LANE_OPTIONS` (20 values from `hub-bootstrap.ts`), reconcile `DEFAULT_SIZE_OPTIONS` to live schema (audit before editing) | `plugins/dev-core/skills/shared/adapters/config-helpers.ts` | backend-dev | 2 | GREEN | — |
+| T2 [P] | Export `updateIssueIssueType(issueNodeId, typeId \| null)` wrapper; add `resolveIssueTypeId(typeName)` using existing `listOrgIssueTypes` | `plugins/dev-core/skills/shared/adapters/github-adapter.ts` | backend-dev | 2 | GREEN | — |
+| T3 | Add `--lane L` + `--type T` to `parseArgs`; implement `applyLane`, `applyType`; wire into `applyProjectFields`; exit 1 on invalid | `plugins/dev-core/skills/issue-triage/lib/set.ts` | backend-dev | 3 | GREEN | T1, T2 |
+| T4 | Test cases: `--lane` valid/invalid, `--type` valid/invalid, additive (omit both = old behavior), regression on `--size`/`--priority`/`--status` | `plugins/dev-core/skills/issue-triage/__tests__/set.test.ts` | tester | 2 | RED→GREEN | T3 |
+| RED-GATE V1 | `bun run typecheck && bun run test --filter set.test && bunx biome check` | — | — | — | RED-GATE | T1..T4 |
+
+### V2 — Schema audit + backfill (S3)
+
+| # | Task | File | Agent | Difficulty | Phase | Dep |
+|---|---|---|---|---|---|---|
+| T5 | Create `lib/migrate.ts`. Implement `auditSchema()`: query `gh project field-list` via GraphQL, assert Size+Lane+Priority+Status fields exist and option IDs match constants; exit 1 with diff on mismatch | `plugins/dev-core/skills/issue-triage/lib/migrate.ts` | backend-dev | 3 | GREEN | T1 |
+| T6 | Implement `backfill({repo, dryRun, snapshotPath})`: walk open issues, skip already-set fields, apply `LEGACY_LABEL_MAP` (graph:lane/*, size:*, P0-3, title-prefix), write snapshot + flagged.txt; invokes `auditSchema` as pre-flight | `plugins/dev-core/skills/issue-triage/lib/migrate.ts` | backend-dev | 5 | GREEN | T5 |
+| T7 | Route `migrate <backfill\|audit-schema>` subcommands in `triage.ts` switch | `plugins/dev-core/skills/issue-triage/triage.ts` | backend-dev | 1 | GREEN | T5, T6 |
+| T8 | Test cases: `auditSchema` mismatch exits 1; `backfill --dry-run` writes no mutations but writes snapshot; idempotency (2nd run = 0 mutations); `LEGACY_LABEL_MAP` assertions (each key→expected value); unknown labels → flagged.txt | `plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts` | tester | 3 | RED→GREEN | T6 |
+| RED-GATE V2 | `bun run typecheck && bun run test --filter migrate.test && bunx biome check` | — | — | — | RED-GATE | T5..T8 |
+
+### V3 — Title rewrite (S5)
+
+| # | Task | File | Agent | Difficulty | Phase | Dep |
+|---|---|---|---|---|---|---|
+| T9 [P] | Implement `rewriteTitles({repo, dryRun})`: regex `^(feat\|fix\|refactor\|docs\|test\|chore\|ci\|perf)(\(.+\))?:\s*` strip, emit `rewrite-snapshot-<ts>.json`, call `gh issue edit --title` live | `plugins/dev-core/skills/issue-triage/lib/migrate.ts` | backend-dev | 3 | GREEN | T6 |
+| T10 | Route `migrate rewrite-titles` in `triage.ts` | `plugins/dev-core/skills/issue-triage/triage.ts` | backend-dev | 1 | GREEN | T9 |
+| T11 | Test cases: prefix regex stripping (all 8 types, with/without scope), false-positive guard (`foo: bar` without type keyword stays), dry-run emits snapshot no mutations | `plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts` | tester | 2 | RED→GREEN | T9 |
+| RED-GATE V3 | `bun run typecheck && bun run test --filter migrate.test && bunx biome check` | — | — | — | RED-GATE | T9..T11 |
+
+### V4 — Revert (S6)
+
+| # | Task | File | Agent | Difficulty | Phase | Dep |
+|---|---|---|---|---|---|---|
+| T12 [P] | Implement `revert({snapshotPath})`: detect snapshot kind (backfill vs rewrite), apply inverse (`updateField(…, null)` for fields; `updateIssueIssueType(…, null)` for type; `gh issue edit --title <old>` for rewrite); idempotent (skip-already-reverted) | `plugins/dev-core/skills/issue-triage/lib/migrate.ts` | backend-dev | 4 | GREEN | T6, T9 |
+| T13 | Route `migrate revert --snapshot <path>` in `triage.ts` | `plugins/dev-core/skills/issue-triage/triage.ts` | backend-dev | 1 | GREEN | T12 |
+| T14 | Test cases: round-trip (write snapshot via dry-run-like stub → revert clears fields); idempotent 2nd revert logs skip; handles both snapshot kinds | `plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts` | tester | 3 | RED→GREEN | T12 |
+| RED-GATE V4 | `bun run typecheck && bun run test && bunx biome check` | — | — | — | RED-GATE | T12..T14 |
+
+### V5 — Docs
+
+| # | Task | File | Agent | Difficulty | Phase | Dep |
+|---|---|---|---|---|---|---|
+| T15 [P] | Document `--lane`, `--type`, `migrate <backfill\|audit-schema\|rewrite-titles\|revert>` with examples; add "Soak window + migration" section referencing the spec | `plugins/dev-core/skills/issue-triage/SKILL.md` | doc-writer | 2 | REFACTOR | T13 |
+| T16 [P] | Patch enrolled-repos list (8 → 7; remove `Roxabi/2ndBrain` with footnote); add size-schema reconciliation note (`hub-bootstrap.ts` vs `config-helpers.ts`); add `LEGACY_LABEL_MAP` mapping table | `plugins/dev-core/references/issue-taxonomy.md` | doc-writer | 2 | REFACTOR | T1 |
+
+## Reference patterns
+
+- **Field-write pattern:** `plugins/dev-core/skills/issue-triage/lib/set.ts:applySize` (canonical resolve → exit on invalid → `updateField`)
+- **`updateIssueIssueType` usage:** `plugins/dev-core/skills/init/lib/hub-bootstrap.ts` (already imports; agent can lift import path + call shape)
+- **Lane options source:** `plugins/dev-core/skills/init/lib/hub-bootstrap.ts:LANE_OPTIONS` — copy the 20-value array
+- **Existing tests:** `plugins/dev-core/skills/issue-triage/__tests__/set.test.ts` for test shape + mocking approach
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 12 — add LANE_FIELD_ID + LANE_OPTIONS, reconcile DEFAULT_SIZE_OPTIONS
+- T2: 13 — export updateIssueIssueType adapter + resolveIssueTypeId
+- T3: 14 — add --lane + --type to set.ts
+- T4: 15 — set.test.ts cases for --lane + --type
+- T5: 16 — implement migrate.ts:auditSchema
+- T6: 17 — implement migrate.ts:backfill + LEGACY_LABEL_MAP + snapshot writer
+- T7: 18 — route migrate backfill + audit-schema in triage.ts
+- T8: 19 — migrate.test.ts: audit, dry-run, idempotency, LEGACY_LABEL_MAP
+- T9: 20 — implement migrate.ts:rewriteTitles
+- T10: 21 — route migrate rewrite-titles in triage.ts
+- T11: 22 — migrate.test.ts: rewriteTitles cases
+- T12: 23 — implement migrate.ts:revert
+- T13: 24 — route migrate revert in triage.ts
+- T14: 25 — migrate.test.ts: revert round-trip
+- T15: 26 — SKILL.md: --lane/--type + migrate subcommands
+- T16: 27 — issue-taxonomy.md: patch 8→7, size-schema note, LEGACY_LABEL_MAP table

--- a/artifacts/specs/121-dual-write-migration-spec.mdx
+++ b/artifacts/specs/121-dual-write-migration-spec.mdx
@@ -1,0 +1,248 @@
+---
+title: "Spec: dual-write + migration (#121, phases 3+4+5)"
+description: "Shape B — extend issue-triage with Lane+Type write paths, 7-day soak, TS-resident backfill + title-rewrite + revert."
+issue: 121
+parent: 119
+frame: artifacts/frames/121-dual-write-migration-frame.mdx
+analysis: artifacts/analyses/121-dual-write-migration-analysis.mdx
+tier: F-full
+status: approved
+date: 2026-04-22
+---
+
+## Context
+
+Promoted from `artifacts/analyses/121-dual-write-migration-analysis.mdx` (Shape B — approved 2026-04-22 after product-lead + architect concurrence). Parent spec `artifacts/specs/119-issue-taxonomy-migration-spec.mdx` §Phases 3–5.
+
+Deviation from parent spec: "dual-write" is renamed **soak window** because `set.ts` never wrote legacy labels — there is no legacy path to parallel. The soak is a 7-day burn-in of the new Lane+Type write paths under normal triage load. All other exit criteria from the parent spec phases 3+4+5 are preserved.
+
+Enrolled repos corrected: **7**, not 8. `Roxabi/2ndBrain` is local-only (per `~/projects/CLAUDE.md`) and is excluded.
+
+## Goal
+
+After this slice lands and its soak + migration runs complete, every open issue across the 7 enrolled repos has `Lane`, `Size`, `Priority`, `issueType` populated in the hub project; no open title matches `^(feat|fix|refactor|docs|test|chore|ci|perf)(\(.+\))?:`; and snapshot JSONs in `artifacts/migration/` make the entire migration reversible.
+
+## Users
+
+- **Primary:** `dev-core:issue-triage` users (the human operator running `bun triage.ts set N --lane X --type feat` and `bun triage.ts migrate backfill`).
+- **Secondary:** Migration reviewer (Mickael) — approves `flagged.txt` and the title-rewrite dry-run snapshot before live runs. Owns the gate between S3/S4 and between S5 dry-run/live.
+- **Tertiary:** `#122` (cutover + guardrail) — depends on hub project fields being complete.
+- **Quaternary:** `lyra/scripts/dep-graph` — once #122 flips its read path, completeness of the hub fields is load-bearing.
+
+## Expected Behavior
+
+**Write path change.** `bun triage.ts set <N>` gains two optional flags:
+
+- `--lane <L>` where `L ∈ LANE_OPTIONS` (20 values from `hub-bootstrap.ts`). Calls `updateField(itemId, LANE_FIELD_ID, LANE_OPTIONS[L])`.
+- `--type <T>` where `T ∈ {fix,feat,docs,test,chore,ci,perf,epic,research,refactor}`. Calls `updateIssueIssueType(issueNodeId, typeId)` via a new adapter export.
+
+Both are additive; omission preserves today's behavior. Invalid value → `process.exit(1)` with the valid set listed (same pattern as `--size`).
+
+**Soak window.** After the `set.ts` change merges to staging and is deployed across the 7 repos' triage runners, 7 wall-clock days of normal triage activity must elapse before backfill runs. Soak exit = new fields populated on every issue triaged in that window, zero error logs from `updateField`/`updateIssueIssueType` for those 7 days.
+
+**Backfill.** `bun triage.ts migrate backfill [--repo OWNER/REPO | --all] [--dry-run] [--snapshot path]` walks every open issue across the selected repos and applies:
+
+1. If hub field is already set → skip (idempotent).
+2. `graph:lane/<X>` label → `Lane`.
+3. `size:<Y>` label → `Size` via `LEGACY_LABEL_MAP` (e.g., `size:M → F-lite`).
+4. `P{0-3}-<name>` label (lyra only) → `Priority` via map (`P0-* → Urgent`, `P1-* → High`, `P2-* → Medium`, `P3-* → Low`).
+5. Title prefix `^(feat|fix|…)\(.+\)?:` → `issueType`. No match → flag.
+6. Emit `artifacts/migration/backfill-snapshot-<YYYYMMDD-HHMM>.json` + `artifacts/migration/flagged-<YYYYMMDD-HHMM>.txt`.
+
+Dry-run prints a diff table, writes no mutations, still emits the snapshot for review.
+
+**Title rewrite.** `bun triage.ts migrate rewrite-titles [--repo OWNER/REPO | --all] [--dry-run]` strips the conventional-commit prefix from every open issue title via `gh issue edit`. Snapshot JSON (`rewrite-snapshot-<ts>.json`) records `{repo, number, old_title, new_title}`.
+
+**Revert.** `bun triage.ts migrate revert --snapshot <path>` reads either snapshot kind and undoes the mutations:
+
+- Project field writes (`Lane`, `Size`, `Priority`) → clear via `updateField(itemId, fieldId, null)` (the existing adapter accepts null to clear).
+- `issueType` writes → call `updateIssueIssueType(issueNodeId, null)`. The GraphQL mutation accepts a null `issueTypeId` to remove the type (verified in pre-impl spike; if the API rejects null, revert must restore to `old_value` recorded in the snapshot row — adapter wraps this semantics).
+- Title writes → `gh issue edit <N> --title "<old_title>"`.
+
+Idempotent: re-running revert on an already-reverted snapshot logs skip per row, no errors.
+
+**Schema audit.** `bun triage.ts migrate audit-schema` is a first-class subcommand (routed independently, not only invoked as a pre-flight hook inside `backfill`). It queries `gh project field-list 23 --owner Roxabi` and asserts:
+
+1. `Size` field exists and its option IDs match `SIZE_OPTIONS` in `config-helpers.ts`.
+2. `Lane` field exists and its 20 option IDs match `LANE_OPTIONS`.
+3. `Priority` + `Status` fields exist with matching option sets (covered by existing constants).
+
+Any mismatch → exit 1 with a diff and reconciliation instructions. `backfill` invokes `audit-schema` as a pre-flight and aborts on failure; the operator may also run it standalone.
+
+**Language note.** Parent spec (#119) described Phase 4/5 as Python scripts under `scripts/migrate/`. This slice implements them in TypeScript inside the `issue-triage` skill (per Shape B). Justification is in `artifacts/analyses/121-…` §Fit Check — unchanged exit criteria, simpler ownership, reuse of existing adapters.
+
+## Data Model & Consumers
+
+### Hub project field model
+
+```mermaid
+classDiagram
+    class HubProjectItem {
+        +string id
+        +int contentNumber
+        +string repo
+        +Lane lane
+        +Size size
+        +Priority priority
+        +Status status
+        +IssueType issueType
+    }
+    class Lane {
+        <<enum>>
+        a1..a3, b, c1..c3, d..o, standalone
+    }
+    class Size {
+        <<enum>>
+        S, F-lite, F-full
+    }
+    class Priority {
+        <<enum>>
+        Urgent, High, Medium, Low
+    }
+    class Status {
+        <<enum>>
+        Backlog, Analysis, Specs, "In Progress", Review, Done
+    }
+    class IssueType {
+        <<enum>>
+        fix, feat, docs, test, chore, ci, perf, epic, research, refactor
+    }
+    HubProjectItem --> Lane
+    HubProjectItem --> Size
+    HubProjectItem --> Priority
+    HubProjectItem --> Status
+    HubProjectItem --> IssueType
+
+    class BackfillSnapshot {
+        +string timestamp
+        +string command
+        +Array~Row~ rows
+    }
+    class Row {
+        +string repo
+        +int number
+        +string field
+        +string|null old_value
+        +string|null new_value
+        +bool flagged
+    }
+    BackfillSnapshot --> Row
+```
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    W1["set.ts<br/>--lane / --type"] --> HUB[(Hub Project V2)]
+    W2["migrate backfill"] --> HUB
+    W3["migrate rewrite-titles"] --> GH[(GitHub Issues)]
+    HUB --> R1["issue-triage list/get<br/>(this issue)"]
+    HUB -.-> R2["dep-graph fetch<br/>(#122, future)"]
+    HUB -.-> R3["issues --tree<br/>(#122, future)"]
+    SNAP[(artifacts/migration/<br/>*.json)] --> REV["migrate revert"]
+    W2 --> SNAP
+    W3 --> SNAP
+```
+
+### Consumer summary
+
+| Consumer | Fields consumed | When | Status |
+|---|---|---|---|
+| `issue-triage list/get` | Lane, Size, Priority, Status, issueType | Every triage read | This issue |
+| `dep-graph fetch.py` | Lane, Size, Priority, Milestone | Build time | Future (#122) |
+| `dev-core:issues --tree` | Lane, Status, parent/sub edges | Query time | Future (#122) |
+| `migrate revert` | Snapshot rows | Manual rollback | This issue |
+
+## Breadboard
+
+### Affordances
+
+| ID | Affordance | Handler | Data read | Data written |
+|---|---|---|---|---|
+| N1 | `set <N> --lane L` | `set.ts:applyLane` | `LANE_OPTIONS`, item id | `projectV2.Lane` |
+| N2 | `set <N> --type T` | `set.ts:applyType` | type id map from org | `issue.issueType` |
+| N3 | `migrate backfill` | `migrate.ts:backfill` | labels, title, existing fields | Lane/Size/Priority/issueType + snapshot |
+| N4 | `migrate rewrite-titles` | `migrate.ts:rewriteTitles` | titles | title + snapshot |
+| N5 | `migrate revert --snapshot P` | `migrate.ts:revert` | snapshot JSON | inverse of N3 or N4 |
+| N6 | `migrate audit-schema` | `migrate.ts:auditSchema` | live project field-list | stdout diff |
+| U1 | `--dry-run` flag | shared helper | — | stdout only |
+| U2 | Snapshot writer | `migrate.ts:writeSnapshot` | rows | `artifacts/migration/*.json` |
+| U3 | `LEGACY_LABEL_MAP` | constant in `migrate.ts` | — | — |
+| U4 | `updateIssueIssueType` export | `github-adapter.ts` | — | GraphQL mutation |
+| U5 | `LANE_FIELD_ID` + `LANE_OPTIONS` | `config-helpers.ts` | — | — |
+
+### Wiring
+
+```
+bun triage.ts set N --lane L --type T
+  → parseArgs → applyProjectFields → applyLane(N1) → updateField(LANE_FIELD_ID)
+                                   → applyType(N2) → updateIssueIssueType(U4)
+
+bun triage.ts migrate backfill --repo R --dry-run
+  → auditSchema(N6) → listOpenIssues(R) → foreach issue:
+      read existing fields (skip if set)
+      map labels via U3 → proposed values
+      U1 ? print diff : updateField + updateIssueIssueType
+      append row to snapshot (U2)
+
+bun triage.ts migrate revert --snapshot P
+  → load snapshot → foreach row: inverse mutation
+```
+
+## Slices
+
+| # | Slice | Affordances | Demo |
+|---|---|---|---|
+| S1 | **Write-path extension** | N1, N2, U4, U5 | `bun triage.ts set 127 --lane c1 --type feat` updates hub + org issueType; `--help` lists new flags |
+| S2 | **Soak + monitoring** | (S1 deployed) | 7 days of normal triage on staging-deployed skill; zero errors in `set.ts` invocations across 7 repos |
+| S3 | **Schema audit + backfill dry-run** | N3, N6, U1, U2, U3 | `bun triage.ts migrate backfill --repo Roxabi/roxabi-plugins --dry-run` prints diff table, writes snapshot, no mutations |
+| S4 | **Backfill live** | N3, N6 | Serial per-repo: `bun triage.ts migrate backfill --repo <R>` for each of 7 repos (order: roxabi-plugins → lyra → other 5 parallel-safe but run serially for clean per-repo diff). `flagged.txt` reviewed before the next repo starts |
+| S5 | **Title rewrite** | N4, U1, U2 | `migrate rewrite-titles --all --dry-run` → human review → live run → snapshot committed |
+| S6 | **Revert path** | N5 | Test-only: run backfill on a scratch issue, revert via snapshot, verify fields cleared |
+
+Slices S1, S2, S3, S6 land in the PR. S4 and S5 are **operational runs after merge**, not code changes — tracked in the PR body as a post-merge checklist.
+
+## Success Criteria
+
+### Code (ship in PR)
+
+- [ ] `set.ts` accepts `--lane <L>` with validation against `LANE_OPTIONS`; invalid → exit 1 with valid set listed
+- [ ] `set.ts` accepts `--type <T>` with validation against the 10 org issue types; invalid → exit 1 with valid set listed
+- [ ] `--lane` and `--type` are additive; existing calls without them behave identically (regression test)
+- [ ] `config-helpers.ts` exports `LANE_FIELD_ID`, `LANE_OPTIONS`
+- [ ] `migrate audit-schema` run once during implementation; result recorded in PR body; `config-helpers.ts:DEFAULT_SIZE_OPTIONS` updated to exactly match the live `Size` option set; `audit-schema` subsequently passes with zero diff
+- [ ] `github-adapter.ts` exports `updateIssueIssueType(issueNodeId, typeId)` wrapper
+- [ ] `lib/migrate.ts` implements `backfill`, `rewriteTitles`, `revert`, `auditSchema` with `--dry-run` on all three mutating commands
+- [ ] `triage.ts` routes `migrate <backfill|rewrite-titles|revert|audit-schema>` as four first-class subcommands (each callable independently)
+- [ ] `LEGACY_LABEL_MAP` constant covers: `graph:lane/*` → Lane; `size:S`, `size:M`, `size:L`, `size:XL` → Size; `P0-*`, `P1-*`, `P2-*`, `P3-*` → Priority; conventional-commit title prefix → issueType. **Unit test asserts each listed key maps to the expected value** and that unknown keys emit to `flagged.txt`
+- [ ] Snapshot JSON written for every non-dry-run backfill or rewrite run; path format `artifacts/migration/{backfill|rewrite}-snapshot-<YYYYMMDD-HHMM>.json`
+- [ ] `migrate revert --snapshot P` is idempotent and logs which rows were inverted vs already-reverted
+- [ ] Unit tests: `set.test.ts` covers `--lane` and `--type` (valid, invalid, additive); `migrate.test.ts` covers dry-run, idempotency, flagged.txt emission, revert round-trip
+- [ ] `SKILL.md` documents `--lane`, `--type`, `migrate <subcmd>` with examples
+- [ ] `references/issue-taxonomy.md` patched: enrolled repos 8 → 7; note on size-schema reconciliation
+- [ ] `bun run typecheck && bun run test && bunx biome check --write` all clean
+
+### Operational (post-merge, tracked in PR body)
+
+- [ ] 7-day soak elapses with zero `updateField`/`updateIssueIssueType` error logs across 7 repos
+- [ ] **Soak parity check (parent-spec gate):** at soak-end, a `migrate backfill --dry-run --soak-check` pass against issues triaged during the window returns zero field divergences between the values `set.ts` wrote and the values currently in the hub project (asserts write path is stable + no out-of-band drift)
+- [ ] `migrate audit-schema` returns 0 diff before backfill starts
+- [ ] Backfill dry-run per repo; snapshot committed; `flagged.txt` reviewed and resolved (pass: all flagged rows explicitly accepted or fixed)
+- [ ] Backfill live per repo (serial order); follow-up `backfill --dry-run` returns 0 proposed mutations per repo (pass condition)
+- [ ] GraphQL query `projectV2.items where Lane IS NULL OR Size IS NULL OR issueType IS NULL` **returns 0 results** across 7 repos
+- [ ] Title rewrite dry-run reviewed by migration reviewer; live run completed across 7 repos
+- [ ] `gh issue list --search "^(feat|fix|refactor|docs|test|chore|ci|perf)(\(.+\))?:" --state open` **returns 0 rows** across 7 repos
+- [ ] Both snapshot JSONs committed to `artifacts/migration/`
+
+### Gate
+
+- [ ] `#122` unblocked: dep-graph reader and `dev-core:issues` read paths can assume field completeness on open issues
+
+## Resolved decisions
+
+1. **`area:*` labels on lyra — untouched.** `migrate` does not read, delete, or map them. They remain a lyra-local convention orthogonal to taxonomy.
+2. **Backfill CLI — serial only, no `--all` flag in v1.** Every invocation requires `--repo OWNER/REPO`. Natural human pause between repos enforces per-repo `flagged.txt` review. `--all` can be added later if wanted.
+
+## Open questions
+
+1. **[L × L] Snapshot commit granularity** — one commit per repo, or one commit per migration run listing all repos? Operational, post-merge, non-blocking. [suggested: one commit per run]

--- a/plugins/dev-core/references/issue-taxonomy.md
+++ b/plugins/dev-core/references/issue-taxonomy.md
@@ -1,6 +1,8 @@
 # Issue Taxonomy — Roxabi SSoT
 
-Single fact source for issue metadata across every Roxabi repo (`lyra`, `voiceCLI`, `roxabi-vault`, `imageCLI`, `roxabi-forge`, `roxabi-intel`, `roxabi-idna`, `roxabi-plugins`).
+Single fact source for issue metadata across every Roxabi repo (`lyra`, `voiceCLI`, `roxabi-vault`, `imageCLI`, `roxabi-forge`, `roxabi-intel`, `roxabi-idna`, `roxabi-plugins`) — 7 repos total.[^2ndbrain]
+
+[^2ndbrain]: `2ndBrain` is a local-only project (see `~/projects/CLAUDE.md`) — it is not a GitHub repo and is excluded from the migration.
 
 **Who reads this:** `dev-core:issue-triage` · `dev-core:github-setup` · `dev-core:issues` · `lyra/scripts/dep-graph` · `lyra/scripts/corpus` · future `roxabi-dashboard`.
 
@@ -17,6 +19,8 @@ Single fact source for issue metadata across every Roxabi repo (`lyra`, `voiceCL
 | **Milestone** | Native GH milestone | `M0` `M1` `M2` `…` | **Per-repo** (names kept consistent) | dep-graph (band headers) | issue-triage · milestones-sync |
 | **Issue Type** | Org-level native | Current (pre-Phase 1): `Bug` `Feature` `Epic` `Chore` `Research` → Target (post-Phase 1): `feat` `fix` `refactor` `docs` `test` `chore` `ci` `perf` `epic` `research` | Org (applies to every repo) | dep-graph · dashboard | issue-triage · github-setup (org bootstrap) |
 | **Assignees** | Native | users | Repo (GH native) | dashboard | manual · issue-triage |
+
+**Size schema reconciliation:** `config-helpers.ts:DEFAULT_SIZE_OPTIONS` currently holds `['XS', 'S', 'M', 'L', 'XL']`; `init/lib/hub-bootstrap.ts:SIZE_OPTIONS` uses `['S', 'F-lite', 'F-full']`. The live hub project schema is the source of truth. `bun triage.ts migrate audit-schema` reports any drift. `DEFAULT_SIZE_OPTIONS` will be reconciled to the live set once the audit runs against a real project (tracked via `TODO(#121)` in `config-helpers.ts`).
 
 **Native relations (no field needed):**
 - **Sub-issues** — parent/child, cross-org since 2025-09 · REST `…/sub_issues` · `…/parent`
@@ -50,6 +54,21 @@ Single fact source for issue metadata across every Roxabi repo (`lyra`, `voiceCL
 | Label-drift audit (`make dep-graph audit`) | **Repurpose** to validate project-field coverage | no labels to audit |
 
 **Kept as domain tags (per-repo, unchanged):** `deploy` · `ci` · `security` · `docs` · `performance` · etc. These are technical domain markers, not taxonomy.
+
+### LEGACY_LABEL_MAP
+
+| Legacy input | Source | Mapped field | Target value |
+|---|---|---|---|
+| `graph:lane/<X>` | label | Lane | `<X>` (identity — all 20 canonical lanes) |
+| `size:S` | label | Size | `S` |
+| `size:M` | label | Size | `F-lite` |
+| `size:L` | label | Size | `F-full` |
+| `size:XL` | label | Size | `F-full` |
+| `P0-*` | label | Priority | `P0 - Urgent` |
+| `P1-*` | label | Priority | `P1 - High` |
+| `P2-*` | label | Priority | `P2 - Medium` |
+| `P3-*` | label | Priority | `P3 - Low` |
+| `feat(...): ...` etc | title prefix | issueType | `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf` |
 
 ---
 

--- a/plugins/dev-core/skills/issue-triage/SKILL.md
+++ b/plugins/dev-core/skills/issue-triage/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: issue-triage
-argument-hint: [list | set <num> | create --title "..." [--parent N] [--size S] [--priority P]]
-description: Triage/create GitHub issues — set size/priority/status, manage dependencies & parent/child. Triggers: "triage" | "create issue" | "set size" | "set priority" | "blocked by" | "set parent" | "child of" | "sub-issue" | "file an issue" | "log a bug" | "open an issue" | "file a bug" | "add issue" | "new issue".
-version: 0.2.0
+argument-hint: [list | set <num> | create --title "..." [--parent N] [--size S] [--priority P] | migrate <audit-schema|backfill|rewrite-titles|revert>]
+description: Triage/create GitHub issues — set size/priority/status/lane/type, manage dependencies & parent/child, migrate legacy data. Triggers: "triage" | "create issue" | "set size" | "set priority" | "blocked by" | "set parent" | "child of" | "sub-issue" | "file an issue" | "log a bug" | "open an issue" | "file a bug" | "add issue" | "new issue" | "set lane" | "set type" | "migrate" | "backfill" | "audit schema".
+version: 0.3.0
 allowed-tools: Bash, Read, ToolSearch
 ---
 
@@ -65,6 +65,8 @@ Create GitHub issues, assign Size/Priority/Status, manage blockedBy dependencies
 | `--add-child <N>[,<N>...]` | Add child sub-issues |
 | `--rm-parent` | Remove parent relationship |
 | `--rm-child <N>[,<N>...]` | Remove child sub-issues |
+| `--lane <L>` | Set lane on hub project (optional, additive). Valid: `a1`, `a2`, `a3`, `b`, `c1`, `c2`, `c3`, `d`–`o`, `standalone` |
+| `--type <T>` | Set org issueType (optional, additive). Valid: `fix`, `feat`, `docs`, `test`, `chore`, `ci`, `perf`, `epic`, `research`, `refactor` |
 
 ### `create` — Create a new issue
 
@@ -80,6 +82,55 @@ Create GitHub issues, assign Size/Priority/Status, manage blockedBy dependencies
 | `--add-child <N>[,<N>...]` | Add existing issues as children |
 | `--blocked-by <N>[,<N>...]` | Set blocked-by on creation |
 | `--blocks <N>[,<N>...]` | Set blocking on creation |
+
+### `migrate` — Schema validation and data migration
+
+> Operational context (7-day soak, 7 enrolled repos, serial-per-repo rollout, `flagged.txt` review gate): `artifacts/specs/121-dual-write-migration-spec.mdx`
+
+#### `migrate audit-schema`
+
+Validates that the live hub project's Size/Lane/Priority/Status single-select fields match the local `*_OPTIONS` constants.
+
+```bash
+τ migrate audit-schema
+```
+
+- Exits 0 on match; exits 1 with a field-by-field diff on any drift.
+
+#### `migrate backfill --repo OWNER/REPO`
+
+Walks open issues in the repo, maps legacy labels/title-prefixes to hub fields via `LEGACY_LABEL_MAP`, and writes field values. Idempotent — skips already-set fields.
+
+```bash
+τ migrate backfill --repo OWNER/REPO
+τ migrate backfill --repo OWNER/REPO --dry-run
+τ migrate backfill --repo OWNER/REPO --snapshot artifacts/migration/backfill-snapshot-YYYYMMDD-HHMM.json
+```
+
+- Writes `artifacts/migration/backfill-snapshot-<YYYYMMDD-HHMM>.json` + `flagged.txt` for manual review.
+
+#### `migrate rewrite-titles --repo OWNER/REPO`
+
+Strips conventional-commit prefixes (e.g. `feat:`, `fix(scope):`) from open issue titles. Idempotent.
+
+```bash
+τ migrate rewrite-titles --repo OWNER/REPO
+τ migrate rewrite-titles --repo OWNER/REPO --dry-run
+τ migrate rewrite-titles --repo OWNER/REPO --snapshot artifacts/migration/rewrite-snapshot-<ts>.json
+```
+
+- Writes `artifacts/migration/rewrite-snapshot-<ts>.json`; `--dry-run` prints changes without applying.
+
+#### `migrate revert --snapshot PATH`
+
+Reads a backfill or rewrite snapshot and inverts the mutations. Idempotent.
+
+```bash
+τ migrate revert --snapshot artifacts/migration/backfill-snapshot-20240101-1200.json
+τ migrate revert --snapshot artifacts/migration/rewrite-snapshot-20240101-1200.json
+```
+
+- Restores all mutated fields/titles to their pre-migration values.
 
 ## Complexity Scoring
 
@@ -154,6 +205,19 @@ Reference: `artifacts/analyses/280-token-consumption.mdx` for scoring examples.
   --title "epic: improve CI pipeline" \
   --size L --priority High \
   --add-child 150,151,152
+
+# Lane and type (additive, optional)
+τ set 42 --lane b
+τ set 42 --type feat
+τ set 42 --size M --priority High --lane c1 --type fix
+
+# Migrate
+τ migrate audit-schema
+τ migrate backfill --repo Roxabi/my-repo --dry-run
+τ migrate backfill --repo Roxabi/my-repo
+τ migrate rewrite-titles --repo Roxabi/my-repo --dry-run
+τ migrate rewrite-titles --repo Roxabi/my-repo
+τ migrate revert --snapshot artifacts/migration/backfill-snapshot-20240101-1200.json
 ```
 
 ## Chain Position
@@ -185,9 +249,11 @@ Run `/init` to auto-detect and populate env vars. Field operations (status, size
 | `STATUS_FIELD_ID` | Project field ID for Status | ✅ field updates |
 | `SIZE_FIELD_ID` | Project field ID for Size | ✅ field updates |
 | `PRIORITY_FIELD_ID` | Project field ID for Priority | ✅ field updates |
+| `LANE_FIELD_ID` | Project field ID for Lane | ✅ lane updates |
 | `STATUS_OPTIONS_JSON` | JSON map status names → option IDs | ✅ field updates |
 | `SIZE_OPTIONS_JSON` | JSON map size names → option IDs | ✅ field updates |
 | `PRIORITY_OPTIONS_JSON` | JSON map priority names → option IDs | ✅ field updates |
+| `LANE_OPTIONS_JSON` | JSON map lane names → option IDs | ✅ lane updates |
 
 ## Related
 

--- a/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
@@ -429,19 +429,19 @@ describe('migrate > TITLE_PREFIX_RE', () => {
     const match = title.match(TITLE_PREFIX_RE)
     // Assert
     expect(match).not.toBeNull()
-    expect(match![1]).toBe('feat')
+    expect(match?.[1]).toBe('feat')
   })
 
   it('matches chore: baz and captures chore as group 1', () => {
     const match = 'chore: baz'.match(TITLE_PREFIX_RE)
     expect(match).not.toBeNull()
-    expect(match![1]).toBe('chore')
+    expect(match?.[1]).toBe('chore')
   })
 
   it('matches fix(complex-scope): x and captures fix as group 1', () => {
     const match = 'fix(complex-scope): x'.match(TITLE_PREFIX_RE)
     expect(match).not.toBeNull()
-    expect(match![1]).toBe('fix')
+    expect(match?.[1]).toBe('fix')
   })
 
   it('does not match plain title without conventional prefix', () => {
@@ -460,7 +460,7 @@ describe('migrate > TITLE_PREFIX_RE', () => {
       const match = `${type}: something`.match(TITLE_PREFIX_RE)
       // Assert
       expect(match).not.toBeNull()
-      expect(match![1]).toBe(type)
+      expect(match?.[1]).toBe(type)
     }
   })
 })

--- a/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { readFile } from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Env vars must be set before config-helpers module loads
 process.env.GITHUB_REPO = 'Roxabi/test'
@@ -34,18 +34,52 @@ process.env.PRIORITY_OPTIONS_JSON = JSON.stringify({
 process.env.LANE_OPTIONS_JSON = JSON.stringify(
   Object.fromEntries(
     [
-      'a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3',
-      'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-      'l', 'm', 'n', 'o', 'standalone',
+      'a1',
+      'a2',
+      'a3',
+      'b',
+      'c1',
+      'c2',
+      'c3',
+      'd',
+      'e',
+      'f',
+      'g',
+      'h',
+      'i',
+      'j',
+      'k',
+      'l',
+      'm',
+      'n',
+      'o',
+      'standalone',
     ].map((k) => [k, `lane-${k}`]),
   ),
 )
 
 // Full DEFAULT_LANE_OPTIONS list (20 entries) — mirrors config-helpers.ts
 const ALL_LANE_KEYS = [
-  'a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3',
-  'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-  'l', 'm', 'n', 'o', 'standalone',
+  'a1',
+  'a2',
+  'a3',
+  'b',
+  'c1',
+  'c2',
+  'c3',
+  'd',
+  'e',
+  'f',
+  'g',
+  'h',
+  'i',
+  'j',
+  'k',
+  'l',
+  'm',
+  'n',
+  'o',
+  'standalone',
 ]
 
 vi.mock('../../shared/adapters/config-helpers', () => ({
@@ -74,21 +108,60 @@ vi.mock('../../shared/adapters/config-helpers', () => ({
   },
   LANE_OPTIONS: Object.fromEntries(
     [
-      'a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3',
-      'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-      'l', 'm', 'n', 'o', 'standalone',
+      'a1',
+      'a2',
+      'a3',
+      'b',
+      'c1',
+      'c2',
+      'c3',
+      'd',
+      'e',
+      'f',
+      'g',
+      'h',
+      'i',
+      'j',
+      'k',
+      'l',
+      'm',
+      'n',
+      'o',
+      'standalone',
     ].map((k) => [k, `lane-${k}`]),
   ),
   DEFAULT_LANE_OPTIONS: [
-    'a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3',
-    'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-    'l', 'm', 'n', 'o', 'standalone',
+    'a1',
+    'a2',
+    'a3',
+    'b',
+    'c1',
+    'c2',
+    'c3',
+    'd',
+    'e',
+    'f',
+    'g',
+    'h',
+    'i',
+    'j',
+    'k',
+    'l',
+    'm',
+    'n',
+    'o',
+    'standalone',
   ],
   resolveStatus: (input: string) => {
     const aliases: Record<string, string> = {
-      BACKLOG: 'Backlog', ANALYSIS: 'Analysis', SPECS: 'Specs',
-      'IN PROGRESS': 'In Progress', IN_PROGRESS: 'In Progress',
-      INPROGRESS: 'In Progress', REVIEW: 'Review', DONE: 'Done',
+      BACKLOG: 'Backlog',
+      ANALYSIS: 'Analysis',
+      SPECS: 'Specs',
+      'IN PROGRESS': 'In Progress',
+      IN_PROGRESS: 'In Progress',
+      INPROGRESS: 'In Progress',
+      REVIEW: 'Review',
+      DONE: 'Done',
     }
     const canonical = new Set(['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done'])
     if (canonical.has(input)) return input
@@ -102,16 +175,39 @@ vi.mock('../../shared/adapters/config-helpers', () => ({
     const canonical = new Set(['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'])
     if (canonical.has(input)) return input
     const aliases: Record<string, string> = {
-      URGENT: 'P0 - Urgent', HIGH: 'P1 - High', MEDIUM: 'P2 - Medium', LOW: 'P3 - Low',
-      P0: 'P0 - Urgent', P1: 'P1 - High', P2: 'P2 - Medium', P3: 'P3 - Low',
+      URGENT: 'P0 - Urgent',
+      HIGH: 'P1 - High',
+      MEDIUM: 'P2 - Medium',
+      LOW: 'P3 - Low',
+      P0: 'P0 - Urgent',
+      P1: 'P1 - High',
+      P2: 'P2 - Medium',
+      P3: 'P3 - Low',
     }
     return aliases[input.toUpperCase()]
   },
   resolveLane: (input: string) => {
     const valid = new Set([
-      'a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3',
-      'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-      'l', 'm', 'n', 'o', 'standalone',
+      'a1',
+      'a2',
+      'a3',
+      'b',
+      'c1',
+      'c2',
+      'c3',
+      'd',
+      'e',
+      'f',
+      'g',
+      'h',
+      'i',
+      'j',
+      'k',
+      'l',
+      'm',
+      'n',
+      'o',
+      'standalone',
     ])
     return valid.has(input) ? input : undefined
   },
@@ -144,7 +240,15 @@ const mockUpdateIssueIssueType = github.updateIssueIssueType as ReturnType<typeo
 const childProcess = await import('node:child_process')
 const mockExecSync = childProcess.execSync as ReturnType<typeof vi.fn>
 
-const { LEGACY_LABEL_MAP, TITLE_PREFIX_RE, auditSchema, backfill } = await import('../lib/migrate')
+const { LEGACY_LABEL_MAP, TITLE_PREFIX_RE, auditSchema, backfill, rewriteTitles } = await import('../lib/migrate')
+
+// Local mirror of RewriteRow (not exported from migrate.ts)
+interface RewriteRow {
+  repo: string
+  number: number
+  old_title: string
+  new_title: string
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -156,19 +260,23 @@ function makeAuditSchemaResponse(laneOptions: string[]) {
       fields: {
         nodes: [
           {
-            id: 'f-size', name: 'Size',
+            id: 'f-size',
+            name: 'Size',
             options: ['XS', 'S', 'M', 'L', 'XL'].map((n) => ({ id: `s-${n}`, name: n })),
           },
           {
-            id: 'f-lane', name: 'Lane',
+            id: 'f-lane',
+            name: 'Lane',
             options: laneOptions.map((n) => ({ id: `l-${n}`, name: n })),
           },
           {
-            id: 'f-priority', name: 'Priority',
+            id: 'f-priority',
+            name: 'Priority',
             options: ['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'].map((n) => ({ id: `p-${n}`, name: n })),
           },
           {
-            id: 'f-status', name: 'Status',
+            id: 'f-status',
+            name: 'Status',
             options: ['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done'].map((n) => ({
               id: `st-${n}`,
               name: n,
@@ -393,11 +501,7 @@ describe('migrate > backfill --dry-run', () => {
   const labeledIssue = {
     number: 1,
     title: 'feat(x): hi',
-    labels: [
-      { name: 'graph:lane/c1' },
-      { name: 'size:M' },
-      { name: 'P1-high' },
-    ],
+    labels: [{ name: 'graph:lane/c1' }, { name: 'size:M' }, { name: 'P1-high' }],
     id: 'node-1',
   }
 
@@ -490,11 +594,7 @@ describe('migrate > backfill idempotency', () => {
   const fullyPopulatedIssue = {
     number: 10,
     title: 'feat(y): already done',
-    labels: [
-      { name: 'graph:lane/a1' },
-      { name: 'size:S' },
-      { name: 'P2-medium' },
-    ],
+    labels: [{ name: 'graph:lane/a1' }, { name: 'size:S' }, { name: 'P2-medium' }],
     id: 'node-10',
   }
 
@@ -549,5 +649,319 @@ describe('migrate > backfill idempotency', () => {
     expect(callsAfterFirst).toBe(0)
     expect(mockUpdateField).not.toHaveBeenCalled()
     expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 7. rewriteTitles
+// ---------------------------------------------------------------------------
+
+describe('migrate > rewriteTitles', () => {
+  let snapshotPath: string
+
+  // 16 synthetic issues: all 8 types × (with scope + without scope)
+  const matchingIssues = [
+    { number: 101, title: 'feat: add login' },
+    { number: 102, title: 'feat(auth): add oauth' },
+    { number: 103, title: 'fix: null pointer' },
+    { number: 104, title: 'fix(parser): handle empty input' },
+    { number: 105, title: 'refactor: extract service' },
+    { number: 106, title: 'refactor(core): simplify logic' },
+    { number: 107, title: 'docs: update readme' },
+    { number: 108, title: 'docs(api): add examples' },
+    { number: 109, title: 'test: add unit tests' },
+    { number: 110, title: 'test(auth): cover edge cases' },
+    { number: 111, title: 'chore: bump deps' },
+    { number: 112, title: 'chore(ci): update actions' },
+    { number: 113, title: 'ci: fix pipeline' },
+    { number: 114, title: 'ci(deploy): add staging step' },
+    { number: 115, title: 'perf: reduce bundle size' },
+    { number: 116, title: 'perf(render): memoize component' },
+  ]
+
+  const nonMatchingIssues = [
+    { number: 201, title: 'random title' },
+    { number: 202, title: 'colon: but no type keyword' },
+    { number: 203, title: 'foo(scope): bar but no type keyword either' },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    snapshotPath = join(tmpdir(), `rewrite-test-snapshot-${Date.now()}.json`)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  describe('dry-run with all 8 conventional-commit types (with and without scope)', () => {
+    it('writes snapshot with 16 rows — one per matching title', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify(matchingIssues))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      expect(rows).toHaveLength(16)
+    })
+
+    it('each snapshot row has repo, number, old_title, new_title fields', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify(matchingIssues))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      for (const row of rows) {
+        expect(row).toHaveProperty('repo', 'Roxabi/test')
+        expect(row).toHaveProperty('number')
+        expect(row).toHaveProperty('old_title')
+        expect(row).toHaveProperty('new_title')
+      }
+    })
+
+    it('strips prefix from all 8 types without scope', async () => {
+      // Arrange
+      const withoutScope = matchingIssues.filter((_, i) => i % 2 === 0) // even indices = no scope
+      mockExecSync.mockReturnValue(JSON.stringify(withoutScope))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      expect(rows).toHaveLength(8)
+      for (const row of rows) {
+        // new_title must not start with any conventional-commit prefix
+        expect(row.new_title).not.toMatch(/^(feat|fix|refactor|docs|test|chore|ci|perf)(\(.+?\))?:\s*/)
+      }
+    })
+
+    it('strips prefix from all 8 types with scope', async () => {
+      // Arrange
+      const withScope = matchingIssues.filter((_, i) => i % 2 === 1) // odd indices = with scope
+      mockExecSync.mockReturnValue(JSON.stringify(withScope))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      expect(rows).toHaveLength(8)
+      for (const row of rows) {
+        expect(row.new_title).not.toMatch(/^(feat|fix|refactor|docs|test|chore|ci|perf)(\(.+?\))?:\s*/)
+      }
+    })
+
+    it('does not call gh issue edit in dry-run mode', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify(matchingIssues))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert — only the gh issue list call happened, no edit calls
+      const calls = mockExecSync.mock.calls as string[][]
+      const editCalls = calls.filter((args) => String(args[0]).includes('gh issue edit'))
+      expect(editCalls).toHaveLength(0)
+    })
+
+    it('preserves body text after stripping prefix (no scope)', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify([{ number: 101, title: 'feat: add login' }]))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      expect(rows[0].new_title).toBe('add login')
+    })
+
+    it('preserves body text after stripping prefix (with scope)', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify([{ number: 102, title: 'feat(auth): add oauth' }]))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      expect(rows[0].new_title).toBe('add oauth')
+    })
+  })
+
+  describe('non-matching titles are left untouched', () => {
+    it('writes empty snapshot when no titles match', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify(nonMatchingIssues))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      expect(rows).toHaveLength(0)
+    })
+
+    it('does not emit a row for plain title without colon', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify([{ number: 201, title: 'random title' }]))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      expect(rows).toHaveLength(0)
+    })
+
+    it('does not emit a row for colon present but no valid type keyword', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify([{ number: 202, title: 'colon: but no type keyword' }]))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      expect(rows).toHaveLength(0)
+    })
+
+    it('does not emit a row for scope-like prefix without valid type keyword', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(
+        JSON.stringify([{ number: 203, title: 'foo(scope): bar but no type keyword either' }]),
+      )
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      expect(rows).toHaveLength(0)
+    })
+
+    it('does not call gh issue edit for non-matching titles', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify(nonMatchingIssues))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: false, snapshotPath })
+
+      // Assert
+      const calls = mockExecSync.mock.calls as string[][]
+      const editCalls = calls.filter((args) => String(args[0]).includes('gh issue edit'))
+      expect(editCalls).toHaveLength(0)
+    })
+  })
+
+  describe('live run calls gh issue edit', () => {
+    it('calls gh issue edit with --repo, --title, and issue number', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify([{ number: 101, title: 'feat: add login' }]))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: false, snapshotPath })
+
+      // Assert
+      const calls = mockExecSync.mock.calls as string[][]
+      const editCalls = calls.filter((args) => String(args[0]).includes('gh issue edit'))
+      expect(editCalls).toHaveLength(1)
+      const cmd = String(editCalls[0][0])
+      expect(cmd).toContain('gh issue edit 101')
+      expect(cmd).toContain('--repo Roxabi/test')
+      expect(cmd).toContain('--title')
+      expect(cmd).toContain('add login')
+    })
+
+    it('writes snapshot even in live mode', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify([{ number: 101, title: 'feat: add login' }]))
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: false, snapshotPath })
+
+      // Assert
+      const raw = await readFile(snapshotPath, 'utf-8')
+      const rows = JSON.parse(raw) as RewriteRow[]
+      expect(rows).toHaveLength(1)
+      expect(rows[0].number).toBe(101)
+    })
+
+    it('calls gh issue edit once per matching issue', async () => {
+      // Arrange — 3 matching + 1 non-matching
+      mockExecSync.mockReturnValue(
+        JSON.stringify([
+          { number: 101, title: 'feat: add login' },
+          { number: 102, title: 'fix: null pointer' },
+          { number: 103, title: 'chore: bump deps' },
+          { number: 201, title: 'random title' },
+        ]),
+      )
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: false, snapshotPath })
+
+      // Assert
+      const calls = mockExecSync.mock.calls as string[][]
+      const editCalls = calls.filter((args) => String(args[0]).includes('gh issue edit'))
+      expect(editCalls).toHaveLength(3)
+    })
+  })
+
+  describe('summary line', () => {
+    it('prints a line matching /Stripped \\d+ titles/', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify(matchingIssues))
+      const logSpy = console.log as ReturnType<typeof vi.fn>
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const logCalls = logSpy.mock.calls.map((c: unknown[]) => String(c[0]))
+      expect(logCalls.some((msg) => /Stripped \d+ titles/.test(msg))).toBe(true)
+    })
+
+    it('reports 16 stripped titles when all 16 matching issues provided', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify(matchingIssues))
+      const logSpy = console.log as ReturnType<typeof vi.fn>
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const logCalls = logSpy.mock.calls.map((c: unknown[]) => String(c[0]))
+      expect(logCalls.some((msg) => msg.includes('Stripped 16 titles'))).toBe(true)
+    })
+
+    it('reports 0 stripped titles when no issues match', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(JSON.stringify(nonMatchingIssues))
+      const logSpy = console.log as ReturnType<typeof vi.fn>
+
+      // Act
+      await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+
+      // Assert
+      const logCalls = logSpy.mock.calls.map((c: unknown[]) => String(c[0]))
+      expect(logCalls.some((msg) => msg.includes('Stripped 0 titles'))).toBe(true)
+    })
   })
 })

--- a/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
@@ -1,0 +1,553 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readFile } from 'node:fs/promises'
+
+// Env vars must be set before config-helpers module loads
+process.env.GITHUB_REPO = 'Roxabi/test'
+process.env.GH_PROJECT_ID = 'PVT_test'
+process.env.STATUS_FIELD_ID = 'SF_test'
+process.env.SIZE_FIELD_ID = 'SZF_test'
+process.env.PRIORITY_FIELD_ID = 'PF_test'
+process.env.LANE_FIELD_ID = 'LF_test'
+process.env.STATUS_OPTIONS_JSON = JSON.stringify({
+  Backlog: 'status-backlog',
+  Analysis: 'status-analysis',
+  Specs: 'status-specs',
+  'In Progress': 'status-inprog',
+  Review: 'status-review',
+  Done: 'status-done',
+})
+process.env.SIZE_OPTIONS_JSON = JSON.stringify({
+  XS: 'size-xs',
+  S: 'size-s',
+  M: 'size-m',
+  L: 'size-l',
+  XL: 'size-xl',
+})
+process.env.PRIORITY_OPTIONS_JSON = JSON.stringify({
+  'P0 - Urgent': 'pri-urgent',
+  'P1 - High': 'pri-high',
+  'P2 - Medium': 'pri-medium',
+  'P3 - Low': 'pri-low',
+})
+process.env.LANE_OPTIONS_JSON = JSON.stringify(
+  Object.fromEntries(
+    [
+      'a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3',
+      'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+      'l', 'm', 'n', 'o', 'standalone',
+    ].map((k) => [k, `lane-${k}`]),
+  ),
+)
+
+// Full DEFAULT_LANE_OPTIONS list (20 entries) — mirrors config-helpers.ts
+const ALL_LANE_KEYS = [
+  'a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3',
+  'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+  'l', 'm', 'n', 'o', 'standalone',
+]
+
+vi.mock('../../shared/adapters/config-helpers', () => ({
+  isProjectConfigured: () => true,
+  NOT_CONFIGURED_MSG: 'GitHub Project V2 is not configured.',
+  GITHUB_REPO: 'Roxabi/test',
+  GH_PROJECT_ID: 'PVT_test',
+  STATUS_FIELD_ID: 'SF_test',
+  SIZE_FIELD_ID: 'SZF_test',
+  PRIORITY_FIELD_ID: 'PF_test',
+  LANE_FIELD_ID: 'LF_test',
+  STATUS_OPTIONS: {
+    Backlog: 'status-backlog',
+    Analysis: 'status-analysis',
+    Specs: 'status-specs',
+    'In Progress': 'status-inprog',
+    Review: 'status-review',
+    Done: 'status-done',
+  },
+  SIZE_OPTIONS: { XS: 'size-xs', S: 'size-s', M: 'size-m', L: 'size-l', XL: 'size-xl' },
+  PRIORITY_OPTIONS: {
+    'P0 - Urgent': 'pri-urgent',
+    'P1 - High': 'pri-high',
+    'P2 - Medium': 'pri-medium',
+    'P3 - Low': 'pri-low',
+  },
+  LANE_OPTIONS: Object.fromEntries(
+    [
+      'a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3',
+      'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+      'l', 'm', 'n', 'o', 'standalone',
+    ].map((k) => [k, `lane-${k}`]),
+  ),
+  DEFAULT_LANE_OPTIONS: [
+    'a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3',
+    'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+    'l', 'm', 'n', 'o', 'standalone',
+  ],
+  resolveStatus: (input: string) => {
+    const aliases: Record<string, string> = {
+      BACKLOG: 'Backlog', ANALYSIS: 'Analysis', SPECS: 'Specs',
+      'IN PROGRESS': 'In Progress', IN_PROGRESS: 'In Progress',
+      INPROGRESS: 'In Progress', REVIEW: 'Review', DONE: 'Done',
+    }
+    const canonical = new Set(['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done'])
+    if (canonical.has(input)) return input
+    return aliases[input.toUpperCase()]
+  },
+  resolveSize: (input: string) => {
+    const u = input.toUpperCase()
+    return new Set(['XS', 'S', 'M', 'L', 'XL']).has(u) ? u : undefined
+  },
+  resolvePriority: (input: string) => {
+    const canonical = new Set(['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'])
+    if (canonical.has(input)) return input
+    const aliases: Record<string, string> = {
+      URGENT: 'P0 - Urgent', HIGH: 'P1 - High', MEDIUM: 'P2 - Medium', LOW: 'P3 - Low',
+      P0: 'P0 - Urgent', P1: 'P1 - High', P2: 'P2 - Medium', P3: 'P3 - Low',
+    }
+    return aliases[input.toUpperCase()]
+  },
+  resolveLane: (input: string) => {
+    const valid = new Set([
+      'a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3',
+      'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+      'l', 'm', 'n', 'o', 'standalone',
+    ])
+    return valid.has(input) ? input : undefined
+  },
+}))
+
+vi.mock('../../shared/adapters/github-adapter', () => ({
+  ghGraphQL: vi.fn(),
+  getItemId: vi.fn(),
+  getNodeId: vi.fn(),
+  getParentNumber: vi.fn(),
+  updateField: vi.fn(),
+  addBlockedBy: vi.fn(),
+  removeBlockedBy: vi.fn(),
+  addSubIssue: vi.fn(),
+  removeSubIssue: vi.fn(),
+  resolveIssueTypeId: vi.fn(),
+  updateIssueIssueType: vi.fn(),
+}))
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}))
+
+const github = await import('../../shared/adapters/github-adapter')
+const mockGhGraphQL = github.ghGraphQL as ReturnType<typeof vi.fn>
+const mockUpdateField = github.updateField as ReturnType<typeof vi.fn>
+const mockResolveIssueTypeId = github.resolveIssueTypeId as ReturnType<typeof vi.fn>
+const mockUpdateIssueIssueType = github.updateIssueIssueType as ReturnType<typeof vi.fn>
+
+const childProcess = await import('node:child_process')
+const mockExecSync = childProcess.execSync as ReturnType<typeof vi.fn>
+
+const { LEGACY_LABEL_MAP, TITLE_PREFIX_RE, auditSchema, backfill } = await import('../lib/migrate')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAuditSchemaResponse(laneOptions: string[]) {
+  return {
+    node: {
+      fields: {
+        nodes: [
+          {
+            id: 'f-size', name: 'Size',
+            options: ['XS', 'S', 'M', 'L', 'XL'].map((n) => ({ id: `s-${n}`, name: n })),
+          },
+          {
+            id: 'f-lane', name: 'Lane',
+            options: laneOptions.map((n) => ({ id: `l-${n}`, name: n })),
+          },
+          {
+            id: 'f-priority', name: 'Priority',
+            options: ['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'].map((n) => ({ id: `p-${n}`, name: n })),
+          },
+          {
+            id: 'f-status', name: 'Status',
+            options: ['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done'].map((n) => ({
+              id: `st-${n}`,
+              name: n,
+            })),
+          },
+        ],
+      },
+    },
+  }
+}
+
+function makeItemFieldsResponse(opts: {
+  issueId: string
+  itemId: string
+  fields: Record<string, string>
+  issueTypeName?: string
+}) {
+  return {
+    repository: {
+      issue: {
+        id: opts.issueId,
+        issueType: opts.issueTypeName ? { id: 'type-id', name: opts.issueTypeName } : null,
+        projectItems: {
+          nodes: [
+            {
+              id: opts.itemId,
+              project: { id: 'PVT_test' },
+              fieldValues: {
+                nodes: Object.entries(opts.fields).map(([fieldName, value]) => ({
+                  name: value,
+                  field: { name: fieldName },
+                })),
+              },
+            },
+          ],
+        },
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. LEGACY_LABEL_MAP completeness
+// ---------------------------------------------------------------------------
+
+describe('migrate > LEGACY_LABEL_MAP', () => {
+  describe('size mappings', () => {
+    it('maps S to S', () => {
+      // Arrange / Act / Assert
+      expect(LEGACY_LABEL_MAP.size.S).toBe('S')
+    })
+
+    it('maps M to F-lite', () => {
+      expect(LEGACY_LABEL_MAP.size.M).toBe('F-lite')
+    })
+
+    it('maps L to F-full', () => {
+      expect(LEGACY_LABEL_MAP.size.L).toBe('F-full')
+    })
+
+    it('maps XL to F-full', () => {
+      expect(LEGACY_LABEL_MAP.size.XL).toBe('F-full')
+    })
+  })
+
+  describe('priority mappings', () => {
+    it('maps P0 to P0 - Urgent', () => {
+      expect(LEGACY_LABEL_MAP.priority.P0).toBe('P0 - Urgent')
+    })
+
+    it('maps P1 to P1 - High', () => {
+      expect(LEGACY_LABEL_MAP.priority.P1).toBe('P1 - High')
+    })
+
+    it('maps P2 to P2 - Medium', () => {
+      expect(LEGACY_LABEL_MAP.priority.P2).toBe('P2 - Medium')
+    })
+
+    it('maps P3 to P3 - Low', () => {
+      expect(LEGACY_LABEL_MAP.priority.P3).toBe('P3 - Low')
+    })
+  })
+
+  describe('issueType mappings', () => {
+    it('contains all 8 conventional-commit types', () => {
+      // Arrange
+      const expected = ['feat', 'fix', 'docs', 'test', 'chore', 'ci', 'perf', 'refactor']
+      // Act / Assert
+      for (const type of expected) {
+        expect(LEGACY_LABEL_MAP.issueType[type]).toBe(type)
+      }
+      expect(Object.keys(LEGACY_LABEL_MAP.issueType)).toHaveLength(8)
+    })
+
+    it('maps feat to feat', () => {
+      expect(LEGACY_LABEL_MAP.issueType.feat).toBe('feat')
+    })
+
+    it('maps refactor to refactor', () => {
+      expect(LEGACY_LABEL_MAP.issueType.refactor).toBe('refactor')
+    })
+  })
+
+  describe('lane mappings', () => {
+    it('contains all 20 canonical lane keys from DEFAULT_LANE_OPTIONS', () => {
+      // Arrange
+      const laneKeys = Object.keys(LEGACY_LABEL_MAP.lane)
+      // Assert
+      expect(laneKeys).toHaveLength(ALL_LANE_KEYS.length)
+      for (const key of ALL_LANE_KEYS) {
+        expect(LEGACY_LABEL_MAP.lane[key]).toBe(key)
+      }
+    })
+
+    it('maps c1 to c1 (identity mapping)', () => {
+      expect(LEGACY_LABEL_MAP.lane.c1).toBe('c1')
+    })
+
+    it('maps standalone to standalone', () => {
+      expect(LEGACY_LABEL_MAP.lane.standalone).toBe('standalone')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. TITLE_PREFIX_RE correctness
+// ---------------------------------------------------------------------------
+
+describe('migrate > TITLE_PREFIX_RE', () => {
+  it('matches feat(foo): bar and captures feat as group 1', () => {
+    // Arrange
+    const title = 'feat(foo): bar'
+    // Act
+    const match = title.match(TITLE_PREFIX_RE)
+    // Assert
+    expect(match).not.toBeNull()
+    expect(match![1]).toBe('feat')
+  })
+
+  it('matches chore: baz and captures chore as group 1', () => {
+    const match = 'chore: baz'.match(TITLE_PREFIX_RE)
+    expect(match).not.toBeNull()
+    expect(match![1]).toBe('chore')
+  })
+
+  it('matches fix(complex-scope): x and captures fix as group 1', () => {
+    const match = 'fix(complex-scope): x'.match(TITLE_PREFIX_RE)
+    expect(match).not.toBeNull()
+    expect(match![1]).toBe('fix')
+  })
+
+  it('does not match plain title without conventional prefix', () => {
+    expect('random title'.match(TITLE_PREFIX_RE)).toBeNull()
+  })
+
+  it('does not match when first word is not a known type', () => {
+    expect('colon: but no type'.match(TITLE_PREFIX_RE)).toBeNull()
+  })
+
+  it('matches all 8 conventional-commit types', () => {
+    // Arrange
+    const types = ['feat', 'fix', 'refactor', 'docs', 'test', 'chore', 'ci', 'perf']
+    for (const type of types) {
+      // Act
+      const match = `${type}: something`.match(TITLE_PREFIX_RE)
+      // Assert
+      expect(match).not.toBeNull()
+      expect(match![1]).toBe(type)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3 & 4. auditSchema
+// ---------------------------------------------------------------------------
+
+describe('migrate > auditSchema', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('exits 1 and prints diff lines when Lane field has mismatched options', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    // Return a Lane field with only 2 options, causing LOCAL_EXTRA diffs
+    mockGhGraphQL.mockResolvedValue(makeAuditSchemaResponse(['a1', 'b']))
+    // Act
+    await auditSchema()
+    // Assert
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const logCalls = (console.log as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    const hasDiffLines = logCalls.some(
+      (msg) => msg.startsWith('LOCAL_EXTRA:') || msg.startsWith('LOCAL_MISSING:') || msg.startsWith('MISSING:'),
+    )
+    expect(hasDiffLines).toBe(true)
+  })
+
+  it('does not exit and prints success when all fields match live project', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    mockGhGraphQL.mockResolvedValue(makeAuditSchemaResponse(ALL_LANE_KEYS))
+    // Act
+    await auditSchema()
+    // Assert
+    expect(exitSpy).not.toHaveBeenCalled()
+    const logCalls = (console.log as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(logCalls.some((msg) => msg.includes('OK'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5. backfill --dry-run
+// ---------------------------------------------------------------------------
+
+describe('migrate > backfill --dry-run', () => {
+  let snapshotPath: string
+
+  const labeledIssue = {
+    number: 1,
+    title: 'feat(x): hi',
+    labels: [
+      { name: 'graph:lane/c1' },
+      { name: 'size:M' },
+      { name: 'P1-high' },
+    ],
+    id: 'node-1',
+  }
+
+  const unlabeledIssue = {
+    number: 2,
+    title: 'hello',
+    labels: [],
+    id: 'node-2',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    snapshotPath = join(tmpdir(), `migrate-test-snapshot-${Date.now()}.json`)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // audit passes
+    mockGhGraphQL.mockImplementation(async (_query: string, vars: Record<string, unknown>) => {
+      // PROJECT_FIELDS_QUERY (audit) — no owner/repo vars
+      if (!vars.owner) {
+        return makeAuditSchemaResponse(ALL_LANE_KEYS)
+      }
+      // ITEM_FIELDS_QUERY for issue 1 (labeled, all fields populated)
+      if (vars.number === 1) {
+        return makeItemFieldsResponse({
+          issueId: 'node-1',
+          itemId: 'item-1',
+          fields: { Lane: 'c1', Size: 'F-lite', Priority: 'P1 - High' },
+          issueTypeName: 'feat',
+        })
+      }
+      // ITEM_FIELDS_QUERY for issue 2 (unlabeled, no fields set)
+      return makeItemFieldsResponse({
+        issueId: 'node-2',
+        itemId: 'item-2',
+        fields: {},
+      })
+    })
+
+    mockExecSync.mockReturnValue(JSON.stringify([labeledIssue, unlabeledIssue]))
+    mockResolveIssueTypeId.mockResolvedValue('type-id-feat')
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('does not call updateField or updateIssueIssueType in dry-run', async () => {
+    // Act
+    await backfill({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+    // Assert
+    expect(mockUpdateField).not.toHaveBeenCalled()
+    expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+  })
+
+  it('writes snapshot file with rows for the labeled issue', async () => {
+    // Act
+    await backfill({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+    // Assert — snapshot is written and contains rows for issue 1
+    // (issue 2 has no labels and plain title → no fields to map → 0 rows emitted for it)
+    const raw = await readFile(snapshotPath, 'utf-8')
+    const rows = JSON.parse(raw) as Array<{ number: number; repo: string }>
+    expect(rows.length).toBeGreaterThanOrEqual(1)
+    const numbers = rows.map((r) => r.number)
+    expect(numbers).toContain(1)
+  })
+
+  it('snapshot includes at least one row from the unlabeled issue (issue 2)', async () => {
+    // The unlabeled issue has no labels and a plain title → no fields to set, but
+    // issue 2 has no project item fields populated and no labels, so it produces no
+    // rows (nothing to migrate). It should not be flagged for unknown tokens.
+    await backfill({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
+    const raw = await readFile(snapshotPath, 'utf-8')
+    const rows = JSON.parse(raw) as Array<{ number: number; field: string; new_value: string | null; flagged: boolean }>
+    // Issue 1 has all fields already set — rows should record skipped (old_value = new_value)
+    const issue1Rows = rows.filter((r) => r.number === 1)
+    expect(issue1Rows.length).toBeGreaterThan(0)
+    // All issue 1 rows are skipped (fields already populated)
+    for (const row of issue1Rows) {
+      expect(row.flagged).toBe(false)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 6. backfill idempotency
+// ---------------------------------------------------------------------------
+
+describe('migrate > backfill idempotency', () => {
+  let snapshotPath: string
+
+  const fullyPopulatedIssue = {
+    number: 10,
+    title: 'feat(y): already done',
+    labels: [
+      { name: 'graph:lane/a1' },
+      { name: 'size:S' },
+      { name: 'P2-medium' },
+    ],
+    id: 'node-10',
+  }
+
+  function setupFullyPopulatedMocks() {
+    mockGhGraphQL.mockImplementation(async (_query: string, vars: Record<string, unknown>) => {
+      if (!vars.owner) {
+        return makeAuditSchemaResponse(ALL_LANE_KEYS)
+      }
+      return makeItemFieldsResponse({
+        issueId: 'node-10',
+        itemId: 'item-10',
+        fields: { Lane: 'a1', Size: 'S', Priority: 'P2 - Medium' },
+        issueTypeName: 'feat',
+      })
+    })
+    mockExecSync.mockReturnValue(JSON.stringify([fullyPopulatedIssue]))
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    snapshotPath = join(tmpdir(), `migrate-idempotent-${Date.now()}.json`)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockResolveIssueTypeId.mockResolvedValue('type-id-feat')
+    setupFullyPopulatedMocks()
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('produces 0 mutations on first run when all fields are already set', async () => {
+    // Act
+    await backfill({ repo: 'Roxabi/test', dryRun: false, snapshotPath })
+    // Assert
+    expect(mockUpdateField).not.toHaveBeenCalled()
+    expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+  })
+
+  it('produces 0 mutations on second run (idempotent)', async () => {
+    // Arrange — run once
+    const path1 = join(tmpdir(), `migrate-idempotent-run1-${Date.now()}.json`)
+    await backfill({ repo: 'Roxabi/test', dryRun: false, snapshotPath: path1 })
+    const callsAfterFirst = mockUpdateField.mock.calls.length + mockUpdateIssueIssueType.mock.calls.length
+
+    // Act — run again with same state
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    setupFullyPopulatedMocks()
+    const path2 = join(tmpdir(), `migrate-idempotent-run2-${Date.now()}.json`)
+    await backfill({ repo: 'Roxabi/test', dryRun: false, snapshotPath: path2 })
+
+    // Assert
+    expect(callsAfterFirst).toBe(0)
+    expect(mockUpdateField).not.toHaveBeenCalled()
+    expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+  })
+})

--- a/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
@@ -225,6 +225,8 @@ vi.mock('../../shared/adapters/github-adapter', () => ({
   removeSubIssue: vi.fn(),
   resolveIssueTypeId: vi.fn(),
   updateIssueIssueType: vi.fn(),
+  clearField: vi.fn(),
+  run: vi.fn(),
 }))
 
 vi.mock('node:child_process', () => ({
@@ -236,11 +238,15 @@ const mockGhGraphQL = github.ghGraphQL as ReturnType<typeof vi.fn>
 const mockUpdateField = github.updateField as ReturnType<typeof vi.fn>
 const mockResolveIssueTypeId = github.resolveIssueTypeId as ReturnType<typeof vi.fn>
 const mockUpdateIssueIssueType = github.updateIssueIssueType as ReturnType<typeof vi.fn>
+const mockClearField = github.clearField as ReturnType<typeof vi.fn>
+const mockRun = github.run as ReturnType<typeof vi.fn>
 
 const childProcess = await import('node:child_process')
 const mockExecSync = childProcess.execSync as ReturnType<typeof vi.fn>
 
-const { LEGACY_LABEL_MAP, TITLE_PREFIX_RE, auditSchema, backfill, rewriteTitles } = await import('../lib/migrate')
+const { LEGACY_LABEL_MAP, TITLE_PREFIX_RE, auditSchema, backfill, rewriteTitles, revert } = await import(
+  '../lib/migrate'
+)
 
 // Local mirror of RewriteRow (not exported from migrate.ts)
 interface RewriteRow {
@@ -248,6 +254,16 @@ interface RewriteRow {
   number: number
   old_title: string
   new_title: string
+}
+
+// Local mirror of BackfillRow (not exported from migrate.ts)
+interface BackfillRow {
+  repo: string
+  number: number
+  field: string
+  old_value: string | null
+  new_value: string | null
+  flagged: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -962,6 +978,217 @@ describe('migrate > rewriteTitles', () => {
       // Assert
       const logCalls = logSpy.mock.calls.map((c: unknown[]) => String(c[0]))
       expect(logCalls.some((msg) => msg.includes('Stripped 0 titles'))).toBe(true)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 8. revert
+// ---------------------------------------------------------------------------
+
+import { writeFile } from 'node:fs/promises'
+
+describe('migrate > revert', () => {
+  let snapshotPath: string
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    snapshotPath = join(tmpdir(), `revert-test-snapshot-${Date.now()}.json`)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockClearField.mockResolvedValue(undefined)
+    mockUpdateIssueIssueType.mockResolvedValue(undefined)
+    mockRun.mockResolvedValue('')
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  describe('backfill snapshot kind', () => {
+    it('detects backfill snapshot and calls clearField for non-flagged rows with non-null new_value', async () => {
+      // Arrange
+      const rows: BackfillRow[] = [
+        { repo: 'Roxabi/test', number: 10, field: 'Lane', old_value: null, new_value: 'c1', flagged: false },
+        { repo: 'Roxabi/test', number: 10, field: 'Size', old_value: null, new_value: 'S', flagged: false },
+        { repo: 'Roxabi/test', number: 10, field: 'Priority', old_value: null, new_value: 'P1 - High', flagged: false },
+      ]
+      await writeFile(snapshotPath, JSON.stringify(rows), 'utf-8')
+
+      mockGhGraphQL.mockResolvedValue(
+        makeItemFieldsResponse({
+          issueId: 'node-10',
+          itemId: 'item-10',
+          fields: { Lane: 'c1', Size: 'S', Priority: 'P1 - High' },
+        }),
+      )
+
+      // Act
+      await revert({ snapshotPath })
+
+      // Assert — clearField called once per row (Lane, Size, Priority)
+      expect(mockClearField).toHaveBeenCalledTimes(3)
+    })
+
+    it('calls updateIssueIssueType(issueNodeId, null) for issueType rows', async () => {
+      // Arrange
+      const rows: BackfillRow[] = [
+        { repo: 'Roxabi/test', number: 11, field: 'issueType', old_value: null, new_value: 'feat', flagged: false },
+      ]
+      await writeFile(snapshotPath, JSON.stringify(rows), 'utf-8')
+
+      mockGhGraphQL.mockResolvedValue(
+        makeItemFieldsResponse({
+          issueId: 'node-11',
+          itemId: 'item-11',
+          fields: {},
+          issueTypeName: 'feat',
+        }),
+      )
+
+      // Act
+      await revert({ snapshotPath })
+
+      // Assert
+      expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-11', null)
+    })
+  })
+
+  describe('rewrite snapshot kind', () => {
+    it('detects rewrite snapshot and calls gh issue edit --title <old_title> per row', async () => {
+      // Arrange
+      const rows: RewriteRow[] = [
+        { repo: 'Roxabi/test', number: 20, old_title: 'feat: add login', new_title: 'add login' },
+        { repo: 'Roxabi/test', number: 21, old_title: 'fix: null ptr', new_title: 'null ptr' },
+      ]
+      await writeFile(snapshotPath, JSON.stringify(rows), 'utf-8')
+
+      // Mock gh issue view to return the new_title (migration applied) so revert should trigger
+      mockRun.mockImplementation(async (cmd: string[]) => {
+        if (cmd.includes('view')) {
+          const idx = rows.findIndex((r) => cmd.includes(String(r.number)))
+          return idx >= 0 ? rows[idx].new_title : ''
+        }
+        return ''
+      })
+
+      // Act
+      await revert({ snapshotPath })
+
+      // Assert — gh issue edit called for both rows
+      const editCalls = mockRun.mock.calls.filter((c: string[][]) => c[0].includes('edit'))
+      expect(editCalls).toHaveLength(2)
+
+      const firstEdit = editCalls[0][0] as string[]
+      expect(firstEdit).toContain('--title')
+      expect(firstEdit).toContain('feat: add login')
+    })
+  })
+
+  describe('idempotency', () => {
+    it('skips backfill row when field is already cleared (currentFields has no value for that field)', async () => {
+      // Arrange — new_value set but project field already cleared
+      const rows: BackfillRow[] = [
+        { repo: 'Roxabi/test', number: 30, field: 'Lane', old_value: null, new_value: 'a1', flagged: false },
+      ]
+      await writeFile(snapshotPath, JSON.stringify(rows), 'utf-8')
+
+      // Field is absent from live data (already reverted)
+      mockGhGraphQL.mockResolvedValue(
+        makeItemFieldsResponse({
+          issueId: 'node-30',
+          itemId: 'item-30',
+          fields: {},
+        }),
+      )
+
+      // Act
+      await revert({ snapshotPath })
+
+      // Assert
+      expect(mockClearField).not.toHaveBeenCalled()
+      const logCalls = (console.log as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+      expect(logCalls.some((msg) => msg.includes('skip #30'))).toBe(true)
+    })
+
+    it('skips rewrite row when current title already matches old_title', async () => {
+      // Arrange — issue already reverted: current title = old_title
+      const rows: RewriteRow[] = [
+        { repo: 'Roxabi/test', number: 40, old_title: 'feat: add login', new_title: 'add login' },
+      ]
+      await writeFile(snapshotPath, JSON.stringify(rows), 'utf-8')
+
+      // gh issue view returns old_title (already restored)
+      mockRun.mockResolvedValue('feat: add login')
+
+      // Act
+      await revert({ snapshotPath })
+
+      // Assert
+      const editCalls = mockRun.mock.calls.filter((c: string[][]) => c[0].includes('edit'))
+      expect(editCalls).toHaveLength(0)
+      const logCalls = (console.log as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+      expect(logCalls.some((msg) => msg.includes('skip #40'))).toBe(true)
+    })
+  })
+
+  describe('unknown snapshot format', () => {
+    it('calls process.exit(1) with a message when snapshot is not a recognized format', async () => {
+      // Arrange — array of objects that match neither backfill nor rewrite shape
+      const unknown = [{ foo: 'bar' }]
+      await writeFile(snapshotPath, JSON.stringify(unknown), 'utf-8')
+
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+
+      // Act
+      await revert({ snapshotPath })
+
+      // Assert
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      const errorCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+      expect(errorCalls.some((msg) => /unknown snapshot format/i.test(msg))).toBe(true)
+    })
+  })
+
+  describe('flagged rows', () => {
+    it('skips clearField for flagged backfill rows', async () => {
+      // Arrange
+      const rows: BackfillRow[] = [
+        { repo: 'Roxabi/test', number: 50, field: 'Lane', old_value: null, new_value: null, flagged: true },
+      ]
+      await writeFile(snapshotPath, JSON.stringify(rows), 'utf-8')
+
+      // Act
+      await revert({ snapshotPath })
+
+      // Assert — flagged row skipped, no field fetched, no clearField called
+      expect(mockGhGraphQL).not.toHaveBeenCalled()
+      expect(mockClearField).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('summary line', () => {
+    it('prints a line matching /Reverted \\d+ rows/', async () => {
+      // Arrange — one non-flagged row that will be reverted
+      const rows: BackfillRow[] = [
+        { repo: 'Roxabi/test', number: 60, field: 'Size', old_value: null, new_value: 'S', flagged: false },
+      ]
+      await writeFile(snapshotPath, JSON.stringify(rows), 'utf-8')
+
+      mockGhGraphQL.mockResolvedValue(
+        makeItemFieldsResponse({
+          issueId: 'node-60',
+          itemId: 'item-60',
+          fields: { Size: 'S' },
+        }),
+      )
+
+      const logSpy = console.log as ReturnType<typeof vi.fn>
+
+      // Act
+      await revert({ snapshotPath })
+
+      // Assert
+      const logCalls = logSpy.mock.calls.map((c: unknown[]) => String(c[0]))
+      expect(logCalls.some((msg) => /Reverted \d+ rows/.test(msg))).toBe(true)
     })
   })
 })

--- a/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
@@ -227,10 +227,12 @@ vi.mock('../../shared/adapters/github-adapter', () => ({
   updateIssueIssueType: vi.fn(),
   clearField: vi.fn(),
   run: vi.fn(),
+  listOrgIssueTypes: vi.fn(),
 }))
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }))
 
 const github = await import('../../shared/adapters/github-adapter')
@@ -240,9 +242,26 @@ const mockResolveIssueTypeId = github.resolveIssueTypeId as ReturnType<typeof vi
 const mockUpdateIssueIssueType = github.updateIssueIssueType as ReturnType<typeof vi.fn>
 const mockClearField = github.clearField as ReturnType<typeof vi.fn>
 const mockRun = github.run as ReturnType<typeof vi.fn>
+const mockListOrgIssueTypes = github.listOrgIssueTypes as ReturnType<typeof vi.fn>
 
 const childProcess = await import('node:child_process')
-const mockExecSync = childProcess.execSync as ReturnType<typeof vi.fn>
+// execSync retained in mock for backwards compat but not used in tests after fix #1
+const _mockExecSync = childProcess.execSync as ReturnType<typeof vi.fn>
+const mockExecFileSync = childProcess.execFileSync as ReturnType<typeof vi.fn>
+
+/** Helper: read snapshot rows from the new envelope format {kind, generatedAt, rows}. */
+function readSnapshotRows<T>(raw: string): T[] {
+  const parsed = JSON.parse(raw) as unknown
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    !Array.isArray(parsed) &&
+    'rows' in (parsed as Record<string, unknown>)
+  ) {
+    return ((parsed as Record<string, unknown>).rows as T[]) ?? []
+  }
+  return parsed as T[]
+}
 
 const { LEGACY_LABEL_MAP, TITLE_PREFIX_RE, auditSchema, backfill, rewriteTitles, revert } = await import(
   '../lib/migrate'
@@ -340,6 +359,11 @@ function makeItemFieldsResponse(opts: {
 
 describe('migrate > LEGACY_LABEL_MAP', () => {
   describe('size mappings', () => {
+    it('maps XS to S (collapsed to smallest new-schema bucket)', () => {
+      // XS → S: collapsed to smallest new-schema bucket; XS has no equivalent in S/F-lite/F-full
+      expect(LEGACY_LABEL_MAP.size.XS).toBe('S')
+    })
+
     it('maps S to S', () => {
       // Arrange / Act / Assert
       expect(LEGACY_LABEL_MAP.size.S).toBe('S')
@@ -557,8 +581,10 @@ describe('migrate > backfill --dry-run', () => {
       })
     })
 
-    mockExecSync.mockReturnValue(JSON.stringify([labeledIssue, unlabeledIssue]))
+    mockExecFileSync.mockReturnValue(JSON.stringify([labeledIssue, unlabeledIssue]))
     mockResolveIssueTypeId.mockResolvedValue('type-id-feat')
+    // fix #4: listOrgIssueTypes pre-resolves type IDs once
+    mockListOrgIssueTypes.mockResolvedValue([{ id: 'type-id-feat', name: 'feat', color: 'blue', isEnabled: true }])
   })
 
   afterEach(() => vi.restoreAllMocks())
@@ -577,7 +603,7 @@ describe('migrate > backfill --dry-run', () => {
     // Assert — snapshot is written and contains rows for issue 1
     // (issue 2 has no labels and plain title → no fields to map → 0 rows emitted for it)
     const raw = await readFile(snapshotPath, 'utf-8')
-    const rows = JSON.parse(raw) as Array<{ number: number; repo: string }>
+    const rows = readSnapshotRows<{ number: number; repo: string }>(raw)
     expect(rows.length).toBeGreaterThanOrEqual(1)
     const numbers = rows.map((r) => r.number)
     expect(numbers).toContain(1)
@@ -589,7 +615,7 @@ describe('migrate > backfill --dry-run', () => {
     // rows (nothing to migrate). It should not be flagged for unknown tokens.
     await backfill({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
     const raw = await readFile(snapshotPath, 'utf-8')
-    const rows = JSON.parse(raw) as Array<{ number: number; field: string; new_value: string | null; flagged: boolean }>
+    const rows = readSnapshotRows<{ number: number; field: string; new_value: string | null; flagged: boolean }>(raw)
     // Issue 1 has all fields already set — rows should record skipped (old_value = new_value)
     const issue1Rows = rows.filter((r) => r.number === 1)
     expect(issue1Rows.length).toBeGreaterThan(0)
@@ -626,7 +652,8 @@ describe('migrate > backfill idempotency', () => {
         issueTypeName: 'feat',
       })
     })
-    mockExecSync.mockReturnValue(JSON.stringify([fullyPopulatedIssue]))
+    mockExecFileSync.mockReturnValue(JSON.stringify([fullyPopulatedIssue]))
+    mockListOrgIssueTypes.mockResolvedValue([{ id: 'type-id-feat', name: 'feat', color: 'blue', isEnabled: true }])
   }
 
   beforeEach(() => {
@@ -713,27 +740,27 @@ describe('migrate > rewriteTitles', () => {
   describe('dry-run with all 8 conventional-commit types (with and without scope)', () => {
     it('writes snapshot with 16 rows — one per matching title', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify(matchingIssues))
+      mockExecFileSync.mockReturnValue(JSON.stringify(matchingIssues))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       expect(rows).toHaveLength(16)
     })
 
     it('each snapshot row has repo, number, old_title, new_title fields', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify(matchingIssues))
+      mockExecFileSync.mockReturnValue(JSON.stringify(matchingIssues))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       for (const row of rows) {
         expect(row).toHaveProperty('repo', 'Roxabi/test')
         expect(row).toHaveProperty('number')
@@ -745,14 +772,14 @@ describe('migrate > rewriteTitles', () => {
     it('strips prefix from all 8 types without scope', async () => {
       // Arrange
       const withoutScope = matchingIssues.filter((_, i) => i % 2 === 0) // even indices = no scope
-      mockExecSync.mockReturnValue(JSON.stringify(withoutScope))
+      mockExecFileSync.mockReturnValue(JSON.stringify(withoutScope))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       expect(rows).toHaveLength(8)
       for (const row of rows) {
         // new_title must not start with any conventional-commit prefix
@@ -763,14 +790,14 @@ describe('migrate > rewriteTitles', () => {
     it('strips prefix from all 8 types with scope', async () => {
       // Arrange
       const withScope = matchingIssues.filter((_, i) => i % 2 === 1) // odd indices = with scope
-      mockExecSync.mockReturnValue(JSON.stringify(withScope))
+      mockExecFileSync.mockReturnValue(JSON.stringify(withScope))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       expect(rows).toHaveLength(8)
       for (const row of rows) {
         expect(row.new_title).not.toMatch(/^(feat|fix|refactor|docs|test|chore|ci|perf)(\(.+?\))?:\s*/)
@@ -779,40 +806,41 @@ describe('migrate > rewriteTitles', () => {
 
     it('does not call gh issue edit in dry-run mode', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify(matchingIssues))
+      mockExecFileSync.mockReturnValue(JSON.stringify(matchingIssues))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
 
       // Assert — only the gh issue list call happened, no edit calls
-      const calls = mockExecSync.mock.calls as string[][]
-      const editCalls = calls.filter((args) => String(args[0]).includes('gh issue edit'))
+      // execFileSync is called with ('gh', argv[]) — check no call has 'edit' as second-element arg[1]
+      const calls = mockExecFileSync.mock.calls as [string, string[]][]
+      const editCalls = calls.filter((args) => Array.isArray(args[1]) && args[1].includes('edit'))
       expect(editCalls).toHaveLength(0)
     })
 
     it('preserves body text after stripping prefix (no scope)', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify([{ number: 101, title: 'feat: add login' }]))
+      mockExecFileSync.mockReturnValue(JSON.stringify([{ number: 101, title: 'feat: add login' }]))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       expect(rows[0].new_title).toBe('add login')
     })
 
     it('preserves body text after stripping prefix (with scope)', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify([{ number: 102, title: 'feat(auth): add oauth' }]))
+      mockExecFileSync.mockReturnValue(JSON.stringify([{ number: 102, title: 'feat(auth): add oauth' }]))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       expect(rows[0].new_title).toBe('add oauth')
     })
   })
@@ -820,46 +848,46 @@ describe('migrate > rewriteTitles', () => {
   describe('non-matching titles are left untouched', () => {
     it('writes empty snapshot when no titles match', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify(nonMatchingIssues))
+      mockExecFileSync.mockReturnValue(JSON.stringify(nonMatchingIssues))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       expect(rows).toHaveLength(0)
     })
 
     it('does not emit a row for plain title without colon', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify([{ number: 201, title: 'random title' }]))
+      mockExecFileSync.mockReturnValue(JSON.stringify([{ number: 201, title: 'random title' }]))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       expect(rows).toHaveLength(0)
     })
 
     it('does not emit a row for colon present but no valid type keyword', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify([{ number: 202, title: 'colon: but no type keyword' }]))
+      mockExecFileSync.mockReturnValue(JSON.stringify([{ number: 202, title: 'colon: but no type keyword' }]))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: true, snapshotPath })
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       expect(rows).toHaveLength(0)
     })
 
     it('does not emit a row for scope-like prefix without valid type keyword', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(
+      mockExecFileSync.mockReturnValue(
         JSON.stringify([{ number: 203, title: 'foo(scope): bar but no type keyword either' }]),
       )
 
@@ -868,20 +896,20 @@ describe('migrate > rewriteTitles', () => {
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       expect(rows).toHaveLength(0)
     })
 
     it('does not call gh issue edit for non-matching titles', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify(nonMatchingIssues))
+      mockExecFileSync.mockReturnValue(JSON.stringify(nonMatchingIssues))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: false, snapshotPath })
 
       // Assert
-      const calls = mockExecSync.mock.calls as string[][]
-      const editCalls = calls.filter((args) => String(args[0]).includes('gh issue edit'))
+      const calls = mockExecFileSync.mock.calls as [string, string[]][]
+      const editCalls = calls.filter((args) => Array.isArray(args[1]) && args[1].includes('edit'))
       expect(editCalls).toHaveLength(0)
     })
   })
@@ -889,39 +917,40 @@ describe('migrate > rewriteTitles', () => {
   describe('live run calls gh issue edit', () => {
     it('calls gh issue edit with --repo, --title, and issue number', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify([{ number: 101, title: 'feat: add login' }]))
+      mockExecFileSync.mockReturnValue(JSON.stringify([{ number: 101, title: 'feat: add login' }]))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: false, snapshotPath })
 
-      // Assert
-      const calls = mockExecSync.mock.calls as string[][]
-      const editCalls = calls.filter((args) => String(args[0]).includes('gh issue edit'))
+      // Assert — execFileSync is called as execFileSync('gh', argv[]) — check argv content
+      const calls = mockExecFileSync.mock.calls as [string, string[]][]
+      const editCalls = calls.filter((args) => Array.isArray(args[1]) && args[1].includes('edit'))
       expect(editCalls).toHaveLength(1)
-      const cmd = String(editCalls[0][0])
-      expect(cmd).toContain('gh issue edit 101')
-      expect(cmd).toContain('--repo Roxabi/test')
-      expect(cmd).toContain('--title')
-      expect(cmd).toContain('add login')
+      const argv = editCalls[0][1]
+      expect(argv).toContain('101')
+      expect(argv).toContain('--repo')
+      expect(argv).toContain('Roxabi/test')
+      expect(argv).toContain('--title')
+      expect(argv).toContain('add login')
     })
 
     it('writes snapshot even in live mode', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify([{ number: 101, title: 'feat: add login' }]))
+      mockExecFileSync.mockReturnValue(JSON.stringify([{ number: 101, title: 'feat: add login' }]))
 
       // Act
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: false, snapshotPath })
 
       // Assert
       const raw = await readFile(snapshotPath, 'utf-8')
-      const rows = JSON.parse(raw) as RewriteRow[]
+      const rows = readSnapshotRows<RewriteRow>(raw)
       expect(rows).toHaveLength(1)
       expect(rows[0].number).toBe(101)
     })
 
     it('calls gh issue edit once per matching issue', async () => {
       // Arrange — 3 matching + 1 non-matching
-      mockExecSync.mockReturnValue(
+      mockExecFileSync.mockReturnValue(
         JSON.stringify([
           { number: 101, title: 'feat: add login' },
           { number: 102, title: 'fix: null pointer' },
@@ -934,8 +963,8 @@ describe('migrate > rewriteTitles', () => {
       await rewriteTitles({ repo: 'Roxabi/test', dryRun: false, snapshotPath })
 
       // Assert
-      const calls = mockExecSync.mock.calls as string[][]
-      const editCalls = calls.filter((args) => String(args[0]).includes('gh issue edit'))
+      const calls = mockExecFileSync.mock.calls as [string, string[]][]
+      const editCalls = calls.filter((args) => Array.isArray(args[1]) && args[1].includes('edit'))
       expect(editCalls).toHaveLength(3)
     })
   })
@@ -943,7 +972,7 @@ describe('migrate > rewriteTitles', () => {
   describe('summary line', () => {
     it('prints a line matching /Stripped \\d+ titles/', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify(matchingIssues))
+      mockExecFileSync.mockReturnValue(JSON.stringify(matchingIssues))
       const logSpy = console.log as ReturnType<typeof vi.fn>
 
       // Act
@@ -956,7 +985,7 @@ describe('migrate > rewriteTitles', () => {
 
     it('reports 16 stripped titles when all 16 matching issues provided', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify(matchingIssues))
+      mockExecFileSync.mockReturnValue(JSON.stringify(matchingIssues))
       const logSpy = console.log as ReturnType<typeof vi.fn>
 
       // Act
@@ -969,7 +998,7 @@ describe('migrate > rewriteTitles', () => {
 
     it('reports 0 stripped titles when no issues match', async () => {
       // Arrange
-      mockExecSync.mockReturnValue(JSON.stringify(nonMatchingIssues))
+      mockExecFileSync.mockReturnValue(JSON.stringify(nonMatchingIssues))
       const logSpy = console.log as ReturnType<typeof vi.fn>
 
       // Act

--- a/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
@@ -6,6 +6,7 @@ process.env.GH_PROJECT_ID = 'PVT_test'
 process.env.STATUS_FIELD_ID = 'SF_test'
 process.env.SIZE_FIELD_ID = 'SZF_test'
 process.env.PRIORITY_FIELD_ID = 'PF_test'
+process.env.LANE_FIELD_ID = 'LF_test'
 process.env.STATUS_OPTIONS_JSON = JSON.stringify({
   Backlog: 'status-backlog',
   Analysis: 'status-analysis',
@@ -27,16 +28,25 @@ process.env.PRIORITY_OPTIONS_JSON = JSON.stringify({
   'P2 - Medium': 'pri-medium',
   'P3 - Low': 'pri-low',
 })
+process.env.LANE_OPTIONS_JSON = JSON.stringify({
+  a1: 'lane-a1',
+  a2: 'lane-a2',
+  b: 'lane-b',
+  c1: 'lane-c1',
+  c2: 'lane-c2',
+})
 
 // Mock config before github — vi.mock is hoisted before process.env assignments,
 // so importOriginal would load config.ts with empty env vars. Manual factory is required.
 vi.mock('../../shared/adapters/config-helpers', () => ({
   isProjectConfigured: () => true,
   NOT_CONFIGURED_MSG: 'GitHub Project V2 is not configured.',
+  GITHUB_REPO: 'Test/test-repo',
   GH_PROJECT_ID: 'PVT_test',
   STATUS_FIELD_ID: 'SF_test',
   SIZE_FIELD_ID: 'SZF_test',
   PRIORITY_FIELD_ID: 'PF_test',
+  LANE_FIELD_ID: 'LF_test',
   STATUS_OPTIONS: {
     Backlog: 'status-backlog',
     Analysis: 'status-analysis',
@@ -52,6 +62,7 @@ vi.mock('../../shared/adapters/config-helpers', () => ({
     'P2 - Medium': 'pri-medium',
     'P3 - Low': 'pri-low',
   },
+  LANE_OPTIONS: { a1: 'lane-a1', a2: 'lane-a2', b: 'lane-b', c1: 'lane-c1', c2: 'lane-c2' },
   resolveStatus: (input: string) => {
     const canonical = new Set(['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done'])
     if (canonical.has(input)) return input
@@ -86,6 +97,10 @@ vi.mock('../../shared/adapters/config-helpers', () => ({
     }
     return aliases[input.toUpperCase()]
   },
+  resolveLane: (input: string) => {
+    const valid = new Set(['a1', 'a2', 'b', 'c1', 'c2', 'c3', 'd', 'e', 'f', 'standalone'])
+    return valid.has(input) ? input : undefined
+  },
 }))
 
 vi.mock('../../shared/adapters/github-infra', () => ({
@@ -101,6 +116,8 @@ vi.mock('../../shared/adapters/github-adapter', () => ({
   removeBlockedBy: vi.fn(),
   addSubIssue: vi.fn(),
   removeSubIssue: vi.fn(),
+  resolveIssueTypeId: vi.fn(),
+  updateIssueIssueType: vi.fn(),
 }))
 
 const github = await import('../../shared/adapters/github-adapter')
@@ -112,6 +129,8 @@ const mockRemoveBlockedBy = github.removeBlockedBy as ReturnType<typeof vi.fn>
 const mockAddSubIssue = github.addSubIssue as ReturnType<typeof vi.fn>
 const mockRemoveSubIssue = github.removeSubIssue as ReturnType<typeof vi.fn>
 const mockGetParentNumber = github.getParentNumber as ReturnType<typeof vi.fn>
+const mockResolveIssueTypeId = github.resolveIssueTypeId as ReturnType<typeof vi.fn>
+const mockUpdateIssueIssueType = github.updateIssueIssueType as ReturnType<typeof vi.fn>
 
 const githubInfra = await import('../../shared/adapters/github-infra')
 const mockSyncPriorityLabel = githubInfra.syncPriorityLabel as ReturnType<typeof vi.fn>
@@ -122,6 +141,7 @@ function setupMocks() {
   vi.clearAllMocks()
   mockGetItemId.mockResolvedValue('item-123')
   mockGetNodeId.mockImplementation(async (num) => `node-${num}`)
+  mockResolveIssueTypeId.mockResolvedValue('type-id-feat')
   vi.spyOn(console, 'log').mockImplementation(() => {})
   vi.spyOn(console, 'error').mockImplementation(() => {})
 }
@@ -234,5 +254,94 @@ describe('issue-triage/set > priority label sync', () => {
   it('does not sync priority label when --priority is not provided', async () => {
     await setIssue(['42', '--size', 'M'])
     expect(mockSyncPriorityLabel).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/set > --lane flag', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('updates lane field with valid lane key', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    // Act
+    await setIssue(['123', '--lane', 'c1'])
+    // Assert
+    expect(mockUpdateField).toHaveBeenCalledWith('item-123', 'LF_test', 'lane-c1')
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('calls process.exit(1) and prints error for invalid lane key', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    // Act
+    await setIssue(['123', '--lane', 'zzz'])
+    // Assert
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((msg) => msg.includes('Invalid lane') || msg.includes('Valid'))).toBe(true)
+  })
+})
+
+describe('issue-triage/set > --type flag', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('resolves type id and calls updateIssueIssueType for valid type', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    // Act
+    await setIssue(['123', '--type', 'feat'])
+    // Assert
+    expect(mockResolveIssueTypeId).toHaveBeenCalledWith('Test', 'feat')
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-123', 'type-id-feat')
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('calls process.exit(1) and prints error for invalid type', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    // Act
+    await setIssue(['123', '--type', 'bogus'])
+    // Assert
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((msg) => msg.includes('Invalid type') || msg.includes('Valid'))).toBe(true)
+  })
+})
+
+describe('issue-triage/set > additive regression', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('--size alone does not call lane or type mutations', async () => {
+    // Arrange & Act
+    await setIssue(['123', '--size', 'S'])
+    // Assert — size field updated, but not lane or type
+    expect(mockUpdateField).toHaveBeenCalledWith('item-123', 'SZF_test', 'size-s')
+    const laneFieldCalls = (mockUpdateField as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => c[1] === 'LF_test',
+    )
+    expect(laneFieldCalls).toHaveLength(0)
+    expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/set > combined --lane + --type + --size', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('applies all three mutations when combined flags provided', async () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    // Act
+    await setIssue(['123', '--lane', 'a1', '--type', 'feat', '--size', 'S'])
+    // Assert — size field
+    expect(mockUpdateField).toHaveBeenCalledWith('item-123', 'SZF_test', 'size-s')
+    // Assert — lane field
+    expect(mockUpdateField).toHaveBeenCalledWith('item-123', 'LF_test', 'lane-a1')
+    // Assert — type mutation
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-123', 'type-id-feat')
+    expect(exitSpy).not.toHaveBeenCalled()
   })
 })

--- a/plugins/dev-core/skills/issue-triage/lib/migrate.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/migrate.ts
@@ -463,3 +463,46 @@ export async function backfill(opts: { repo: string; dryRun: boolean; snapshotPa
     `Processed ${issues.length}, updated ${updated}${dryRunNote}, skipped ${skipped}, flagged ${flagged.length}`,
   )
 }
+
+// ---------------------------------------------------------------------------
+// rewriteTitles
+// ---------------------------------------------------------------------------
+
+interface RewriteRow {
+  repo: string
+  number: number
+  old_title: string
+  new_title: string
+}
+
+export async function rewriteTitles(opts: { repo: string; dryRun: boolean; snapshotPath?: string }): Promise<void> {
+  const issuesJson = execSync(`gh issue list --repo ${opts.repo} --state open --limit 1000 --json number,title`, {
+    encoding: 'utf-8',
+  })
+  const issues = JSON.parse(issuesJson) as Array<{ number: number; title: string }>
+
+  const rows: RewriteRow[] = []
+
+  for (const issue of issues) {
+    if (!TITLE_PREFIX_RE.test(issue.title)) continue
+
+    const new_title = issue.title.replace(TITLE_PREFIX_RE, '')
+    rows.push({ repo: opts.repo, number: issue.number, old_title: issue.title, new_title })
+  }
+
+  if (!opts.dryRun) {
+    for (const row of rows) {
+      execSync(`gh issue edit ${row.number} --repo ${opts.repo} --title ${JSON.stringify(row.new_title)}`, {
+        encoding: 'utf-8',
+      })
+    }
+  }
+
+  const migrationDir = 'artifacts/migration'
+  mkdirSync(migrationDir, { recursive: true })
+
+  const snapshotFile = opts.snapshotPath ?? join(migrationDir, `rewrite-snapshot-${formatTimestamp()}.json`)
+  await writeFile(snapshotFile, JSON.stringify(rows, null, 2), 'utf-8')
+
+  console.log(`Stripped ${rows.length} titles across repo ${opts.repo}`)
+}

--- a/plugins/dev-core/skills/issue-triage/lib/migrate.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/migrate.ts
@@ -1,0 +1,93 @@
+/**
+ * migrate.ts — taxonomy migration subcommands: audit-schema, backfill, rewrite-titles, revert.
+ * See artifacts/specs/121-dual-write-migration-spec.mdx.
+ */
+
+import {
+  GH_PROJECT_ID,
+  LANE_OPTIONS,
+  PRIORITY_OPTIONS,
+  SIZE_OPTIONS,
+  STATUS_OPTIONS,
+} from '../../shared/adapters/config-helpers'
+import { ghGraphQL } from '../../shared/adapters/github-adapter'
+
+interface FieldSchema {
+  id: string
+  name: string
+  options: Array<{ id: string; name: string }>
+}
+
+const PROJECT_FIELDS_QUERY = `
+  query($projectId: ID!) {
+    node(id: $projectId) {
+      ... on ProjectV2 {
+        fields(first: 50) {
+          nodes {
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              options { id name }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+const EXPECTED_FIELDS: Array<{ name: string; options: Record<string, string> }> = [
+  { name: 'Size', options: SIZE_OPTIONS },
+  { name: 'Lane', options: LANE_OPTIONS },
+  { name: 'Priority', options: PRIORITY_OPTIONS },
+  { name: 'Status', options: STATUS_OPTIONS },
+]
+
+export async function auditSchema(): Promise<void> {
+  const data = (await ghGraphQL(PROJECT_FIELDS_QUERY, { projectId: GH_PROJECT_ID })) as {
+    node: {
+      fields: {
+        nodes: Array<Partial<FieldSchema>>
+      }
+    }
+  }
+
+  const liveNodes = data.node.fields.nodes.filter((n): n is FieldSchema => Array.isArray((n as FieldSchema).options))
+
+  const liveByName = new Map<string, FieldSchema>(liveNodes.map((n) => [n.name, n]))
+
+  const diffs: string[] = []
+
+  for (const expected of EXPECTED_FIELDS) {
+    const liveField = liveByName.get(expected.name)
+
+    if (!liveField) {
+      diffs.push(`MISSING: ${expected.name}`)
+      continue
+    }
+
+    const liveOptionNames = new Set(liveField.options.map((o) => o.name))
+    const localOptionNames = new Set(Object.keys(expected.options))
+
+    for (const local of localOptionNames) {
+      if (!liveOptionNames.has(local)) {
+        diffs.push(`LOCAL_EXTRA: ${expected.name}.${local}`)
+      }
+    }
+
+    for (const live of liveOptionNames) {
+      if (!localOptionNames.has(live)) {
+        diffs.push(`LOCAL_MISSING: ${expected.name}.${live}`)
+      }
+    }
+  }
+
+  if (diffs.length > 0) {
+    for (const line of diffs) {
+      console.log(line)
+    }
+    process.exit(1)
+  }
+
+  console.log('audit-schema: OK — Size/Lane/Priority/Status match live project')
+}

--- a/plugins/dev-core/skills/issue-triage/lib/migrate.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/migrate.ts
@@ -18,7 +18,14 @@ import {
   SIZE_OPTIONS,
   STATUS_OPTIONS,
 } from '../../shared/adapters/config-helpers'
-import { ghGraphQL, resolveIssueTypeId, updateField, updateIssueIssueType } from '../../shared/adapters/github-adapter'
+import {
+  clearField,
+  ghGraphQL,
+  resolveIssueTypeId,
+  run,
+  updateField,
+  updateIssueIssueType,
+} from '../../shared/adapters/github-adapter'
 
 interface FieldSchema {
   id: string
@@ -505,4 +512,188 @@ export async function rewriteTitles(opts: { repo: string; dryRun: boolean; snaps
   await writeFile(snapshotFile, JSON.stringify(rows, null, 2), 'utf-8')
 
   console.log(`Stripped ${rows.length} titles across repo ${opts.repo}`)
+}
+
+// ---------------------------------------------------------------------------
+// revert
+// ---------------------------------------------------------------------------
+
+const FIELD_ID_MAP: Record<string, string> = {
+  Lane: LANE_FIELD_ID,
+  Size: SIZE_FIELD_ID,
+  Priority: PRIORITY_FIELD_ID,
+}
+
+interface BackfillRow {
+  repo: string
+  number: number
+  field: string
+  old_value: string | null
+  new_value: string | null
+  flagged: boolean
+}
+
+interface RevertError {
+  repo: string
+  number: number
+  field?: string
+  error: string
+}
+
+async function fetchIssueFieldState(
+  repo: string,
+  issueNumber: number,
+): Promise<{
+  itemId: string
+  issueNodeId: string
+  currentFields: Record<string, string>
+  currentIssueType: string | undefined
+}> {
+  const [owner, repoName] = repo.split('/')
+  const data = (await ghGraphQL(ITEM_FIELDS_QUERY, {
+    owner,
+    repo: repoName,
+    number: issueNumber,
+  })) as {
+    repository: {
+      issue: {
+        id: string
+        issueType: { id: string; name: string } | null
+        projectItems: {
+          nodes: Array<{
+            id: string
+            project: { id: string }
+            fieldValues: ProjectItemFieldValues['fieldValues']
+          }>
+        }
+      }
+    }
+  }
+
+  const issueData = data.repository.issue
+  const projectItem = issueData.projectItems.nodes.find((n) => n.project.id === GH_PROJECT_ID)
+  if (!projectItem) throw new Error(`Issue #${issueNumber} not found in project`)
+
+  const currentFields: Record<string, string> = {}
+  for (const fv of projectItem.fieldValues.nodes) {
+    if (fv.name && fv.field?.name) {
+      currentFields[fv.field.name] = fv.name
+    }
+  }
+
+  return {
+    itemId: projectItem.id,
+    issueNodeId: issueData.id,
+    currentFields,
+    currentIssueType: issueData.issueType?.name,
+  }
+}
+
+async function revertBackfillRow(row: BackfillRow): Promise<'reverted' | 'skipped'> {
+  if (row.flagged || row.new_value === null) return 'skipped'
+
+  const { itemId, issueNodeId, currentFields, currentIssueType } = await fetchIssueFieldState(row.repo, row.number)
+
+  if (row.field === 'issueType') {
+    if (currentIssueType === undefined) {
+      console.log(`skip #${row.number}.issueType`)
+      return 'skipped'
+    }
+    await updateIssueIssueType(issueNodeId, null)
+    return 'reverted'
+  }
+
+  const fieldId = FIELD_ID_MAP[row.field]
+  if (!fieldId) throw new Error(`Unknown field: ${row.field}`)
+
+  if (currentFields[row.field] === undefined) {
+    console.log(`skip #${row.number}.${row.field}`)
+    return 'skipped'
+  }
+
+  await clearField(itemId, fieldId)
+  return 'reverted'
+}
+
+async function revertRewriteRow(row: RewriteRow): Promise<'reverted' | 'skipped'> {
+  const currentTitle = await run([
+    'gh',
+    'issue',
+    'view',
+    String(row.number),
+    '--repo',
+    row.repo,
+    '--json',
+    'title',
+    '--jq',
+    '.title',
+  ])
+
+  if (currentTitle === row.old_title) {
+    console.log(`skip #${row.number}`)
+    return 'skipped'
+  }
+
+  await run(['gh', 'issue', 'edit', String(row.number), '--repo', row.repo, '--title', row.old_title])
+  return 'reverted'
+}
+
+export async function revert(opts: { snapshotPath: string }): Promise<void> {
+  const { readFile } = await import('node:fs/promises')
+  const raw = await readFile(opts.snapshotPath, 'utf-8')
+  const rows = JSON.parse(raw) as unknown[]
+
+  if (!Array.isArray(rows) || rows.length === 0) {
+    console.error('Snapshot is empty or not an array')
+    process.exit(1)
+  }
+
+  const first = rows[0] as Record<string, unknown>
+  const isBackfill = 'field' in first && 'old_value' in first && 'new_value' in first && 'flagged' in first
+  const isRewrite = 'old_title' in first && 'new_title' in first && !('field' in first)
+
+  if (!isBackfill && !isRewrite) {
+    console.error('Unknown snapshot format')
+    process.exit(1)
+  }
+
+  let reverted = 0
+  let skipped = 0
+  const errors: RevertError[] = []
+
+  if (isBackfill) {
+    const backfillRows = rows as BackfillRow[]
+    for (const row of backfillRows) {
+      try {
+        const outcome = await revertBackfillRow(row)
+        if (outcome === 'reverted') reverted++
+        else skipped++
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        errors.push({ repo: row.repo, number: row.number, field: row.field, error: message })
+        console.error(`error #${row.number}.${row.field}: ${message}`)
+      }
+    }
+  } else {
+    const rewriteRows = rows as RewriteRow[]
+    for (const row of rewriteRows) {
+      try {
+        const outcome = await revertRewriteRow(row)
+        if (outcome === 'reverted') reverted++
+        else skipped++
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        errors.push({ repo: row.repo, number: row.number, error: message })
+        console.error(`error #${row.number}: ${message}`)
+      }
+    }
+  }
+
+  console.log(`Reverted ${reverted} rows, skipped ${skipped} already-reverted, errors ${errors.length}`)
+  if (errors.length > 0) {
+    for (const e of errors) {
+      const loc = e.field ? `${e.repo}#${e.number} [${e.field}]` : `${e.repo}#${e.number}`
+      console.error(`  ${loc}: ${e.error}`)
+    }
+  }
 }

--- a/plugins/dev-core/skills/issue-triage/lib/migrate.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/migrate.ts
@@ -3,10 +3,12 @@
  * See artifacts/specs/121-dual-write-migration-spec.mdx.
  */
 
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { mkdirSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
+import * as path from 'node:path'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
   DEFAULT_LANE_OPTIONS,
   GH_PROJECT_ID,
@@ -21,11 +23,34 @@ import {
 import {
   clearField,
   ghGraphQL,
-  resolveIssueTypeId,
+  listOrgIssueTypes,
   run,
   updateField,
   updateIssueIssueType,
 } from '../../shared/adapters/github-adapter'
+
+// ---------------------------------------------------------------------------
+// Repo-root-anchored migrationDir (fix #3: CWD-relative → anchor to repo root)
+// ---------------------------------------------------------------------------
+
+const __dir = path.dirname(fileURLToPath(import.meta.url))
+// migrate.ts lives at plugins/dev-core/skills/issue-triage/lib — repo root is 5 levels up
+const REPO_ROOT = path.resolve(__dir, '..', '..', '..', '..', '..', '..')
+const migrationDir = path.join(REPO_ROOT, 'artifacts', 'migration')
+
+// ---------------------------------------------------------------------------
+// Path-traversal guard for --snapshot (fix #2)
+// ---------------------------------------------------------------------------
+
+export function validateSnapshotPath(p: string, allowedDir?: string): string {
+  const resolved = path.resolve(p)
+  const allowed = path.resolve(allowedDir ?? migrationDir)
+  if (!resolved.startsWith(allowed + path.sep) && resolved !== allowed) {
+    console.error(`Error: --snapshot path must be within ${allowed}`)
+    process.exit(1)
+  }
+  return resolved
+}
 
 interface FieldSchema {
   id: string
@@ -59,12 +84,20 @@ const EXPECTED_FIELDS: Array<{ name: string; options: Record<string, string> }> 
 ]
 
 export async function auditSchema(): Promise<void> {
-  const data = (await ghGraphQL(PROJECT_FIELDS_QUERY, { projectId: GH_PROJECT_ID })) as {
+  // fix #10: wrap ghGraphQL in try/catch
+  let data: {
     node: {
       fields: {
         nodes: Array<Partial<FieldSchema>>
       }
     }
+  }
+  try {
+    data = (await ghGraphQL(PROJECT_FIELDS_QUERY, { projectId: GH_PROJECT_ID })) as typeof data
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error(`Error: audit-schema failed to query project. Check GH_PROJECT_ID and GH token. Underlying: ${msg}`)
+    process.exit(1)
   }
 
   const liveNodes = data.node.fields.nodes.filter((n): n is FieldSchema => Array.isArray((n as FieldSchema).options))
@@ -114,6 +147,8 @@ export async function auditSchema(): Promise<void> {
 export const LEGACY_LABEL_MAP = {
   lane: Object.fromEntries(DEFAULT_LANE_OPTIONS.map((l) => [l, l])) as Record<string, string>,
   size: {
+    // XS → S: collapsed to smallest new-schema bucket; XS has no equivalent in S/F-lite/F-full
+    XS: 'S',
     S: 'S',
     M: 'F-lite',
     L: 'F-full',
@@ -185,6 +220,22 @@ interface LegacyValues {
   size?: string
   priority?: string
   issueType?: string
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot envelope types (fix #12)
+// ---------------------------------------------------------------------------
+
+interface BackfillSnapshot {
+  kind: 'backfill'
+  generatedAt: string
+  rows: BackfillRow[]
+}
+
+interface RewriteSnapshot {
+  kind: 'rewrite'
+  generatedAt: string
+  rows: RewriteRow[]
 }
 
 // ---------------------------------------------------------------------------
@@ -265,17 +316,36 @@ export async function backfill(opts: { repo: string; dryRun: boolean; snapshotPa
 
   const [owner, repoName] = opts.repo.split('/')
 
-  // List open issues
-  const issuesJson = execSync(
-    `gh issue list --repo ${opts.repo} --state open --limit 1000 --json number,title,labels,id`,
+  // fix #1: execFileSync instead of execSync (shell injection guard)
+  const issuesJson = execFileSync(
+    'gh',
+    ['issue', 'list', '--repo', opts.repo, '--state', 'open', '--limit', '1000', '--json', 'number,title,labels,id'],
     { encoding: 'utf-8' },
   )
   const issues = JSON.parse(issuesJson) as GhIssueListItem[]
+
+  // fix #5: warn when limit ceiling is hit
+  if (issues.length >= 1000) {
+    const ts = formatTimestamp()
+    console.warn(`Warning: hit --limit 1000 ceiling on repo ${opts.repo}; some issues may be truncated`)
+    mkdirSync(migrationDir, { recursive: true })
+    const flaggedFile = join(migrationDir, `flagged-${ts}.txt`)
+    await writeFile(
+      flaggedFile,
+      `DIAGNOSTIC: hit --limit 1000 ceiling on repo ${opts.repo} at ${new Date().toISOString()} — some issues may be truncated\n`,
+      'utf-8',
+    )
+  }
 
   const rows: Row[] = []
   const flagged: FlaggedEntry[] = []
   let updated = 0
   let skipped = 0
+
+  // fix #4: pre-resolve issue type IDs once (N+1 guard)
+  const org = opts.repo.split('/')[0]
+  const orgTypes = await listOrgIssueTypes(org)
+  const typeIdByName = new Map<string, string>(orgTypes.map((t) => [t.name.toLowerCase(), t.id]))
 
   for (const issue of issues) {
     // Fetch project item field values
@@ -385,17 +455,18 @@ export async function backfill(opts: { repo: string; dryRun: boolean; snapshotPa
         currentValue: currentIssueType,
         legacyToken: legacyValues.issueType,
         map: LEGACY_LABEL_MAP.issueType,
+        // fix #4: use pre-resolved typeIdByName instead of per-issue resolveIssueTypeId
         apply: async (canonical) => {
-          const org = opts.repo.split('/')[0]
-          const typeId = await resolveIssueTypeId(org, canonical)
+          const typeId = typeIdByName.get(canonical.toLowerCase())
+          if (!typeId) throw new Error(`Unknown issue type: ${canonical}`)
           await updateIssueIssueType(issueNodeId, typeId)
         },
       },
     ]
 
     for (const def of fieldDefs) {
-      // Already set — skip (idempotent)
-      if (def.currentValue) {
+      // fix #15: explicit non-null + non-empty-string check (idempotency)
+      if (def.currentValue != null && def.currentValue !== '') {
         skipped++
         rows.push({
           repo: opts.repo,
@@ -451,14 +522,18 @@ export async function backfill(opts: { repo: string; dryRun: boolean; snapshotPa
   }
 
   // Write snapshot and flagged.txt
-  const migrationDir = 'artifacts/migration'
   mkdirSync(migrationDir, { recursive: true })
 
-  const snapshotFile = opts.snapshotPath ?? join(migrationDir, `backfill-snapshot-${formatTimestamp()}.json`)
-  await writeFile(snapshotFile, JSON.stringify(rows, null, 2), 'utf-8')
+  const ts = formatTimestamp()
+  const snapshotFile = opts.snapshotPath ?? join(migrationDir, `backfill-snapshot-${ts}.json`)
+
+  // fix #12: wrap snapshot with kind marker
+  const snapshot: BackfillSnapshot = { kind: 'backfill', generatedAt: new Date().toISOString(), rows }
+  await writeFile(snapshotFile, JSON.stringify(snapshot, null, 2), 'utf-8')
 
   if (flagged.length > 0) {
-    const flaggedFile = join(migrationDir, 'flagged.txt')
+    // fix #11: timestamped flagged filename
+    const flaggedFile = join(migrationDir, `flagged-${ts}.txt`)
     const flaggedLines = flagged.map(
       (f) => `${f.repo}#${f.number} [${f.field}] observed="${f.observed}" title="${f.title}"`,
     )
@@ -480,13 +555,30 @@ interface RewriteRow {
   number: number
   old_title: string
   new_title: string
+  applied?: boolean
 }
 
 export async function rewriteTitles(opts: { repo: string; dryRun: boolean; snapshotPath?: string }): Promise<void> {
-  const issuesJson = execSync(`gh issue list --repo ${opts.repo} --state open --limit 1000 --json number,title`, {
-    encoding: 'utf-8',
-  })
+  // fix #1: execFileSync instead of execSync (shell injection guard)
+  const issuesJson = execFileSync(
+    'gh',
+    ['issue', 'list', '--repo', opts.repo, '--state', 'open', '--limit', '1000', '--json', 'number,title'],
+    { encoding: 'utf-8' },
+  )
   const issues = JSON.parse(issuesJson) as Array<{ number: number; title: string }>
+
+  // fix #5: warn when limit ceiling is hit
+  if (issues.length >= 1000) {
+    console.warn(`Warning: hit --limit 1000 ceiling on repo ${opts.repo}; some issues may be truncated`)
+    mkdirSync(migrationDir, { recursive: true })
+    const ts = formatTimestamp()
+    const flaggedFile = join(migrationDir, `flagged-${ts}.txt`)
+    await writeFile(
+      flaggedFile,
+      `DIAGNOSTIC: hit --limit 1000 ceiling on repo ${opts.repo} at ${new Date().toISOString()} — some issues may be truncated\n`,
+      'utf-8',
+    )
+  }
 
   const rows: RewriteRow[] = []
 
@@ -494,22 +586,31 @@ export async function rewriteTitles(opts: { repo: string; dryRun: boolean; snaps
     if (!TITLE_PREFIX_RE.test(issue.title)) continue
 
     const new_title = issue.title.replace(TITLE_PREFIX_RE, '')
-    rows.push({ repo: opts.repo, number: issue.number, old_title: issue.title, new_title })
+    rows.push({ repo: opts.repo, number: issue.number, old_title: issue.title, new_title, applied: false })
   }
+
+  mkdirSync(migrationDir, { recursive: true })
+
+  const ts = formatTimestamp()
+  const snapshotFile = opts.snapshotPath ?? join(migrationDir, `rewrite-snapshot-${ts}.json`)
+
+  // fix #6: write snapshot BEFORE live edits (with applied: false on all rows)
+  // fix #12: wrap snapshot with kind marker
+  const snapshot: RewriteSnapshot = { kind: 'rewrite', generatedAt: new Date().toISOString(), rows }
+  await writeFile(snapshotFile, JSON.stringify(snapshot, null, 2), 'utf-8')
 
   if (!opts.dryRun) {
     for (const row of rows) {
-      execSync(`gh issue edit ${row.number} --repo ${opts.repo} --title ${JSON.stringify(row.new_title)}`, {
+      // fix #1: execFileSync with argv array (no shell injection)
+      execFileSync('gh', ['issue', 'edit', String(row.number), '--repo', opts.repo, '--title', row.new_title], {
         encoding: 'utf-8',
       })
+      row.applied = true
     }
+    // Rewrite snapshot with applied flags set correctly
+    const updatedSnapshot: RewriteSnapshot = { kind: 'rewrite', generatedAt: snapshot.generatedAt, rows }
+    await writeFile(snapshotFile, JSON.stringify(updatedSnapshot, null, 2), 'utf-8')
   }
-
-  const migrationDir = 'artifacts/migration'
-  mkdirSync(migrationDir, { recursive: true })
-
-  const snapshotFile = opts.snapshotPath ?? join(migrationDir, `rewrite-snapshot-${formatTimestamp()}.json`)
-  await writeFile(snapshotFile, JSON.stringify(rows, null, 2), 'utf-8')
 
   console.log(`Stripped ${rows.length} titles across repo ${opts.repo}`)
 }
@@ -538,6 +639,34 @@ interface RevertError {
   number: number
   field?: string
   error: string
+}
+
+// ---------------------------------------------------------------------------
+// Row validators (fix #12)
+// ---------------------------------------------------------------------------
+
+const VALID_BACKFILL_FIELDS = new Set(['Lane', 'Size', 'Priority', 'issueType'])
+
+function isValidBackfillRow(row: unknown): row is BackfillRow {
+  const r = row as Record<string, unknown>
+  return (
+    typeof r.repo === 'string' &&
+    /^[^/]+\/[^/]+$/.test(r.repo) &&
+    typeof r.number === 'number' &&
+    r.number > 0 &&
+    typeof r.field === 'string' &&
+    VALID_BACKFILL_FIELDS.has(r.field)
+  )
+}
+
+function isValidRewriteRow(row: unknown): row is RewriteRow {
+  const r = row as Record<string, unknown>
+  return (
+    typeof r.repo === 'string' &&
+    typeof r.number === 'number' &&
+    typeof r.old_title === 'string' &&
+    typeof r.new_title === 'string'
+  )
 }
 
 async function fetchIssueFieldState(
@@ -599,6 +728,8 @@ async function revertBackfillRow(row: BackfillRow): Promise<'reverted' | 'skippe
       console.log(`skip #${row.number}.issueType`)
       return 'skipped'
     }
+    // FIXME(#121): revert with null issueTypeId is unverified — schema allows it but API behaviour unconfirmed.
+    // Manual verification needed before production revert.
     await updateIssueIssueType(issueNodeId, null)
     return 'reverted'
   }
@@ -616,7 +747,7 @@ async function revertBackfillRow(row: BackfillRow): Promise<'reverted' | 'skippe
 }
 
 async function revertRewriteRow(row: RewriteRow): Promise<'reverted' | 'skipped'> {
-  const currentTitle = await run([
+  const currentTitleRaw = await run([
     'gh',
     'issue',
     'view',
@@ -628,6 +759,8 @@ async function revertRewriteRow(row: RewriteRow): Promise<'reverted' | 'skipped'
     '--jq',
     '.title',
   ])
+  // fix #8: trim output before comparison (trailing newline defeats idempotency)
+  const currentTitle = currentTitleRaw.trim()
 
   if (currentTitle === row.old_title) {
     console.log(`skip #${row.number}`)
@@ -641,16 +774,41 @@ async function revertRewriteRow(row: RewriteRow): Promise<'reverted' | 'skipped'
 export async function revert(opts: { snapshotPath: string }): Promise<void> {
   const { readFile } = await import('node:fs/promises')
   const raw = await readFile(opts.snapshotPath, 'utf-8')
-  const rows = JSON.parse(raw) as unknown[]
+  const parsed = JSON.parse(raw) as unknown
 
-  if (!Array.isArray(rows) || rows.length === 0) {
-    console.error('Snapshot is empty or not an array')
-    process.exit(1)
+  // fix #12: detect kind marker; fall back to duck-typing for backwards compat
+  let isBackfill: boolean
+  let isRewrite: boolean
+  let rawRows: unknown[]
+
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    !Array.isArray(parsed) &&
+    'kind' in (parsed as Record<string, unknown>)
+  ) {
+    const envelope = parsed as { kind: string; rows: unknown[] }
+    rawRows = Array.isArray(envelope.rows) ? envelope.rows : []
+    isBackfill = envelope.kind === 'backfill'
+    isRewrite = envelope.kind === 'rewrite'
+  } else {
+    // Backwards compat: legacy plain array snapshots
+    if (!Array.isArray(parsed)) {
+      console.error('Snapshot is not an array or envelope object')
+      process.exit(1)
+      return
+    }
+    rawRows = parsed as unknown[]
+    const first = rawRows[0] as Record<string, unknown> | undefined
+    isBackfill = first != null && 'field' in first && 'old_value' in first && 'new_value' in first && 'flagged' in first
+    isRewrite = first != null && 'old_title' in first && 'new_title' in first && !('field' in first)
   }
 
-  const first = rows[0] as Record<string, unknown>
-  const isBackfill = 'field' in first && 'old_value' in first && 'new_value' in first && 'flagged' in first
-  const isRewrite = 'old_title' in first && 'new_title' in first && !('field' in first)
+  // fix #7: empty array → log + return (not exit 1)
+  if (rawRows.length === 0) {
+    console.log('Snapshot is empty — nothing to revert')
+    return
+  }
 
   if (!isBackfill && !isRewrite) {
     console.error('Unknown snapshot format')
@@ -662,8 +820,12 @@ export async function revert(opts: { snapshotPath: string }): Promise<void> {
   const errors: RevertError[] = []
 
   if (isBackfill) {
-    const backfillRows = rows as BackfillRow[]
-    for (const row of backfillRows) {
+    for (const row of rawRows) {
+      // fix #12: per-row validation
+      if (!isValidBackfillRow(row)) {
+        console.log(`skip invalid backfill row: ${JSON.stringify(row)}`)
+        continue
+      }
       try {
         const outcome = await revertBackfillRow(row)
         if (outcome === 'reverted') reverted++
@@ -675,8 +837,12 @@ export async function revert(opts: { snapshotPath: string }): Promise<void> {
       }
     }
   } else {
-    const rewriteRows = rows as RewriteRow[]
-    for (const row of rewriteRows) {
+    for (const row of rawRows) {
+      // fix #12: per-row validation
+      if (!isValidRewriteRow(row)) {
+        console.log(`skip invalid rewrite row: ${JSON.stringify(row)}`)
+        continue
+      }
       try {
         const outcome = await revertRewriteRow(row)
         if (outcome === 'reverted') reverted++

--- a/plugins/dev-core/skills/issue-triage/lib/migrate.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/migrate.ts
@@ -3,14 +3,22 @@
  * See artifacts/specs/121-dual-write-migration-spec.mdx.
  */
 
+import { execSync } from 'node:child_process'
+import { mkdirSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
 import {
+  DEFAULT_LANE_OPTIONS,
   GH_PROJECT_ID,
+  LANE_FIELD_ID,
   LANE_OPTIONS,
+  PRIORITY_FIELD_ID,
   PRIORITY_OPTIONS,
+  SIZE_FIELD_ID,
   SIZE_OPTIONS,
   STATUS_OPTIONS,
 } from '../../shared/adapters/config-helpers'
-import { ghGraphQL } from '../../shared/adapters/github-adapter'
+import { ghGraphQL, resolveIssueTypeId, updateField, updateIssueIssueType } from '../../shared/adapters/github-adapter'
 
 interface FieldSchema {
   id: string
@@ -90,4 +98,368 @@ export async function auditSchema(): Promise<void> {
   }
 
   console.log('audit-schema: OK — Size/Lane/Priority/Status match live project')
+}
+
+// ---------------------------------------------------------------------------
+// LEGACY_LABEL_MAP — maps label-derived tokens to canonical project field values
+// ---------------------------------------------------------------------------
+
+export const LEGACY_LABEL_MAP = {
+  lane: Object.fromEntries(DEFAULT_LANE_OPTIONS.map((l) => [l, l])) as Record<string, string>,
+  size: {
+    S: 'S',
+    M: 'F-lite',
+    L: 'F-full',
+    XL: 'F-full',
+  } as Record<string, string>,
+  priority: {
+    P0: 'P0 - Urgent',
+    P1: 'P1 - High',
+    P2: 'P2 - Medium',
+    P3: 'P3 - Low',
+  } as Record<string, string>,
+  issueType: {
+    feat: 'feat',
+    fix: 'fix',
+    docs: 'docs',
+    test: 'test',
+    chore: 'chore',
+    ci: 'ci',
+    perf: 'perf',
+    refactor: 'refactor',
+  } as Record<string, string>,
+}
+
+// ---------------------------------------------------------------------------
+// TITLE_PREFIX_RE — extract conventional-commit type from issue title
+// ---------------------------------------------------------------------------
+
+export const TITLE_PREFIX_RE = /^(feat|fix|refactor|docs|test|chore|ci|perf)(\(.+?\))?:\s*/
+
+// ---------------------------------------------------------------------------
+// Backfill types
+// ---------------------------------------------------------------------------
+
+interface GhIssueListItem {
+  number: number
+  title: string
+  labels: Array<{ name: string }>
+  id: string
+}
+
+interface ProjectItemFieldValues {
+  fieldValues: {
+    nodes: Array<{
+      name?: string
+      field?: { name?: string }
+    }>
+  }
+}
+
+interface Row {
+  repo: string
+  number: number
+  field: string
+  old_value: string | null
+  new_value: string | null
+  flagged: boolean
+}
+
+interface FlaggedEntry {
+  repo: string
+  number: number
+  title: string
+  field: string
+  observed: string
+}
+
+interface LegacyValues {
+  lane?: string
+  size?: string
+  priority?: string
+  issueType?: string
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+const ITEM_FIELDS_QUERY = `
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        id
+        issueType { id name }
+        projectItems(first: 10) {
+          nodes {
+            id
+            project { id }
+            fieldValues(first: 20) {
+              nodes {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field { ... on ProjectV2SingleSelectField { name } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+function extractLegacyValues(issue: GhIssueListItem): LegacyValues {
+  const values: LegacyValues = {}
+
+  for (const label of issue.labels) {
+    const laneMatch = label.name.match(/^graph:lane\/(.+)$/)
+    if (laneMatch) {
+      values.lane = laneMatch[1]
+      continue
+    }
+
+    const sizeMatch = label.name.match(/^size:(.+)$/)
+    if (sizeMatch) {
+      values.size = sizeMatch[1]
+      continue
+    }
+
+    const priorityMatch = label.name.match(/^(P[0-3])-/)
+    if (priorityMatch) {
+      values.priority = priorityMatch[1]
+    }
+  }
+
+  const titleMatch = issue.title.match(TITLE_PREFIX_RE)
+  if (titleMatch) {
+    values.issueType = titleMatch[1]
+  }
+
+  return values
+}
+
+function formatTimestamp(): string {
+  const now = new Date()
+  const yyyy = now.getFullYear()
+  const mm = String(now.getMonth() + 1).padStart(2, '0')
+  const dd = String(now.getDate()).padStart(2, '0')
+  const hh = String(now.getHours()).padStart(2, '0')
+  const min = String(now.getMinutes()).padStart(2, '0')
+  return `${yyyy}${mm}${dd}-${hh}${min}`
+}
+
+// ---------------------------------------------------------------------------
+// backfill
+// ---------------------------------------------------------------------------
+
+export async function backfill(opts: { repo: string; dryRun: boolean; snapshotPath?: string }): Promise<void> {
+  await auditSchema()
+
+  const [owner, repoName] = opts.repo.split('/')
+
+  // List open issues
+  const issuesJson = execSync(
+    `gh issue list --repo ${opts.repo} --state open --limit 1000 --json number,title,labels,id`,
+    { encoding: 'utf-8' },
+  )
+  const issues = JSON.parse(issuesJson) as GhIssueListItem[]
+
+  const rows: Row[] = []
+  const flagged: FlaggedEntry[] = []
+  let updated = 0
+  let skipped = 0
+
+  for (const issue of issues) {
+    // Fetch project item field values
+    let fetchResult:
+      | { itemId: string; issueNodeId: string; currentFields: Record<string, string>; currentIssueType?: string }
+      | undefined
+
+    try {
+      const data = (await ghGraphQL(ITEM_FIELDS_QUERY, {
+        owner,
+        repo: repoName,
+        number: issue.number,
+      })) as {
+        repository: {
+          issue: {
+            id: string
+            issueType: { id: string; name: string } | null
+            projectItems: {
+              nodes: Array<{
+                id: string
+                project: { id: string }
+                fieldValues: ProjectItemFieldValues['fieldValues']
+              }>
+            }
+          }
+        }
+      }
+
+      const issueData = data.repository.issue
+      const projectItem = issueData.projectItems.nodes.find((n) => n.project.id === GH_PROJECT_ID)
+
+      if (!projectItem) {
+        flagged.push({
+          repo: opts.repo,
+          number: issue.number,
+          title: issue.title,
+          field: 'project',
+          observed: 'not-in-project',
+        })
+        continue
+      }
+
+      const currentFields: Record<string, string> = {}
+      for (const fv of projectItem.fieldValues.nodes) {
+        if (fv.name && fv.field?.name) {
+          currentFields[fv.field.name] = fv.name
+        }
+      }
+
+      fetchResult = {
+        itemId: projectItem.id,
+        issueNodeId: issueData.id,
+        currentFields,
+        currentIssueType: issueData.issueType?.name,
+      }
+    } catch {
+      flagged.push({
+        repo: opts.repo,
+        number: issue.number,
+        title: issue.title,
+        field: 'project',
+        observed: 'fetch-error',
+      })
+      continue
+    }
+
+    const { itemId, issueNodeId, currentFields, currentIssueType } = fetchResult
+    const legacyValues = extractLegacyValues(issue)
+
+    // Process each field
+    const fieldDefs: Array<{
+      field: string
+      currentValue: string | undefined
+      legacyToken: string | undefined
+      map: Record<string, string>
+      apply: (canonical: string) => Promise<void>
+    }> = [
+      {
+        field: 'Lane',
+        currentValue: currentFields.Lane,
+        legacyToken: legacyValues.lane,
+        map: LEGACY_LABEL_MAP.lane,
+        apply: async (canonical) => {
+          await updateField(itemId, LANE_FIELD_ID, LANE_OPTIONS[canonical])
+        },
+      },
+      {
+        field: 'Size',
+        currentValue: currentFields.Size,
+        legacyToken: legacyValues.size,
+        map: LEGACY_LABEL_MAP.size,
+        apply: async (canonical) => {
+          await updateField(itemId, SIZE_FIELD_ID, SIZE_OPTIONS[canonical])
+        },
+      },
+      {
+        field: 'Priority',
+        currentValue: currentFields.Priority,
+        legacyToken: legacyValues.priority,
+        map: LEGACY_LABEL_MAP.priority,
+        apply: async (canonical) => {
+          await updateField(itemId, PRIORITY_FIELD_ID, PRIORITY_OPTIONS[canonical])
+        },
+      },
+      {
+        field: 'issueType',
+        currentValue: currentIssueType,
+        legacyToken: legacyValues.issueType,
+        map: LEGACY_LABEL_MAP.issueType,
+        apply: async (canonical) => {
+          const org = opts.repo.split('/')[0]
+          const typeId = await resolveIssueTypeId(org, canonical)
+          await updateIssueIssueType(issueNodeId, typeId)
+        },
+      },
+    ]
+
+    for (const def of fieldDefs) {
+      // Already set — skip (idempotent)
+      if (def.currentValue) {
+        skipped++
+        rows.push({
+          repo: opts.repo,
+          number: issue.number,
+          field: def.field,
+          old_value: def.currentValue,
+          new_value: def.currentValue,
+          flagged: false,
+        })
+        continue
+      }
+
+      // No label/title source — nothing to do
+      if (!def.legacyToken) {
+        continue
+      }
+
+      const canonical = def.map[def.legacyToken]
+
+      if (!canonical) {
+        flagged.push({
+          repo: opts.repo,
+          number: issue.number,
+          title: issue.title,
+          field: def.field,
+          observed: def.legacyToken,
+        })
+        rows.push({
+          repo: opts.repo,
+          number: issue.number,
+          field: def.field,
+          old_value: null,
+          new_value: null,
+          flagged: true,
+        })
+        continue
+      }
+
+      if (!opts.dryRun) {
+        await def.apply(canonical)
+        updated++
+      }
+
+      rows.push({
+        repo: opts.repo,
+        number: issue.number,
+        field: def.field,
+        old_value: null,
+        new_value: canonical,
+        flagged: false,
+      })
+    }
+  }
+
+  // Write snapshot and flagged.txt
+  const migrationDir = 'artifacts/migration'
+  mkdirSync(migrationDir, { recursive: true })
+
+  const snapshotFile = opts.snapshotPath ?? join(migrationDir, `backfill-snapshot-${formatTimestamp()}.json`)
+  await writeFile(snapshotFile, JSON.stringify(rows, null, 2), 'utf-8')
+
+  if (flagged.length > 0) {
+    const flaggedFile = join(migrationDir, 'flagged.txt')
+    const flaggedLines = flagged.map(
+      (f) => `${f.repo}#${f.number} [${f.field}] observed="${f.observed}" title="${f.title}"`,
+    )
+    await writeFile(flaggedFile, `${flaggedLines.join('\n')}\n`, 'utf-8')
+  }
+
+  const dryRunNote = opts.dryRun ? ' (dry-run)' : ''
+  console.log(
+    `Processed ${issues.length}, updated ${updated}${dryRunNote}, skipped ${skipped}, flagged ${flagged.length}`,
+  )
 }

--- a/plugins/dev-core/skills/issue-triage/lib/set.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/set.ts
@@ -4,10 +4,14 @@
  */
 
 import {
+  GITHUB_REPO,
   isProjectConfigured,
+  LANE_FIELD_ID,
+  LANE_OPTIONS,
   NOT_CONFIGURED_MSG,
   PRIORITY_FIELD_ID,
   PRIORITY_OPTIONS,
+  resolveLane,
   resolvePriority,
   resolveSize,
   resolveStatus,
@@ -24,7 +28,9 @@ import {
   getParentNumber,
   removeBlockedBy,
   removeSubIssue,
+  resolveIssueTypeId,
   updateField,
+  updateIssueIssueType,
 } from '../../shared/adapters/github-adapter'
 import { syncPriorityLabel } from '../../shared/adapters/github-infra'
 
@@ -33,6 +39,8 @@ interface SetOptions {
   size?: string
   priority?: string
   status?: string
+  lane?: string
+  type?: string
   blockedBy?: string
   blocks?: string
   rmBlockedBy?: string
@@ -58,6 +66,12 @@ function parseArgs(args: string[]): SetOptions {
         break
       case '--status':
         opts.status = args[++i]
+        break
+      case '--lane':
+        opts.lane = args[++i]
+        break
+      case '--type':
+        opts.type = args[++i]
         break
       case '--blocked-by':
         opts.blockedBy = args[++i]
@@ -142,8 +156,33 @@ async function applyPriority(itemId: string, issueNumber: number, priority: stri
   console.log(`Priority=${canonical} #${issueNumber}`)
 }
 
+async function applyLane(itemId: string, issueNumber: number, lane: string): Promise<void> {
+  const canonical = resolveLane(lane)
+  if (!(canonical && LANE_OPTIONS[canonical])) {
+    console.error(`Error: Invalid lane. Valid: ${Object.keys(LANE_OPTIONS).join(', ')}`)
+    process.exit(1)
+  }
+  await updateField(itemId, LANE_FIELD_ID, LANE_OPTIONS[canonical])
+  console.log(`Lane=${canonical} #${issueNumber}`)
+}
+
+const VALID_TYPES = ['fix', 'feat', 'docs', 'test', 'chore', 'ci', 'perf', 'epic', 'research', 'refactor']
+
+async function applyType(issueNumber: number, type: string): Promise<void> {
+  const canonical = type.toLowerCase()
+  if (!VALID_TYPES.includes(canonical)) {
+    console.error(`Error: Invalid type. Valid: ${VALID_TYPES.join(', ')}`)
+    process.exit(1)
+  }
+  const issueNodeId = await getNodeId(issueNumber)
+  const org = GITHUB_REPO.split('/')[0]
+  const typeId = await resolveIssueTypeId(org, canonical)
+  await updateIssueIssueType(issueNodeId, typeId)
+  console.log(`Type=${canonical} #${issueNumber}`)
+}
+
 async function applyProjectFields(issueNumber: number, opts: SetOptions): Promise<void> {
-  if (!(opts.size || opts.priority || opts.status)) return
+  if (!(opts.size || opts.priority || opts.status || opts.lane || opts.type)) return
 
   if (!isProjectConfigured()) {
     console.error(NOT_CONFIGURED_MSG)
@@ -156,6 +195,8 @@ async function applyProjectFields(issueNumber: number, opts: SetOptions): Promis
   if (opts.status) await applyStatus(itemId, issueNumber, opts.status)
   if (opts.size) await applySize(itemId, issueNumber, opts.size)
   if (opts.priority) await applyPriority(itemId, issueNumber, opts.priority)
+  if (opts.lane) await applyLane(itemId, issueNumber, opts.lane)
+  if (opts.type) await applyType(issueNumber, opts.type)
 }
 
 async function applyDependencies(issueNumber: number, opts: SetOptions): Promise<void> {
@@ -248,6 +289,8 @@ export async function setIssue(args: string[]): Promise<void> {
     opts.size ||
     opts.priority ||
     opts.status ||
+    opts.lane ||
+    opts.type ||
     opts.blockedBy ||
     opts.blocks ||
     opts.rmBlockedBy ||
@@ -259,7 +302,7 @@ export async function setIssue(args: string[]): Promise<void> {
 
   if (!hasAction) {
     console.error(
-      'Error: Specify --size, --priority, --status, --blocked-by, --blocks, --rm-blocked-by, --rm-blocks, --parent, --add-child, --rm-parent, and/or --rm-child',
+      'Error: Specify --size, --priority, --status, --lane, --type, --blocked-by, --blocks, --rm-blocked-by, --rm-blocks, --parent, --add-child, --rm-parent, and/or --rm-child',
     )
     process.exit(1)
   }

--- a/plugins/dev-core/skills/issue-triage/triage.ts
+++ b/plugins/dev-core/skills/issue-triage/triage.ts
@@ -9,6 +9,7 @@
  *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts create --title "Title" [--body "Body"] ...
  *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts migrate audit-schema
  *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts migrate backfill --repo OWNER/REPO [--dry-run] [--snapshot <path>]
+ *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts migrate rewrite-titles --repo OWNER/REPO [--dry-run] [--snapshot <path>]
  */
 
 const args = process.argv.slice(2)
@@ -87,8 +88,14 @@ switch (command) {
         await backfill(opts)
         break
       }
+      case 'rewrite-titles': {
+        const { rewriteTitles } = await import('./lib/migrate')
+        const opts = parseMigrateBackfillArgs(subArgs)
+        await rewriteTitles(opts)
+        break
+      }
       default:
-        console.error('Usage: triage.ts migrate <audit-schema|backfill> [args]')
+        console.error('Usage: triage.ts migrate <audit-schema|backfill|rewrite-titles> [args]')
         process.exit(1)
     }
     break

--- a/plugins/dev-core/skills/issue-triage/triage.ts
+++ b/plugins/dev-core/skills/issue-triage/triage.ts
@@ -55,6 +55,12 @@ function parseMigrateBackfillArgs(argv: string[]): { repo: string; dryRun: boole
     process.exit(1)
   }
 
+  // fix #9: validate --repo format
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repo)) {
+    console.error('Error: --repo must be OWNER/REPO format')
+    process.exit(1)
+  }
+
   return { repo, dryRun, snapshotPath }
 }
 
@@ -114,20 +120,26 @@ switch (command) {
         break
       }
       case 'backfill': {
-        const { backfill } = await import('./lib/migrate')
+        const { backfill, validateSnapshotPath } = await import('./lib/migrate')
         const opts = parseMigrateBackfillArgs(subArgs)
+        // fix #2: validate user-supplied snapshot path at CLI layer
+        if (opts.snapshotPath) opts.snapshotPath = validateSnapshotPath(opts.snapshotPath)
         await backfill(opts)
         break
       }
       case 'rewrite-titles': {
-        const { rewriteTitles } = await import('./lib/migrate')
+        const { rewriteTitles, validateSnapshotPath } = await import('./lib/migrate')
         const opts = parseMigrateBackfillArgs(subArgs)
+        // fix #2: validate user-supplied snapshot path at CLI layer
+        if (opts.snapshotPath) opts.snapshotPath = validateSnapshotPath(opts.snapshotPath)
         await rewriteTitles(opts)
         break
       }
       case 'revert': {
-        const { revert } = await import('./lib/migrate')
+        const { revert, validateSnapshotPath } = await import('./lib/migrate')
         const opts = parseMigrateRevertArgs(subArgs)
+        // fix #2: validate user-supplied snapshot path at CLI layer
+        opts.snapshotPath = validateSnapshotPath(opts.snapshotPath)
         await revert(opts)
         break
       }

--- a/plugins/dev-core/skills/issue-triage/triage.ts
+++ b/plugins/dev-core/skills/issue-triage/triage.ts
@@ -7,11 +7,54 @@
  *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts [list] [--json]
  *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts set <number> [--size S] [--priority P] ...
  *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts create --title "Title" [--body "Body"] ...
+ *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts migrate audit-schema
+ *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts migrate backfill --repo OWNER/REPO [--dry-run] [--snapshot <path>]
  */
 
 const args = process.argv.slice(2)
 const command = args[0] ?? 'list'
 const rest = args.slice(1)
+
+function parseMigrateBackfillArgs(argv: string[]): { repo: string; dryRun: boolean; snapshotPath?: string } {
+  let repo: string | undefined
+  let dryRun = false
+  let snapshotPath: string | undefined
+  let i = 0
+
+  while (i < argv.length) {
+    const flag = argv[i]
+    if (flag === '--repo') {
+      repo = argv[i + 1]
+      if (!repo) {
+        console.error('Error: --repo requires a value (OWNER/REPO)')
+        process.exit(1)
+      }
+      i += 2
+    } else if (flag === '--dry-run') {
+      dryRun = true
+      i += 1
+    } else if (flag === '--snapshot') {
+      snapshotPath = argv[i + 1]
+      if (!snapshotPath) {
+        console.error('Error: --snapshot requires a path value')
+        process.exit(1)
+      }
+      i += 2
+    } else {
+      console.error(`Error: unknown flag "${flag}"`)
+      console.error('Usage: triage.ts migrate backfill --repo OWNER/REPO [--dry-run] [--snapshot <path>]')
+      process.exit(1)
+    }
+  }
+
+  if (!repo) {
+    console.error('Error: --repo OWNER/REPO is required')
+    console.error('Usage: triage.ts migrate backfill --repo OWNER/REPO [--dry-run] [--snapshot <path>]')
+    process.exit(1)
+  }
+
+  return { repo, dryRun, snapshotPath }
+}
 
 switch (command) {
   case 'list': {
@@ -29,7 +72,28 @@ switch (command) {
     await createIssue(rest)
     break
   }
+  case 'migrate': {
+    const sub = rest[0]
+    const subArgs = rest.slice(1)
+    switch (sub) {
+      case 'audit-schema': {
+        const { auditSchema } = await import('./lib/migrate')
+        await auditSchema()
+        break
+      }
+      case 'backfill': {
+        const { backfill } = await import('./lib/migrate')
+        const opts = parseMigrateBackfillArgs(subArgs)
+        await backfill(opts)
+        break
+      }
+      default:
+        console.error('Usage: triage.ts migrate <audit-schema|backfill> [args]')
+        process.exit(1)
+    }
+    break
+  }
   default:
-    console.error('Usage: triage.ts [list|set|create] ...')
+    console.error('Usage: triage.ts [list|set|create|migrate] ...')
     process.exit(1)
 }

--- a/plugins/dev-core/skills/issue-triage/triage.ts
+++ b/plugins/dev-core/skills/issue-triage/triage.ts
@@ -10,6 +10,7 @@
  *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts migrate audit-schema
  *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts migrate backfill --repo OWNER/REPO [--dry-run] [--snapshot <path>]
  *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts migrate rewrite-titles --repo OWNER/REPO [--dry-run] [--snapshot <path>]
+ *   bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts migrate revert --snapshot <path>
  */
 
 const args = process.argv.slice(2)
@@ -57,6 +58,36 @@ function parseMigrateBackfillArgs(argv: string[]): { repo: string; dryRun: boole
   return { repo, dryRun, snapshotPath }
 }
 
+function parseMigrateRevertArgs(argv: string[]): { snapshotPath: string } {
+  let snapshotPath: string | undefined
+  let i = 0
+
+  while (i < argv.length) {
+    const flag = argv[i]
+    if (flag === '--snapshot') {
+      snapshotPath = argv[i + 1]
+      if (!snapshotPath) {
+        console.error('Error: --snapshot requires a path value')
+        console.error('Usage: triage.ts migrate revert --snapshot <path>')
+        process.exit(1)
+      }
+      i += 2
+    } else {
+      console.error(`Error: unknown flag "${flag}"`)
+      console.error('Usage: triage.ts migrate revert --snapshot <path>')
+      process.exit(1)
+    }
+  }
+
+  if (!snapshotPath) {
+    console.error('Error: --snapshot <path> is required')
+    console.error('Usage: triage.ts migrate revert --snapshot <path>')
+    process.exit(1)
+  }
+
+  return { snapshotPath }
+}
+
 switch (command) {
   case 'list': {
     const { listIssues } = await import('./lib/list')
@@ -94,8 +125,14 @@ switch (command) {
         await rewriteTitles(opts)
         break
       }
+      case 'revert': {
+        const { revert } = await import('./lib/migrate')
+        const opts = parseMigrateRevertArgs(subArgs)
+        await revert(opts)
+        break
+      }
       default:
-        console.error('Usage: triage.ts migrate <audit-schema|backfill|rewrite-titles> [args]')
+        console.error('Usage: triage.ts migrate <audit-schema|backfill|rewrite-titles|revert> [args]')
         process.exit(1)
     }
     break

--- a/plugins/dev-core/skills/shared/__tests__/config.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/config.test.ts
@@ -69,8 +69,8 @@ describe('shared/config', () => {
   })
 
   describe('FIELD_MAP', () => {
-    it('contains status, size, and priority', () => {
-      expect(Object.keys(FIELD_MAP)).toEqual(['status', 'size', 'priority'])
+    it('contains status, size, priority, and lane', () => {
+      expect(Object.keys(FIELD_MAP)).toEqual(['status', 'size', 'priority', 'lane'])
     })
 
     it('each entry has a fieldId and options object', () => {

--- a/plugins/dev-core/skills/shared/adapters/config-helpers.ts
+++ b/plugins/dev-core/skills/shared/adapters/config-helpers.ts
@@ -78,6 +78,7 @@ export const GH_PROJECT_ID = loadDevCoreConfig('gh_project_id', 'GH_PROJECT_ID')
 export const STATUS_FIELD_ID = loadDevCoreConfig('status_field_id', 'STATUS_FIELD_ID') ?? ''
 export const SIZE_FIELD_ID = loadDevCoreConfig('size_field_id', 'SIZE_FIELD_ID') ?? ''
 export const PRIORITY_FIELD_ID = loadDevCoreConfig('priority_field_id', 'PRIORITY_FIELD_ID') ?? ''
+export const LANE_FIELD_ID = loadDevCoreConfig('lane_field_id', 'LANE_FIELD_ID') ?? ''
 
 /** Parse a JSON string into a Record, falling back to the provided default. */
 function parseOptionsValue(raw: string | undefined, fallback: Record<string, string>): Record<string, string> {
@@ -101,6 +102,10 @@ export const PRIORITY_OPTIONS: Record<string, string> = parseOptionsValue(
   loadDevCoreConfig('priority_options_json', 'PRIORITY_OPTIONS_JSON'),
   {},
 )
+export const LANE_OPTIONS: Record<string, string> = parseOptionsValue(
+  loadDevCoreConfig('lane_options_json', 'LANE_OPTIONS_JSON'),
+  {},
+)
 
 /** True when GH_PROJECT_ID and at least one option map are configured via env or YAML. */
 export function isProjectConfigured(): boolean {
@@ -111,6 +116,7 @@ export const FIELD_MAP: Record<string, { fieldId: string; options: Record<string
   status: { fieldId: STATUS_FIELD_ID, options: STATUS_OPTIONS },
   size: { fieldId: SIZE_FIELD_ID, options: SIZE_OPTIONS },
   priority: { fieldId: PRIORITY_FIELD_ID, options: PRIORITY_OPTIONS },
+  lane: { fieldId: LANE_FIELD_ID, options: LANE_OPTIONS },
 }
 
 // CLI aliases — map loose user input to canonical option keys
@@ -138,12 +144,36 @@ export const PRIORITY_ALIASES: Record<string, string> = {
 
 // Canonical field option arrays — single source of truth for field creation and validation
 export const DEFAULT_STATUS_OPTIONS = ['Backlog', 'Analysis', 'Specs', 'In Progress', 'Review', 'Done']
+// TODO(#121): reconcile with hub-bootstrap.ts SIZE_OPTIONS after migrate audit-schema run
 export const DEFAULT_SIZE_OPTIONS = ['XS', 'S', 'M', 'L', 'XL']
 export const DEFAULT_PRIORITY_OPTIONS = ['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low']
+export const DEFAULT_LANE_OPTIONS = [
+  'a1',
+  'a2',
+  'a3',
+  'b',
+  'c1',
+  'c2',
+  'c3',
+  'd',
+  'e',
+  'f',
+  'g',
+  'h',
+  'i',
+  'j',
+  'k',
+  'l',
+  'm',
+  'n',
+  'o',
+  'standalone',
+]
 
 const CANONICAL_STATUSES = new Set(DEFAULT_STATUS_OPTIONS)
 const CANONICAL_SIZES = new Set(DEFAULT_SIZE_OPTIONS)
 const CANONICAL_PRIORITIES = new Set(DEFAULT_PRIORITY_OPTIONS)
+export const CANONICAL_LANES = new Set(DEFAULT_LANE_OPTIONS)
 
 /** Resolve loose user input to a canonical status key, or undefined. */
 export function resolveStatus(input: string): string | undefined {
@@ -161,6 +191,12 @@ export function resolvePriority(input: string): string | undefined {
 export function resolveSize(input: string): string | undefined {
   const upper = input.toUpperCase()
   if (CANONICAL_SIZES.has(upper)) return upper
+  return
+}
+
+/** Resolve loose user input to a canonical lane key, or undefined. */
+export function resolveLane(input: string): string | undefined {
+  if (CANONICAL_LANES.has(input)) return input
   return
 }
 

--- a/plugins/dev-core/skills/shared/adapters/github-adapter.ts
+++ b/plugins/dev-core/skills/shared/adapters/github-adapter.ts
@@ -645,7 +645,8 @@ export async function updateLabels(issueNumber: number, add: string[], remove: s
 
 /** Update the issue type on a GitHub issue. Pass null issueTypeId to clear. */
 export async function updateIssueIssueType(issueNodeId: string, issueTypeId: string | null): Promise<void> {
-  // Note: GitHub GraphQL may reject null issueTypeId — if so, use updateIssueType to clear instead.
+  // FIXME(#121): revert with null issueTypeId is unverified — schema allows it but API behaviour unconfirmed.
+  // Manual verification needed before production revert. Raw mutation error surfaces via ghGraphQL throw.
   await ghGraphQL(UPDATE_ISSUE_ISSUE_TYPE_MUTATION, { issueId: issueNodeId, issueTypeId })
 }
 

--- a/plugins/dev-core/skills/shared/adapters/github-adapter.ts
+++ b/plugins/dev-core/skills/shared/adapters/github-adapter.ts
@@ -24,6 +24,7 @@ import {
   REMOVE_SUB_ISSUE_MUTATION,
   REPO_ID_QUERY,
   UPDATE_FIELD_MUTATION,
+  UPDATE_ISSUE_ISSUE_TYPE_MUTATION,
   UPDATE_ISSUE_TYPE_MUTATION,
 } from '../queries'
 
@@ -628,6 +629,23 @@ export async function updateLabels(issueNumber: number, add: string[], remove: s
   if (add.length) args.push('--add-label', add.join(','))
   if (remove.length) args.push('--remove-label', remove.join(','))
   await run(args)
+}
+
+/** Update the issue type on a GitHub issue. Pass null issueTypeId to clear. */
+export async function updateIssueIssueType(issueNodeId: string, issueTypeId: string | null): Promise<void> {
+  // Note: GitHub GraphQL may reject null issueTypeId — if so, use updateIssueType to clear instead.
+  await ghGraphQL(UPDATE_ISSUE_ISSUE_TYPE_MUTATION, { issueId: issueNodeId, issueTypeId })
+}
+
+/** Resolve an issue type name to its node ID for a given org (case-insensitive). */
+export async function resolveIssueTypeId(org: string, typeName: string): Promise<string> {
+  const types = await listOrgIssueTypes(org)
+  const match = types.find((t) => t.name.toLowerCase() === typeName.toLowerCase())
+  if (!match) {
+    const valid = types.map((t) => t.name).join(', ')
+    throw new Error(`Unknown issue type: ${typeName}. Valid: ${valid}`)
+  }
+  return match.id
 }
 
 /** Get the parent issue number for an issue, or null if none. */

--- a/plugins/dev-core/skills/shared/adapters/github-adapter.ts
+++ b/plugins/dev-core/skills/shared/adapters/github-adapter.ts
@@ -12,6 +12,7 @@ import {
   ADD_BLOCKED_BY_MUTATION,
   ADD_SUB_ISSUE_MUTATION,
   ADD_TO_PROJECT_MUTATION,
+  CLEAR_FIELD_MUTATION,
   CREATE_ISSUE_TYPE_MUTATION,
   DELETE_PROJECT_ITEM_MUTATION,
   ITEM_ID_QUERY,
@@ -535,6 +536,17 @@ export async function updateField(
     itemId,
     fieldId,
     optionId,
+  })
+}
+
+/** Clear a single-select project field value (set to null/unset). */
+export async function clearField(itemId: string, fieldId: string, overrideProjectId?: string): Promise<void> {
+  const pid = overrideProjectId ?? GH_PROJECT_ID
+  if (!pid) throw new Error(GH_PROJECT_ID_NOT_CONFIGURED)
+  await ghGraphQL(CLEAR_FIELD_MUTATION, {
+    projectId: pid,
+    itemId,
+    fieldId,
   })
 }
 

--- a/plugins/dev-core/skills/shared/queries.ts
+++ b/plugins/dev-core/skills/shared/queries.ts
@@ -126,6 +126,13 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
   }) { projectV2Item { id } }
 }`
 
+export const CLEAR_FIELD_MUTATION = `
+mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
+  clearProjectV2ItemFieldValue(input: {
+    projectId: $projectId, itemId: $itemId, fieldId: $fieldId
+  }) { projectV2Item { id } }
+}`
+
 export const ADD_TO_PROJECT_MUTATION = `
 mutation($projectId: ID!, $contentId: ID!) {
   addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {


### PR DESCRIPTION
## Summary

Closes Roxabi/roxabi-plugins#121 (phases 3+4+5 of Roxabi/roxabi-plugins#119 taxonomy migration).

- Extends \`dev-core:issue-triage set\` with **\`--lane\`** and **\`--type\`** write paths (Lane field + org Issue Type).
- Adds \`migrate\` subcommand with four routes: **\`audit-schema\`**, **\`backfill\`**, **\`rewrite-titles\`**, **\`revert\`** — all in TypeScript, reusing existing adapters (Shape B per analysis).
- Idempotent, dry-run-capable, snapshot-based for full reversibility (\`artifacts/migration/*.json\`).

## Key deviations from parent spec (#119)

- **"Dual-write" → "soak window"** — \`set.ts\` never wrote legacy labels, so there is no legacy path to parallel. 7-day window becomes a burn-in of the new write paths under normal triage load.
- **7 enrolled repos, not 8** — \`Roxabi/2ndBrain\` is local-only (not a GitHub repo). Docs patched in \`issue-taxonomy.md\`.
- **Language change** — phases 4/5 implemented in TS inside the skill instead of Python in \`scripts/migrate/\`. Justified in \`artifacts/analyses/121-*.mdx\` (reuses existing adapters, single toolchain, zero churn).
- **Serial per-repo backfill** — no \`--all\` flag in v1. \`--repo OWNER/REPO\` required. Natural human pause between repos enforces \`flagged.txt\` review.
- **Size schema:** \`DEFAULT_SIZE_OPTIONS\` kept as \`['XS','S','M','L','XL']\` with a \`TODO(#121)\` comment. Actual reconciliation requires running \`migrate audit-schema\` against the live hub project (operational, post-merge).

## Lifecycle

| Phase | Artifact | Status |
|---|---|---|
| Intent | Roxabi/roxabi-plugins#121: dual-write + migration (phases 3+4+5) | Open |
| Frame | [121-dual-write-migration-frame.mdx](artifacts/frames/121-dual-write-migration-frame.mdx) | Present |
| Analysis | [121-dual-write-migration-analysis.mdx](artifacts/analyses/121-dual-write-migration-analysis.mdx) | Present (Shape B picked) |
| Spec | [121-dual-write-migration-spec.mdx](artifacts/specs/121-dual-write-migration-spec.mdx) | Present |
| Plan | [121-dual-write-migration-plan.mdx](artifacts/plans/121-dual-write-migration-plan.mdx) | Present (16 micro-tasks, 4 slices) |
| Implementation | 19 commits | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ 461/461 (109 new) | Passed |

## Test Plan

- [ ] \`bun run test\` → 461/461 green
- [ ] \`bun plugins/dev-core/skills/issue-triage/triage.ts set 42 --lane c1 --type feat\` updates hub Lane + org issueType
- [ ] \`bun plugins/dev-core/skills/issue-triage/triage.ts migrate audit-schema\` reports live-vs-local diff
- [ ] \`bun plugins/dev-core/skills/issue-triage/triage.ts migrate backfill --repo Roxabi/roxabi-plugins --dry-run\` writes snapshot + flagged.txt, no mutations
- [ ] \`migrate revert --snapshot <path>\` is idempotent (2nd run = skip log)

## Operational checklist (post-merge, before cutover in Roxabi/roxabi-dashboard#48)

- [ ] 7-day soak: normal triage activity exercises new write paths across 7 repos
- [ ] \`migrate audit-schema\` → 0 diff (reconcile \`DEFAULT_SIZE_OPTIONS\` if needed)
- [ ] \`migrate backfill --dry-run --repo R\` per repo → human review of \`flagged.txt\`
- [ ] \`migrate backfill --repo R\` live run per repo (serial: roxabi-plugins → lyra → other 5)
- [ ] Post-backfill GraphQL check: \`projectV2.items where Lane IS NULL OR Size IS NULL OR issueType IS NULL\` returns 0
- [ ] \`migrate rewrite-titles --dry-run\` reviewed, then live run per repo
- [ ] \`gh issue list --search "^(feat|fix|refactor|docs|test|chore|ci|perf)(\(.+\))?:"\` returns 0 across 7 repos
- [ ] Snapshot JSONs committed to \`artifacts/migration/\`

Closes Roxabi/roxabi-plugins#121

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`