### PR TITLE
refactor(dev-core): remove detectLocalPath HOME scan, add --local flag

### DIFF
--- a/plugins/dev-core/cli/__tests__/resolve.test.ts
+++ b/plugins/dev-core/cli/__tests__/resolve.test.ts
@@ -5,7 +5,7 @@
  *   - parseGitRemoteUrl (SSH / HTTPS / .git suffix / invalid)
  *   - resolveRepoFromCwd (.roxabi marker walk-up, git remote fallback)
  *   - resolveCurrentProject (localPath → git-remote fallback, case-insensitive)
- *   - detectLocalPath (cwd match, ~/projects/<name> scan)
+ *   - detectLocalPath (cwd match only — HOME scan removed)
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -218,18 +218,15 @@ describe('resolveCurrentProject', () => {
 describe('detectLocalPath', () => {
   let tmpDir: string
   let originalCwd: string
-  let originalHome: string | undefined
 
   beforeEach(() => {
     tmpDir = makeTmpDir()
     originalCwd = process.cwd()
-    originalHome = process.env.HOME
   })
 
   afterEach(() => {
     try {
       process.chdir(originalCwd)
-      process.env.HOME = originalHome
     } finally {
       rmSync(tmpDir, { recursive: true, force: true })
     }
@@ -241,46 +238,15 @@ describe('detectLocalPath', () => {
     expect(detectLocalPath('Roxabi/roxabi-forge')).toBe(tmpDir)
   })
 
-  it('falls back to ~/projects/<name> when cwd does not match', () => {
-    const projectsDir = join(tmpDir, 'projects', 'some-repo')
-    mkdirSync(join(projectsDir, '.git'), { recursive: true })
-    process.env.HOME = tmpDir
-    process.chdir(tmpDir)
-    expect(detectLocalPath('Roxabi/some-repo')).toBe(projectsDir)
-  })
-
-  it('returns undefined when no candidate directory exists', () => {
-    process.env.HOME = tmpDir
+  it('returns undefined when cwd does not match the repo', () => {
+    initGitRepo(tmpDir, 'git@github.com:Roxabi/other-repo.git')
     process.chdir(tmpDir)
     expect(detectLocalPath('Roxabi/does-not-exist')).toBeUndefined()
   })
 
-  it('rejects ".." as the name segment — guard provably fires', () => {
-    // Without the guard, existsSync('$HOME/projects/../.git') would match $HOME/.git
-    // and detectLocalPath would return '$HOME/projects/..'. Planting both parents
-    // makes the test discriminate "guard rejected" from "path didn't exist".
-    mkdirSync(join(tmpDir, 'projects'))
-    mkdirSync(join(tmpDir, '.git'))
-    process.env.HOME = tmpDir
+  it('matches repo slug case-insensitively', () => {
+    initGitRepo(tmpDir, 'git@github.com:ROXABI/Roxabi-Forge.git')
     process.chdir(tmpDir)
-    expect(detectLocalPath('Roxabi/..')).toBeUndefined()
-  })
-
-  it('rejects multi-segment traversal like "../etc"', () => {
-    // Plant $HOME/etc/.git so the normalized path $HOME/projects/../etc/.git
-    // would resolve to an existing dir without the `/` / `..` guards.
-    mkdirSync(join(tmpDir, 'projects'))
-    mkdirSync(join(tmpDir, 'etc', '.git'), { recursive: true })
-    process.env.HOME = tmpDir
-    process.chdir(tmpDir)
-    expect(detectLocalPath('Roxabi/../etc')).toBeUndefined()
-  })
-
-  it('rejects dot-prefixed name like ".hidden"', () => {
-    // Plant $HOME/projects/.hidden/.git so the lookup would succeed without the guard.
-    mkdirSync(join(tmpDir, 'projects', '.hidden', '.git'), { recursive: true })
-    process.env.HOME = tmpDir
-    process.chdir(tmpDir)
-    expect(detectLocalPath('Roxabi/.hidden')).toBeUndefined()
+    expect(detectLocalPath('roxabi/roxabi-forge')).toBe(tmpDir)
   })
 })

--- a/plugins/dev-core/cli/__tests__/workspace.test.ts
+++ b/plugins/dev-core/cli/__tests__/workspace.test.ts
@@ -429,3 +429,158 @@ describe('parseWorkspace', () => {
     expect(() => parseWorkspace(null)).toThrow()
   })
 })
+
+// ---------------------------------------------------------------------------
+// workspace add --local flag
+// ---------------------------------------------------------------------------
+
+describe('workspace add --local', () => {
+  it('persists --local path to workspace.json', async () => {
+    const tmpDir = makeTmpDir()
+    const vaultDir = join(tmpDir, '.roxabi-vault')
+    mkdirSync(vaultDir, { recursive: true })
+    const workspacePath = join(vaultDir, 'workspace.json')
+    require('node:fs').writeFileSync(workspacePath, makeWorkspaceJson([]))
+
+    const originalHome = process.env.HOME
+    process.env.HOME = tmpDir
+
+    const mockFetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              repository: {
+                projectsV2: {
+                  nodes: [{ id: 'PVT_test', title: 'Test Project' }],
+                },
+              },
+            },
+          }),
+      }),
+    )
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mockFetch as unknown as typeof fetch
+
+    try {
+      const lines: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => lines.push(args.join(' '))
+
+      const { run } = await import('../commands/workspace')
+      await run(['add', 'Roxabi/test-repo', '--local', '/custom/path/to/repo'])
+
+      console.log = originalLog
+
+      const written = JSON.parse(readFileSync(workspacePath, 'utf8'))
+      expect(written.projects).toHaveLength(1)
+      expect(written.projects[0].localPath).toBe('/custom/path/to/repo')
+    } finally {
+      globalThis.fetch = originalFetch
+      process.env.HOME = originalHome
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects --local path with ".." traversal', async () => {
+    const tmpDir = makeTmpDir()
+    const vaultDir = join(tmpDir, '.roxabi-vault')
+    mkdirSync(vaultDir, { recursive: true })
+    const workspacePath = join(vaultDir, 'workspace.json')
+    require('node:fs').writeFileSync(workspacePath, makeWorkspaceJson([]))
+
+    const originalHome = process.env.HOME
+    process.env.HOME = tmpDir
+
+    const mockFetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              repository: {
+                projectsV2: {
+                  nodes: [{ id: 'PVT_test', title: 'Test Project' }],
+                },
+              },
+            },
+          }),
+      }),
+    )
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mockFetch as unknown as typeof fetch
+
+    try {
+      const errorLines: string[] = []
+      const originalError = console.error
+      console.error = (...args: unknown[]) => errorLines.push(args.join(' '))
+
+      let exitCode: number | undefined
+      const originalExit = process.exit
+      process.exit = ((code?: number) => {
+        exitCode = code
+      }) as typeof process.exit
+
+      const { run } = await import('../commands/workspace')
+      await run(['add', 'Roxabi/test-repo', '--local', '/path/../etc'])
+
+      console.error = originalError
+      process.exit = originalExit
+
+      expect(exitCode).toBe(1)
+      expect(errorLines.join('\n')).toContain('Invalid --local path')
+    } finally {
+      globalThis.fetch = originalFetch
+      process.env.HOME = originalHome
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts relative path with "./"', async () => {
+    const tmpDir = makeTmpDir()
+    const vaultDir = join(tmpDir, '.roxabi-vault')
+    mkdirSync(vaultDir, { recursive: true })
+    const workspacePath = join(vaultDir, 'workspace.json')
+    require('node:fs').writeFileSync(workspacePath, makeWorkspaceJson([]))
+
+    const originalHome = process.env.HOME
+    process.env.HOME = tmpDir
+
+    const mockFetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              repository: {
+                projectsV2: {
+                  nodes: [{ id: 'PVT_test', title: 'Test Project' }],
+                },
+              },
+            },
+          }),
+      }),
+    )
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mockFetch as unknown as typeof fetch
+
+    try {
+      const lines: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => lines.push(args.join(' '))
+
+      const { run } = await import('../commands/workspace')
+      await run(['add', 'Roxabi/test-repo', '--local', './local-repo'])
+
+      console.log = originalLog
+
+      const written = JSON.parse(readFileSync(workspacePath, 'utf8'))
+      expect(written.projects[0].localPath).toBe('./local-repo')
+    } finally {
+      globalThis.fetch = originalFetch
+      process.env.HOME = originalHome
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/plugins/dev-core/cli/commands/workspace.ts
+++ b/plugins/dev-core/cli/commands/workspace.ts
@@ -4,9 +4,18 @@ import { readWorkspace, writeWorkspace } from '../lib/workspace-store'
 const USAGE = `
 Usage:
   roxabi workspace list
-  roxabi workspace add <owner/repo>
+  roxabi workspace add <owner/repo> [--local <path>]
   roxabi workspace remove <owner/repo>
 `.trim()
+
+function validateLocalPath(path: string): string {
+  // Reject path traversal — the only security guard needed for user-provided paths.
+  // Absolute paths (/home/user/repo) and relative paths (./repo) are valid.
+  if (path.includes('..')) {
+    throw new Error(`Invalid --local path: '${path}' must not contain '..'`)
+  }
+  return path
+}
 
 function printTable(projects: { repo: string; projectId: string; label: string }[]): void {
   if (projects.length === 0) {
@@ -32,13 +41,22 @@ async function cmdList(): Promise<void> {
   printTable(ws.projects)
 }
 
-async function cmdAdd(repo: string): Promise<void> {
+async function cmdAdd(repo: string, localPath?: string): Promise<void> {
   if (!repo) {
-    console.error('Usage: roxabi workspace add <owner/repo>')
+    console.error('Usage: roxabi workspace add <owner/repo> [--local <path>]')
     process.exit(1)
   }
 
-  let nodes: { repo: string; projectId: string; label: string }[]
+  if (localPath !== undefined) {
+    try {
+      validateLocalPath(localPath)
+    } catch (e) {
+      console.error(String(e))
+      process.exit(1)
+    }
+  }
+
+  let nodes: { repo: string; projectId: string; label: string; localPath?: string }[]
   try {
     nodes = await discoverProject(repo)
   } catch (e) {
@@ -51,7 +69,7 @@ async function cmdAdd(repo: string): Promise<void> {
     process.exit(1)
   }
 
-  let chosen: { repo: string; projectId: string; label: string }
+  let chosen: { repo: string; projectId: string; label: string; localPath?: string }
 
   if (nodes.length === 1) {
     chosen = nodes[0]
@@ -70,6 +88,11 @@ async function cmdAdd(repo: string): Promise<void> {
       process.exit(1)
     }
     chosen = nodes[idx]
+  }
+
+  // Override localPath if explicitly provided via --local
+  if (localPath !== undefined) {
+    chosen = { ...chosen, localPath }
   }
 
   const ws = readWorkspace()
@@ -111,9 +134,13 @@ export async function run(args: string[]): Promise<void> {
       await cmdList()
       break
 
-    case 'add':
-      await cmdAdd(args[1] ?? '')
+    case 'add': {
+      const localIdx = args.indexOf('--local')
+      const localPath = localIdx !== -1 ? args[localIdx + 1] : undefined
+      const repo = args[1] && args[1] !== '--local' ? args[1] : ''
+      await cmdAdd(repo, localPath)
       break
+    }
 
     case 'remove':
       await cmdRemove(args[1] ?? '')

--- a/plugins/dev-core/cli/lib/cwd-resolver.ts
+++ b/plugins/dev-core/cli/lib/cwd-resolver.ts
@@ -96,20 +96,10 @@ export function resolveCurrentProject(projects: WorkspaceProject[], cwd: string)
 }
 
 /**
- * Try to find the local clone of a repo.
- * Prefers cwd if it is the repo itself, otherwise scans common directories.
+ * Return cwd if it matches the requested repo slug.
+ * Users must provide --local <path> when their clone is not at cwd.
  */
 export function detectLocalPath(repo: string): string | undefined {
   const cwd = process.cwd()
-  if (resolveRepoFromCwd(cwd)?.toLowerCase() === repo.toLowerCase()) return cwd
-
-  const home = process.env.HOME
-  const [, name] = repo.split('/')
-  if (!home || !name) return undefined
-  // Reject path-traversal / hidden segments — the probe must stay inside $HOME.
-  if (name.includes('/') || name.includes('..') || name.startsWith('.')) return undefined
-  for (const dir of [`${home}/projects/${name}`, `${home}/${name}`, `${home}/src/${name}`]) {
-    if (existsSync(`${dir}/.git`)) return dir
-  }
-  return undefined
+  return resolveRepoFromCwd(cwd)?.toLowerCase() === repo.toLowerCase() ? cwd : undefined
 }


### PR DESCRIPTION
## Summary
- Simplify `detectLocalPath` to cwd-match only (remove HOME scan)
- Add `--local <path>` flag to `roxabi workspace add` command
- Add path traversal guard (reject `..`) for `--local` input
- Update tests: remove HOME scan tests, add `--local` flag tests

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #103: remove detectLocalPath HOME scan | OPEN |
| Implementation | 1 commit on `feat/103-remove-detectlocalpath-home-scan` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2 new) | Passed |

## Test Plan
- [ ] Run `roxabi workspace add owner/repo --local /path/to/repo` — path persisted
- [ ] Run `roxabi workspace add owner/repo --local /path/../etc` — rejected with error
- [ ] Run `roxabi workspace add owner/repo --local ./local-repo` — accepted
- [ ] Verify existing workspace entries without `localPath` still work

Closes #103

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/pr`