### PR TITLE
feat(taxonomy): agent_src trust boundary for candidate graduation

### DIFF
--- a/docs/analysis-review-fix-strategy.md
+++ b/docs/analysis-review-fix-strategy.md
@@ -220,39 +220,73 @@ Path: `plugins/dev-core/skills/code-review/review-classes.yml` (new)
 ### 4.2 Candidate namespace (runtime, ephemeral)
 
 - Storage: `~/.dev-core/candidate-classes.jsonl` (per-machine, append-only)
-- Schema per entry: `{ class: "candidate/<slug>", finding_id, pr, hit_at, agent_src }`
+- Schema per entry: `{ class: "candidate/<slug>", finding_id, pr, hit_at, agent_slug, spec_version: "1" }`
+  - `spec_version`: REQUIRED — Slice 5 implementation MUST reject entries lacking this field. Current value: `"1"`.
+  - `agent_slug`: replaces former `agent_src` field — authorization field, not audit-only (see §4.3).
 - Findings tagged `candidate/*` are **advisory only** — never trigger recall
 - Multi-tag allowed: a finding can carry one canonical + one candidate tag
 
 ### 4.3 Graduation cron
 
-**Trust boundary (agent_src allowlist) — REQUIRED before processing any entry:**
+#### 4.3.1 Trust boundary
+
+**Trust boundary (agent_slug allowlist) — REQUIRED before processing any entry:**
 
 Before counting occurrences or distinct PRs, the cron MUST filter the JSONL:
 
 ```
 parse-time filter:
   ∀ entry in candidate-classes.jsonl:
-    IF entry.agent_src is absent OR entry.agent_src NOT IN trusted_agents:
+    IF entry.spec_version is absent:
       drop entry — do NOT count toward graduation threshold
+    IF entry.agent_slug is absent OR entry.agent_slug NOT IN trusted_agents:
+      drop entry — do NOT count toward graduation threshold
+      EMIT WARN log: "WARN: dropped entry pr=<pr> agent_slug=<raw-value> — not in trusted list"
 
-trusted_agents (closed enumeration, derived from plugins/dev-core/agents/*.md):
-  { architect, backend-dev, devops, doc-writer, fixer,
-    frontend-dev, product-lead, security-auditor, tester }
+  AT END OF RUN: print "N entries dropped (unknown agent_slug)" (N=0 → still print)
+
+trusted_agents (normative derivation — SSoT: agents/*.md):
+  trusted_agents := { name from each plugins/dev-core/agents/*.md }
+  derivation: `grep -h '^name:' plugins/dev-core/agents/*.md | awk '{print $2}'`
+  SSoT: agents/*.md (no other location is authoritative)
+
+  Authoritative listing as of 30c092b (derived from agents/; do NOT update by hand
+  — re-run the derivation):
+    { architect, backend-dev, devops, doc-writer, fixer,
+      frontend-dev, product-lead, security-auditor, tester }
+
+  Filter implementation: MUST scan plugins/dev-core/agents/*.md at runtime and
+  extract name: fields — the inline listing is documentation-only. When recall.md
+  (Slice 3) ships, no spec change is needed — the filter automatically picks it up.
 ```
 
 Rationale: without this gate a single subagent can write the same slug across
-≥2 PRs 3× and trivially trigger a graduation PR. `agent_src` is an authorization
-field, not an audit field. Dropped entries are not logged as errors — they are
-silently discarded (same as invalid slug). No coercion, no fallback identity.
+≥2 PRs 3× and trivially trigger a graduation PR. `agent_slug` is an authorization
+field, not an audit field. The silent-drop OUTCOME is preserved — no error surfaced
+to the entry writer, no coercion, no fallback identity. The WARN log + drop-count
+metric are for operators only.
 
-SSoT for the trusted list: agent slugs in `plugins/dev-core/agents/` (name: field).
-If this list drifts from the agents directory, the agents directory wins.
+Dropped entry semantics (NOT the same as invalid slug): an invalid-slug entry also
+gets `C(f) := 0` (never processed far enough to produce a confidence score); an
+unknown `agent_slug` entry is skipped at parse time, no JSONL re-write, audit log
+entry per the WARN requirement above.
+
+#### 4.3.2 Human-in-the-loop invariant
 
 **Human-in-the-loop invariant (mandatory, not advisory):**
 Graduation PRs filed by this cron MUST be human-reviewed before merge.
 `assignee: @human` is required in every filed PR. Auto-merge on graduation PRs
 is explicitly forbidden.
+
+`@human` is a placeholder — Slice 5 implementation MUST resolve it to a concrete
+GitHub user, team handle, or CODEOWNERS entry before this spec can be considered
+enforceable. The branch-protection rule (see below) is the structural complement
+to this resolution.
+
+Enforcement mechanism: TBD — Slice 5 acceptance MUST include a concrete mechanism
+(branch protection rule on the PR's target ref disabling auto-merge, OR a runtime
+check in the cron that refuses to file the PR if auto-merge is enabled). Until
+then, this invariant is documentation-only.
 
 ```
 weekly:
@@ -263,9 +297,11 @@ weekly:
     occurrences ≥ 3 AND distinct_prs ≥ 2
       → file PR to roxabi-plugins:
           - add canonical entry to review-classes.yml
-          - body: list of (pr, finding_id, agent_src) evidence
+          - body: list of (pr, finding_id, agent_slug) evidence
           - label: graduate-class
           - assignee: @human (manual review required — auto-merge forbidden)
+            (@human = placeholder; resolve to concrete GitHub user/team/CODEOWNERS
+             entry in Slice 5 implementation)
 
   ∀ canonical class in review-classes.yml:
     occurrences = count(class, last 90d, across all repos)

--- a/docs/analysis-review-fix-strategy.md
+++ b/docs/analysis-review-fix-strategy.md
@@ -226,9 +226,37 @@ Path: `plugins/dev-core/skills/code-review/review-classes.yml` (new)
 
 ### 4.3 Graduation cron
 
+**Trust boundary (agent_src allowlist) — REQUIRED before processing any entry:**
+
+Before counting occurrences or distinct PRs, the cron MUST filter the JSONL:
+
+```
+parse-time filter:
+  ∀ entry in candidate-classes.jsonl:
+    IF entry.agent_src is absent OR entry.agent_src NOT IN trusted_agents:
+      drop entry — do NOT count toward graduation threshold
+
+trusted_agents (closed enumeration, derived from plugins/dev-core/agents/*.md):
+  { architect, backend-dev, devops, doc-writer, fixer,
+    frontend-dev, product-lead, security-auditor, tester }
+```
+
+Rationale: without this gate a single subagent can write the same slug across
+≥2 PRs 3× and trivially trigger a graduation PR. `agent_src` is an authorization
+field, not an audit field. Dropped entries are not logged as errors — they are
+silently discarded (same as invalid slug). No coercion, no fallback identity.
+
+SSoT for the trusted list: agent slugs in `plugins/dev-core/agents/` (name: field).
+If this list drifts from the agents directory, the agents directory wins.
+
+**Human-in-the-loop invariant (mandatory, not advisory):**
+Graduation PRs filed by this cron MUST be human-reviewed before merge.
+`assignee: @human` is required in every filed PR. Auto-merge on graduation PRs
+is explicitly forbidden.
+
 ```
 weekly:
-  ∀ candidate/<slug> in jsonl:
+  ∀ candidate/<slug> in jsonl [after trust-boundary filter above]:
     occurrences = count(slug, last 30d)
     distinct_prs = count(distinct pr, last 30d)
 
@@ -237,7 +265,7 @@ weekly:
           - add canonical entry to review-classes.yml
           - body: list of (pr, finding_id, agent_src) evidence
           - label: graduate-class
-          - assignee: @human (manual review required)
+          - assignee: @human (manual review required — auto-merge forbidden)
 
   ∀ canonical class in review-classes.yml:
     occurrences = count(class, last 90d, across all repos)

--- a/plugins/dev-core/skills/code-review/review-classes.yml
+++ b/plugins/dev-core/skills/code-review/review-classes.yml
@@ -129,3 +129,31 @@ classes:
 #   ≥2-distinct-PRs promotion gate (advisory only).
 #
 # Findings tagged candidate/* are advisory only — never trigger recall.
+#
+# ── agent_src: authorization field (NOT audit-only) ─────────────────────────
+#
+# agent_src is a CLOSED ENUMERATION of trusted identities. Graduation cron MUST
+# reject (drop, not coerce) any entry where agent_src is absent or not in this list.
+#
+# Threat: a single subagent writing the same slug across ≥2 PRs 3× trivially
+# satisfies the graduation gate (hit ≥3×/30d, ≥2 distinct PRs). Restricting
+# writes to trusted identities raises the bar without requiring human sign-off
+# on every individual JSONL entry.
+#
+# Trusted agent identities — must match agent slugs in plugins/dev-core/agents/:
+#   architect | backend-dev | devops | doc-writer | fixer
+#   frontend-dev | product-lead | security-auditor | tester
+#
+# SSoT: agent slugs are derived from plugins/dev-core/agents/*.md (name: field).
+# When a new agent is added to that directory, update this list to keep them in sync.
+#
+# Enforcement point: graduation cron (Slice 5 — docs/analysis-review-fix-strategy.md §4.3).
+# Until Slice 5 is implemented, this comment IS the binding spec.
+#
+# Failure mode: entry with unknown or absent agent_src → dropped silently (same
+# as invalid slug). No coercion, no fallback identity.
+#
+# Belt-and-suspenders invariant (Option 2):
+# Graduation PRs MUST be human-reviewed before merge. No automation may auto-merge
+# a graduation PR. The assignee: @human field in the cron output (§4.3) is
+# mandatory, not advisory. Auto-merge on graduation PRs is explicitly forbidden.

--- a/plugins/dev-core/skills/code-review/review-classes.yml
+++ b/plugins/dev-core/skills/code-review/review-classes.yml
@@ -118,7 +118,11 @@ classes:
 #   Invalid slug → entry dropped + C(f) := 0. No path components, no whitespace.
 #
 # Schema per entry:
-#   { class: "candidate/<slug>", finding_id, pr: str (required), hit_at, agent_src }
+#   { class: "candidate/<slug>", finding_id, pr: str (required), hit_at,
+#     agent_slug, spec_version: "1" }
+#
+#   spec_version: REQUIRED — Slice 5 implementation MUST reject entries lacking
+#     this field. Current value: "1".
 #
 #   pr: PR identifier (e.g. "146") or synthetic "local:<branch-slug>:<sha8>" for non-PR runs.
 #   branch-slug component: [a-z0-9-]+, max 60 chars; slugify branch name
@@ -130,30 +134,59 @@ classes:
 #
 # Findings tagged candidate/* are advisory only — never trigger recall.
 #
-# ── agent_src: authorization field (NOT audit-only) ─────────────────────────
+# ── agent_slug: authorization field (NOT audit-only) ────────────────────────
 #
-# agent_src is a CLOSED ENUMERATION of trusted identities. Graduation cron MUST
-# reject (drop, not coerce) any entry where agent_src is absent or not in this list.
+# agent_slug is a CLOSED ENUMERATION of trusted identities. Graduation cron MUST
+# reject (drop, not coerce) any entry where agent_slug is absent or not in this list.
 #
 # Threat: a single subagent writing the same slug across ≥2 PRs 3× trivially
 # satisfies the graduation gate (hit ≥3×/30d, ≥2 distinct PRs). Restricting
 # writes to trusted identities raises the bar without requiring human sign-off
 # on every individual JSONL entry.
 #
-# Trusted agent identities — must match agent slugs in plugins/dev-core/agents/:
+# Trusted agent identities — normative derivation (SSoT):
+#   trusted_agents := { name from each plugins/dev-core/agents/*.md }
+#   derivation: `grep -h '^name:' plugins/dev-core/agents/*.md | awk '{print $2}'`
+#   SSoT: agents/*.md (no other location is authoritative)
+#
+# Authoritative listing as of 30c092b (derived from agents/; do NOT update by hand
+# — re-run the derivation above):
 #   architect | backend-dev | devops | doc-writer | fixer
 #   frontend-dev | product-lead | security-auditor | tester
 #
-# SSoT: agent slugs are derived from plugins/dev-core/agents/*.md (name: field).
-# When a new agent is added to that directory, update this list to keep them in sync.
+# Filter implementation (Slice 5 cron): MUST scan plugins/dev-core/agents/*.md at
+# runtime and extract name: fields — the inline listing above is documentation-only.
+# When recall.md (Slice 3) ships, no spec change is needed — the filter automatically
+# picks it up.
 #
 # Enforcement point: graduation cron (Slice 5 — docs/analysis-review-fix-strategy.md §4.3).
 # Until Slice 5 is implemented, this comment IS the binding spec.
 #
-# Failure mode: entry with unknown or absent agent_src → dropped silently (same
-# as invalid slug). No coercion, no fallback identity.
+# Failure mode: entry with unknown or absent agent_slug → dropped silently. This
+# is NOT the same as invalid slug: an invalid-slug entry also gets C(f) := 0 (never
+# processed far enough to produce a confidence score); an unknown agent_slug entry
+# is skipped at parse time, no JSONL re-write, audit log entry per the WARN
+# requirement below. No coercion, no fallback identity.
+#
+# Audit channel (REQUIRED — operator visibility without weakening the security gate):
+# The graduation cron MUST, per dropped entry (unknown or absent agent_slug):
+#   1. Emit a WARN-level log line including: raw agent_slug value + source PR identifier
+#      (e.g. "WARN: dropped entry pr=146 agent_slug=<raw-value> — not in trusted list")
+#   2. At end of each cron run, print: "N entries dropped (unknown agent_slug)"
+#      (the drop-count metric). N=0 → still print.
+# The silent-drop OUTCOME is preserved — no error surfaced to the entry writer,
+# no coercion, no fallback identity. The audit is for operators, not attackers.
 #
 # Belt-and-suspenders invariant (Option 2):
 # Graduation PRs MUST be human-reviewed before merge. No automation may auto-merge
 # a graduation PR. The assignee: @human field in the cron output (§4.3) is
 # mandatory, not advisory. Auto-merge on graduation PRs is explicitly forbidden.
+# Enforcement mechanism: TBD — Slice 5 acceptance MUST include a concrete mechanism
+# (branch protection rule on the PR's target ref disabling auto-merge, OR a runtime
+# check in the cron that refuses to file the PR if auto-merge is enabled). Until
+# then, this invariant is documentation-only.
+#
+# @human placeholder: @human is a placeholder — Slice 5 implementation MUST resolve
+# it to a concrete GitHub user, team handle, or CODEOWNERS entry before this spec
+# can be considered enforceable. The branch-protection rule (per above) is the
+# structural complement to this resolution.


### PR DESCRIPTION
Closes #153

## Summary

- Defines `agent_src` as a **closed authorization field** (not audit-only) in the candidate namespace. Graduation cron must drop entries with absent or unknown `agent_src` before counting toward promotion thresholds.
- Codifies the trusted agent identity list (derived from `plugins/dev-core/agents/*.md`): `architect`, `backend-dev`, `devops`, `doc-writer`, `fixer`, `frontend-dev`, `product-lead`, `security-auditor`, `tester`.
- Documents the human-in-the-loop belt: graduation PRs must carry `assignee: @human`; auto-merge is explicitly forbidden.
- Spec written in two places: `review-classes.yml` (binding until Slice 5 lands) and `docs/analysis-review-fix-strategy.md §4.3` (canonical statement for Slice 5 implementation).

## Test plan

- [ ] Re-read graduation cron design in `docs/analysis-review-fix-strategy.md §4.3` — confirm allowlist filter is placed before occurrence counting
- [ ] Confirm trusted list matches `plugins/dev-core/agents/*.md` name fields (9 entries)
- [ ] Confirm `review-classes.yml` YAML still parses (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Confirm no `classes:` entries were modified (surgical comment-only edit)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)