### PR TITLE
fix(dev-core): replace awk -v with ENVIRON in exemption check

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,7 @@
     }
   },
   "files": {
-    "includes": ["**/*.ts", "**/*.js", "!node_modules", "!**/.venv", "!.cache", "!.claude/worktrees"]
+    "includes": ["**/*.ts", "**/*.js", "!**/node_modules", "!**/.venv", "!**/.cache", "!.claude/worktrees"]
   },
   "overrides": []
 }

--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,7 @@
     }
   },
   "files": {
-    "includes": ["**/*.ts", "**/*.js", "!node_modules", "!plugins/web-intel/.venv", "!.cache", "!.claude/worktrees"]
+    "includes": ["**/*.ts", "**/*.js", "!node_modules", "!**/.venv", "!.cache", "!.claude/worktrees"]
   },
   "overrides": []
 }

--- a/plugins/dev-core/tools/check_file_length.sh
+++ b/plugins/dev-core/tools/check_file_length.sh
@@ -28,7 +28,8 @@ is_exempt() {
     # Exact match on the first whitespace-delimited field — no regex, no escaping,
     # left-anchored (awk field split) so a path substring elsewhere on the line
     # cannot cause a false positive. Exemption format: '<path> <issue-url>'.
-    awk -v p="$1" '$1 == p { found = 1 } END { exit !found }' "$EXEMPT_FILE"
+    # ENVIRON avoids awk's -v escape processing (backslash sequences in path → corrupted match).
+    P="$1" awk '$1 == ENVIRON["P"] { found = 1 } END { exit !found }' "$EXEMPT_FILE"
 }
 
 while IFS= read -r -d '' f; do

--- a/plugins/dev-core/tools/check_file_length.sh
+++ b/plugins/dev-core/tools/check_file_length.sh
@@ -28,9 +28,16 @@ is_exempt() {
     # Exact match on the first whitespace-delimited field — no regex, no escaping,
     # left-anchored (awk field split) so a path substring elsewhere on the line
     # cannot cause a false positive. Exemption format: '<path> <issue-url>'.
+    # Paths must not contain spaces — field splitting would break the match.
     # ENVIRON avoids awk's -v escape processing (backslash sequences in path → corrupted match).
     P="$1" awk '$1 == ENVIRON["P"] { found = 1 } END { exit !found }' "$EXEMPT_FILE"
 }
+
+# Guard: exemption paths must not contain spaces (NF>2 means path has embedded whitespace).
+if [ -f "$EXEMPT_FILE" ] && awk 'NF > 2 { exit 0 } END { exit 1 }' "$EXEMPT_FILE"; then
+    echo "ERROR: $EXEMPT_FILE: exemption path contains spaces — paths with spaces are not supported" >&2
+    exit 1
+fi
 
 while IFS= read -r -d '' f; do
     is_exempt "$f" && continue

--- a/plugins/dev-core/tools/check_file_length.sh
+++ b/plugins/dev-core/tools/check_file_length.sh
@@ -33,8 +33,9 @@ is_exempt() {
     P="$1" awk '$1 == ENVIRON["P"] { found = 1 } END { exit !found }' "$EXEMPT_FILE"
 }
 
-# Guard: exemption paths must not contain spaces (NF>2 means path has embedded whitespace).
-if [ -f "$EXEMPT_FILE" ] && awk 'NF > 2 { exit 0 } END { exit 1 }' "$EXEMPT_FILE"; then
+# Guard: exemption paths must not contain spaces (NF>2 on a non-comment line means embedded whitespace).
+# Skips comment lines (#) to avoid false-positives on scaffold-generated exemption file headers.
+if [ -f "$EXEMPT_FILE" ] && awk '/^[[:space:]]*#/ { next } NF > 2 { found=1 } END { exit !found }' "$EXEMPT_FILE"; then
     echo "ERROR: $EXEMPT_FILE: exemption path contains spaces — paths with spaces are not supported" >&2
     exit 1
 fi

--- a/plugins/dev-core/tools/check_folder_size.sh
+++ b/plugins/dev-core/tools/check_folder_size.sh
@@ -32,8 +32,9 @@ is_exempt() {
     P="$1" awk '$1 == ENVIRON["P"] { found = 1 } END { exit !found }' "$EXEMPT_FILE"
 }
 
-# Guard: exemption paths must not contain spaces (NF>2 means path has embedded whitespace).
-if [ -f "$EXEMPT_FILE" ] && awk 'NF > 2 { exit 0 } END { exit 1 }' "$EXEMPT_FILE"; then
+# Guard: exemption paths must not contain spaces (NF>2 on a non-comment line means embedded whitespace).
+# Skips comment lines (#) to avoid false-positives on scaffold-generated exemption file headers.
+if [ -f "$EXEMPT_FILE" ] && awk '/^[[:space:]]*#/ { next } NF > 2 { found=1 } END { exit !found }' "$EXEMPT_FILE"; then
     echo "ERROR: $EXEMPT_FILE: exemption path contains spaces — paths with spaces are not supported" >&2
     exit 1
 fi

--- a/plugins/dev-core/tools/check_folder_size.sh
+++ b/plugins/dev-core/tools/check_folder_size.sh
@@ -27,9 +27,16 @@ is_exempt() {
     # Exact match on the first whitespace-delimited field — no regex, no escaping,
     # left-anchored (awk field split) so a path substring elsewhere on the line
     # cannot cause a false positive. Exemption format: '<path> <issue-url>'.
+    # Paths must not contain spaces — field splitting would break the match.
     # ENVIRON avoids awk's -v escape processing (backslash sequences in path → corrupted match).
     P="$1" awk '$1 == ENVIRON["P"] { found = 1 } END { exit !found }' "$EXEMPT_FILE"
 }
+
+# Guard: exemption paths must not contain spaces (NF>2 means path has embedded whitespace).
+if [ -f "$EXEMPT_FILE" ] && awk 'NF > 2 { exit 0 } END { exit 1 }' "$EXEMPT_FILE"; then
+    echo "ERROR: $EXEMPT_FILE: exemption path contains spaces — paths with spaces are not supported" >&2
+    exit 1
+fi
 
 while IFS= read -r -d '' d; do
     is_exempt "$d" && continue

--- a/plugins/dev-core/tools/check_folder_size.sh
+++ b/plugins/dev-core/tools/check_folder_size.sh
@@ -27,7 +27,8 @@ is_exempt() {
     # Exact match on the first whitespace-delimited field — no regex, no escaping,
     # left-anchored (awk field split) so a path substring elsewhere on the line
     # cannot cause a false positive. Exemption format: '<path> <issue-url>'.
-    awk -v p="$1" '$1 == p { found = 1 } END { exit !found }' "$EXEMPT_FILE"
+    # ENVIRON avoids awk's -v escape processing (backslash sequences in path → corrupted match).
+    P="$1" awk '$1 == ENVIRON["P"] { found = 1 } END { exit !found }' "$EXEMPT_FILE"
 }
 
 while IFS= read -r -d '' d; do


### PR DESCRIPTION
## Summary

- Replace \`awk -v p=\"\$1\"\` with \`P=\"\$1\" awk '... ENVIRON[\"P\"] ...'\` in \`check_file_length.sh\` and \`check_folder_size.sh\` — fixes silent exemption bypass for paths with backslash sequences
- Extend \`biome.json\` file exclusions to cover all \`.venv\` dirs (was only \`plugins/web-intel/.venv\`) and \`.claude/worktrees\` — eliminates nested-config lint failure

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #130: harden quality-gate awk exemption against backslash-bearing paths | Open |
| Implementation | 2 commits on \`fix/130-awk-environ-exemption\` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests 988/988 ✅ | Passed |

## Test Plan

- [ ] Verify \`is_exempt\` returns true for a path containing \`\\\n\` in the exemption file
- [ ] Verify normal paths still match correctly in both \`check_file_length.sh\` and \`check_folder_size.sh\`
- [ ] Run \`bun run lint\` — should show 0 errors (worktree + .venv exclusions take effect)

## Cross-repo

The same awk fix is needed in voiceCLI's project-side copies (companion issue required — noted in #130).

Closes #130

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`