### PR TITLE
fix(issue-triage): accept owner/repo#N syntax for set subject arg

### DIFF
--- a/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
@@ -414,30 +414,21 @@ describe('issue-triage/set > cross-repo subject', () => {
     await setIssue(['Roxabi/voiceCLI#144', '--rm-blocked-by', 'Roxabi/lyra#1063'])
     expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
     expect(mockGetNodeId).toHaveBeenCalledWith(1063, 'Roxabi/lyra')
-    expect(mockRemoveBlockedBy).toHaveBeenCalledWith(
-      'node-Roxabi-voiceCLI-144',
-      'node-Roxabi-lyra-1063',
-    )
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith('node-Roxabi-voiceCLI-144', 'node-Roxabi-lyra-1063')
   })
 
   it('removes blocks with cross-repo subject', async () => {
     await setIssue(['Roxabi/voiceCLI#144', '--rm-blocks', 'Roxabi/lyra#200'])
     expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
     expect(mockGetNodeId).toHaveBeenCalledWith(200, 'Roxabi/lyra')
-    expect(mockRemoveBlockedBy).toHaveBeenCalledWith(
-      'node-Roxabi-lyra-200',
-      'node-Roxabi-voiceCLI-144',
-    )
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith('node-Roxabi-lyra-200', 'node-Roxabi-voiceCLI-144')
   })
 
   it('removes child with cross-repo subject', async () => {
     await setIssue(['Roxabi/voiceCLI#144', '--rm-child', 'Roxabi/lyra#50'])
     expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
     expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
-    expect(mockRemoveSubIssue).toHaveBeenCalledWith(
-      'node-Roxabi-voiceCLI-144',
-      'node-Roxabi-lyra-50',
-    )
+    expect(mockRemoveSubIssue).toHaveBeenCalledWith('node-Roxabi-voiceCLI-144', 'node-Roxabi-lyra-50')
   })
 })
 

--- a/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
@@ -149,9 +149,13 @@ const { setIssue } = await import('../lib/set')
 function setupMocks() {
   vi.clearAllMocks()
   mockGetItemId.mockResolvedValue('item-123')
-  mockGetNodeId.mockImplementation(async (num) => `node-${num}`)
+  // repo included in key so cross-repo calls return distinguishable node IDs
+  mockGetNodeId.mockImplementation(async (num, repo?: string) =>
+    repo ? `node-${repo.replace('/', '-')}-${num}` : `node-${num}`,
+  )
   mockResolveIssueTypeId.mockResolvedValue('type-id-feat')
   vi.spyOn(console, 'log').mockImplementation(() => {})
+  // console.error spy installed here — .mock.calls still accessible when impl is () => {}
   vi.spyOn(console, 'error').mockImplementation(() => {})
 }
 
@@ -209,13 +213,13 @@ describe('issue-triage/set > dependencies', () => {
   it('adds cross-repo blocked-by dependency', async () => {
     await setIssue(['42', '--blocked-by', 'Roxabi/lyra#728'])
     expect(mockGetNodeId).toHaveBeenCalledWith(728, 'Roxabi/lyra')
-    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-42', 'node-728')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-42', 'node-Roxabi-lyra-728')
   })
 
   it('adds cross-repo blocks dependency', async () => {
     await setIssue(['42', '--blocks', 'Roxabi/voiceCLI#94'])
     expect(mockGetNodeId).toHaveBeenCalledWith(94, 'Roxabi/voiceCLI')
-    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-94', 'node-42')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-Roxabi-voiceCLI-94', 'node-42')
   })
 
   it('handles mixed local and cross-repo refs', async () => {
@@ -239,7 +243,7 @@ describe('issue-triage/set > parent-child relationships', () => {
   it('sets cross-repo parent relationship', async () => {
     await setIssue(['42', '--parent', 'Roxabi/lyra#100'])
     expect(mockGetNodeId).toHaveBeenCalledWith(100, 'Roxabi/lyra')
-    expect(mockAddSubIssue).toHaveBeenCalledWith('node-100', 'node-42')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-Roxabi-lyra-100', 'node-42')
   })
 
   it('adds children', async () => {
@@ -251,7 +255,7 @@ describe('issue-triage/set > parent-child relationships', () => {
   it('adds cross-repo children', async () => {
     await setIssue(['42', '--add-child', 'Roxabi/lyra#50'])
     expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
-    expect(mockAddSubIssue).toHaveBeenCalledWith('node-42', 'node-50')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-42', 'node-Roxabi-lyra-50')
   })
 
   it('removes parent', async () => {
@@ -357,21 +361,21 @@ describe('issue-triage/set > cross-repo subject', () => {
     await setIssue(['Roxabi/voiceCLI#144', '--blocks', 'Roxabi/lyra#200'])
     expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
     expect(mockGetNodeId).toHaveBeenCalledWith(200, 'Roxabi/lyra')
-    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-200', 'node-144')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-Roxabi-lyra-200', 'node-Roxabi-voiceCLI-144')
   })
 
   it('resolves cross-repo subject for --parent', async () => {
     await setIssue(['Roxabi/voiceCLI#144', '--parent', 'Roxabi/lyra#10'])
     expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
     expect(mockGetNodeId).toHaveBeenCalledWith(10, 'Roxabi/lyra')
-    expect(mockAddSubIssue).toHaveBeenCalledWith('node-10', 'node-144')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-Roxabi-lyra-10', 'node-Roxabi-voiceCLI-144')
   })
 
   it('resolves cross-repo subject for --add-child', async () => {
     await setIssue(['Roxabi/voiceCLI#144', '--add-child', 'Roxabi/lyra#50'])
     expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
     expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
-    expect(mockAddSubIssue).toHaveBeenCalledWith('node-144', 'node-50')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-Roxabi-voiceCLI-144', 'node-Roxabi-lyra-50')
   })
 
   it('skips project field updates for cross-repo subject', async () => {
@@ -383,10 +387,19 @@ describe('issue-triage/set > cross-repo subject', () => {
     expect(errCalls.some((m) => m.includes('not supported for cross-repo'))).toBe(true)
   })
 
+  it('skips label sync for cross-repo subject with --size', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--size', 'S'])
+    expect(mockSyncSizeLabel).not.toHaveBeenCalled()
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('label sync') && m.includes('cross-repo'))).toBe(true)
+  })
+
   it('exits with error for --rm-parent on cross-repo subject', async () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
     await setIssue(['Roxabi/voiceCLI#144', '--rm-parent'])
     expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('--rm-parent') && m.includes('cross-repo'))).toBe(true)
   })
 
   it('log output shows cross-repo subject correctly', async () => {
@@ -394,6 +407,37 @@ describe('issue-triage/set > cross-repo subject', () => {
     vi.spyOn(console, 'log').mockImplementation((...args) => logs.push(String(args[0])))
     await setIssue(['Roxabi/voiceCLI#144', '--blocked-by', '100'])
     expect(logs.some((l) => l.includes('Roxabi/voiceCLI#144'))).toBe(true)
+    expect(logs.some((l) => l.includes('#100'))).toBe(true)
+  })
+
+  it('removes blocked-by with cross-repo subject', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-blocked-by', 'Roxabi/lyra#1063'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(1063, 'Roxabi/lyra')
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith(
+      'node-Roxabi-voiceCLI-144',
+      'node-Roxabi-lyra-1063',
+    )
+  })
+
+  it('removes blocks with cross-repo subject', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-blocks', 'Roxabi/lyra#200'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(200, 'Roxabi/lyra')
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith(
+      'node-Roxabi-lyra-200',
+      'node-Roxabi-voiceCLI-144',
+    )
+  })
+
+  it('removes child with cross-repo subject', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-child', 'Roxabi/lyra#50'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
+    expect(mockRemoveSubIssue).toHaveBeenCalledWith(
+      'node-Roxabi-voiceCLI-144',
+      'node-Roxabi-lyra-50',
+    )
   })
 })
 

--- a/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
@@ -181,7 +181,7 @@ describe('issue-triage/set > dependencies', () => {
 
   it('adds blocked-by dependency', async () => {
     await setIssue(['42', '--blocked-by', '100'])
-    expect(mockGetNodeId).toHaveBeenCalledWith(42)
+    expect(mockGetNodeId).toHaveBeenCalledWith(42, undefined)
     expect(mockGetNodeId).toHaveBeenCalledWith(100, undefined)
     expect(mockAddBlockedBy).toHaveBeenCalledWith('node-42', 'node-100')
   })
@@ -338,6 +338,62 @@ describe('issue-triage/set > --type flag', () => {
     expect(exitSpy).toHaveBeenCalledWith(1)
     const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
     expect(errCalls.some((msg) => msg.includes('Invalid type') || msg.includes('Valid'))).toBe(true)
+  })
+})
+
+describe('issue-triage/set > cross-repo subject', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('resolves cross-repo subject for --blocked-by', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--blocked-by', 'Roxabi/lyra#1063,Roxabi/lyra#1064'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(1063, 'Roxabi/lyra')
+    expect(mockGetNodeId).toHaveBeenCalledWith(1064, 'Roxabi/lyra')
+    expect(mockAddBlockedBy).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves cross-repo subject for --blocks', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--blocks', 'Roxabi/lyra#200'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(200, 'Roxabi/lyra')
+    expect(mockAddBlockedBy).toHaveBeenCalledWith('node-200', 'node-144')
+  })
+
+  it('resolves cross-repo subject for --parent', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--parent', 'Roxabi/lyra#10'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(10, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-10', 'node-144')
+  })
+
+  it('resolves cross-repo subject for --add-child', async () => {
+    await setIssue(['Roxabi/voiceCLI#144', '--add-child', 'Roxabi/lyra#50'])
+    expect(mockGetNodeId).toHaveBeenCalledWith(144, 'Roxabi/voiceCLI')
+    expect(mockGetNodeId).toHaveBeenCalledWith(50, 'Roxabi/lyra')
+    expect(mockAddSubIssue).toHaveBeenCalledWith('node-144', 'node-50')
+  })
+
+  it('skips project field updates for cross-repo subject', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    await setIssue(['Roxabi/voiceCLI#144', '--status', 'Backlog'])
+    expect(exitSpy).not.toHaveBeenCalled()
+    expect(mockUpdateField).not.toHaveBeenCalled()
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('not supported for cross-repo'))).toBe(true)
+  })
+
+  it('exits with error for --rm-parent on cross-repo subject', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+    await setIssue(['Roxabi/voiceCLI#144', '--rm-parent'])
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('log output shows cross-repo subject correctly', async () => {
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args) => logs.push(String(args[0])))
+    await setIssue(['Roxabi/voiceCLI#144', '--blocked-by', '100'])
+    expect(logs.some((l) => l.includes('Roxabi/voiceCLI#144'))).toBe(true)
   })
 })
 

--- a/plugins/dev-core/skills/issue-triage/lib/set.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/set.ts
@@ -29,10 +29,11 @@ import {
   updateIssueIssueType,
 } from '../../shared/adapters/github-adapter'
 import { syncLaneLabel, syncPriorityLabel, syncSizeLabel } from '../../shared/adapters/github-infra'
-import { parseIssueRefs } from '../../shared/domain/parse-issue-ref'
+import { parseIssueRef, parseIssueRefs } from '../../shared/domain/parse-issue-ref'
 
 interface SetOptions {
   issueNumber: number
+  subjectRepo?: string
   size?: string
   priority?: string
   status?: string
@@ -95,8 +96,16 @@ function parseArgs(args: string[]): SetOptions {
         opts.rmChild = args[++i]
         break
       default:
-        if (!opts.issueNumber && /^\d+$/.test(arg)) {
-          opts.issueNumber = Number(arg)
+        if (!opts.issueNumber) {
+          if (/^\d+$/.test(arg)) {
+            opts.issueNumber = Number(arg)
+          } else {
+            const ref = parseIssueRef(arg)
+            if (ref) {
+              opts.issueNumber = ref.number
+              opts.subjectRepo = ref.repo
+            }
+          }
         }
         break
     }
@@ -104,6 +113,10 @@ function parseArgs(args: string[]): SetOptions {
   }
 
   return opts
+}
+
+function subjectStr(issueNumber: number, repo?: string): string {
+  return repo ? `${repo}#${issueNumber}` : `#${issueNumber}`
 }
 
 function resolveItemId(issueNumber: number): Promise<string | undefined> {
@@ -153,6 +166,13 @@ async function applyType(issueNumber: number, type: string): Promise<void> {
 async function applyProjectFields(issueNumber: number, opts: SetOptions): Promise<void> {
   if (!(opts.priority || opts.status || opts.type)) return
 
+  if (opts.subjectRepo) {
+    console.error(
+      `Warning: --status/--priority/--type are not supported for cross-repo subjects (${opts.subjectRepo}#${issueNumber}) — skipped`,
+    )
+    return
+  }
+
   if (!isProjectConfigured()) {
     console.error(NOT_CONFIGURED_MSG)
     process.exit(1)
@@ -167,88 +187,96 @@ async function applyProjectFields(issueNumber: number, opts: SetOptions): Promis
 }
 
 async function applyDependencies(issueNumber: number, opts: SetOptions): Promise<void> {
+  const subjStr = subjectStr(issueNumber, opts.subjectRepo)
+
   if (opts.blockedBy) {
-    const issueNodeId = await getNodeId(issueNumber)
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
     for (const ref of parseIssueRefs(opts.blockedBy)) {
       const blockingNodeId = await getNodeId(ref.number, ref.repo)
       await addBlockedBy(issueNodeId, blockingNodeId)
       const refStr = ref.repo ? `${ref.repo}#${ref.number}` : `#${ref.number}`
-      console.log(`BlockedBy=${refStr} #${issueNumber}`)
+      console.log(`BlockedBy=${refStr} ${subjStr}`)
     }
   }
 
   if (opts.blocks) {
-    const blockingNodeId = await getNodeId(issueNumber)
+    const blockingNodeId = await getNodeId(issueNumber, opts.subjectRepo)
     for (const ref of parseIssueRefs(opts.blocks)) {
       const blockedNodeId = await getNodeId(ref.number, ref.repo)
       await addBlockedBy(blockedNodeId, blockingNodeId)
       const refStr = ref.repo ? `${ref.repo}#${ref.number}` : `#${ref.number}`
-      console.log(`Blocks=${refStr} #${issueNumber}`)
+      console.log(`Blocks=${refStr} ${subjStr}`)
     }
   }
 
   if (opts.rmBlockedBy) {
-    const issueNodeId = await getNodeId(issueNumber)
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
     for (const ref of parseIssueRefs(opts.rmBlockedBy)) {
       const blockingNodeId = await getNodeId(ref.number, ref.repo)
       await removeBlockedBy(issueNodeId, blockingNodeId)
       const refStr = ref.repo ? `${ref.repo}#${ref.number}` : `#${ref.number}`
-      console.log(`RemovedBlockedBy=${refStr} #${issueNumber}`)
+      console.log(`RemovedBlockedBy=${refStr} ${subjStr}`)
     }
   }
 
   if (opts.rmBlocks) {
-    const blockingNodeId = await getNodeId(issueNumber)
+    const blockingNodeId = await getNodeId(issueNumber, opts.subjectRepo)
     for (const ref of parseIssueRefs(opts.rmBlocks)) {
       const blockedNodeId = await getNodeId(ref.number, ref.repo)
       await removeBlockedBy(blockedNodeId, blockingNodeId)
       const refStr = ref.repo ? `${ref.repo}#${ref.number}` : `#${ref.number}`
-      console.log(`RemovedBlocks=${refStr} #${issueNumber}`)
+      console.log(`RemovedBlocks=${refStr} ${subjStr}`)
     }
   }
 }
 
 async function applyParentChild(issueNumber: number, opts: SetOptions): Promise<void> {
+  const subjStr = subjectStr(issueNumber, opts.subjectRepo)
+
   if (opts.parent) {
     const parentRef = parseIssueRefs(opts.parent)[0]
     if (parentRef) {
-      const issueNodeId = await getNodeId(issueNumber)
+      const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
       const parentNodeId = await getNodeId(parentRef.number, parentRef.repo)
       await addSubIssue(parentNodeId, issueNodeId)
       const refStr = parentRef.repo ? `${parentRef.repo}#${parentRef.number}` : `#${parentRef.number}`
-      console.log(`Parent=${refStr} #${issueNumber}`)
+      console.log(`Parent=${refStr} ${subjStr}`)
     }
   }
 
   if (opts.addChild) {
-    const issueNodeId = await getNodeId(issueNumber)
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
     for (const childRef of parseIssueRefs(opts.addChild)) {
       const childNodeId = await getNodeId(childRef.number, childRef.repo)
       await addSubIssue(issueNodeId, childNodeId)
       const refStr = childRef.repo ? `${childRef.repo}#${childRef.number}` : `#${childRef.number}`
-      console.log(`Child=${refStr} #${issueNumber}`)
+      console.log(`Child=${refStr} ${subjStr}`)
     }
   }
 
   if (opts.rmParent) {
+    if (opts.subjectRepo) {
+      console.error(`Error: --rm-parent is not supported for cross-repo subjects (${subjStr}) — use direct GraphQL`)
+      process.exit(1)
+    }
     const parentNum = await getParentNumber(issueNumber)
     if (parentNum) {
       const issueNodeId = await getNodeId(issueNumber)
       const parentNodeId = await getNodeId(parentNum)
       await removeSubIssue(parentNodeId, issueNodeId)
-      console.log(`RemovedParent=#${parentNum} #${issueNumber}`)
+      console.log(`RemovedParent=#${parentNum} ${subjStr}`)
     } else {
-      console.log(`No parent found for #${issueNumber}`)
+      console.log(`No parent found for ${subjStr}`)
     }
   }
 
   if (opts.rmChild) {
-    const issueNodeId = await getNodeId(issueNumber)
+    const issueNodeId = await getNodeId(issueNumber, opts.subjectRepo)
     for (const childRef of parseIssueRefs(opts.rmChild)) {
       const childNodeId = await getNodeId(childRef.number, childRef.repo)
       await removeSubIssue(issueNodeId, childNodeId)
       const refStr = childRef.repo ? `${childRef.repo}#${childRef.number}` : `#${childRef.number}`
-      console.log(`RemovedChild=${refStr} #${issueNumber}`)
+      console.log(`RemovedChild=${refStr} ${subjStr}`)
     }
   }
 }
@@ -285,23 +313,29 @@ export async function setIssue(args: string[]): Promise<void> {
 
   await applyProjectFields(opts.issueNumber, opts)
 
-  // Sync labels (independent of project board)
-  if (opts.priority) {
-    const canonical = resolvePriority(opts.priority)
-    if (canonical) await syncPriorityLabel(opts.issueNumber, canonical)
-  }
-  if (opts.size) {
-    const canonical = resolveSize(opts.size)
-    if (canonical) {
-      await syncSizeLabel(opts.issueNumber, canonical)
-      console.log(`Size=${canonical} #${opts.issueNumber}`)
+  // Sync labels (independent of project board) — skipped for cross-repo subjects
+  if (opts.subjectRepo && (opts.priority || opts.size || opts.lane)) {
+    console.error(
+      `Warning: --size/--priority/--lane label sync is not supported for cross-repo subjects (${opts.subjectRepo}#${opts.issueNumber}) — skipped`,
+    )
+  } else {
+    if (opts.priority) {
+      const canonical = resolvePriority(opts.priority)
+      if (canonical) await syncPriorityLabel(opts.issueNumber, canonical)
     }
-  }
-  if (opts.lane) {
-    const canonical = resolveLane(opts.lane)
-    if (canonical) {
-      await syncLaneLabel(opts.issueNumber, canonical)
-      console.log(`Lane=${canonical} #${opts.issueNumber}`)
+    if (opts.size) {
+      const canonical = resolveSize(opts.size)
+      if (canonical) {
+        await syncSizeLabel(opts.issueNumber, canonical)
+        console.log(`Size=${canonical} #${opts.issueNumber}`)
+      }
+    }
+    if (opts.lane) {
+      const canonical = resolveLane(opts.lane)
+      if (canonical) {
+        await syncLaneLabel(opts.issueNumber, canonical)
+        console.log(`Lane=${canonical} #${opts.issueNumber}`)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Fixes silent cross-repo collision: `τ set 144 --blocked-by Roxabi/lyra#1063` resolved #144 against the *current* repo instead of the intended cross-repo target, silently corrupting an unrelated issue
- Reuses existing `parseIssueRef` for the positional subject arg so `τ set Roxabi/voiceCLI#144 --blocked-by Roxabi/lyra#1063,...` routes `getNodeId` to the correct repo
- Skips project-field/label mutations for cross-repo subjects with an explicit warning (unsupported)
- Errors on `--rm-parent` with cross-repo subject (`getParentNumber` has no repo param)
- Log output now shows full `owner/repo#N` for cross-repo subjects

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #137: bug(dev-core:issue-triage): set <N> resolves subject against current repo only | Open |
| Analysis | — | Absent (S-tier) |
| Spec | — | Absent (S-tier) |
| Implementation | 1 commit on `fix/137-cross-repo-subject-resolution` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (7 new) | Passed |

## Test Plan

- [ ] `τ set Roxabi/voiceCLI#144 --blocked-by Roxabi/lyra#1063,Roxabi/lyra#1064` — verify correct node IDs resolved, not lyra#144
- [ ] `τ set Roxabi/voiceCLI#144 --blocks Roxabi/lyra#200` — verify reverse direction correct
- [ ] `τ set Roxabi/voiceCLI#144 --status Backlog` — verify warning emitted, no mutation
- [ ] Local numeric subject `τ set 42 --blocked-by 100` — verify no regression

Closes #137

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`