### PR TITLE
feat(code-review): chunker + boundary digest (Slice 2)

### DIFF
--- a/plugins/dev-core/skills/code-review/SKILL.md
+++ b/plugins/dev-core/skills/code-review/SKILL.md
@@ -81,6 +81,28 @@ git diff ${BASE}...HEAD | grep -iE '(password|passwd|secret|api[_-]?key|auth[_-]
 
 Spawn fresh agents via Task (¬implementation context → ¬bias).
 
+### Chunking (Slice 2 — O2)
+
+Before dispatching agents, partition Δ into chunks using the Python chunker
+(`${CLAUDE_SKILL_DIR}/chunker.py`). Recall wiring is deferred to Slice 3.
+
+```python
+# Pseudo-code — orchestrator executes this logic inline
+from chunker import parse_diff, chunk, compute_budget
+from digest import emit_all_digests, format_digest_for_agent
+
+raw_diff   = <diff text from Phase 1>
+ctx_window = <active model context window, e.g. 200_000>
+
+files   = parse_diff(raw_diff)
+budget  = compute_budget(ctx_window)          # 0.4 × ctx_window
+chunks  = chunk(files, budget)                # list[Chunk]
+digests = emit_all_digests(chunks)            # list[BoundaryDigest]
+```
+
+- If `len(chunks) == 1` → single-chunk path (identical to pre-Slice-2 behaviour; all agents receive the full diff as before).
+- If `len(chunks) > 1` → per-chunk Lane A dispatch (see below).
+
 ### Agent dispatch
 
 | Agent | Condition | Focus |
@@ -95,7 +117,7 @@ Spawn fresh agents via Task (¬implementation context → ¬bias).
 
 Skip rules: architect → |Δ| ≤ 5 ∧ ¬arch keywords | product-lead → spec ∄ | tester → Δ ⊂ {config, docs, infra}
 
-**Subdomain split:** |files_domain| ≥ 8 ∧ distinct modules → N agents, 1/module. Default: 1/domain.
+**Subdomain split (multi-chunk):** For each chunk `c_i`, apply the dispatch table against `c_i.files` only (not full Δ). Default: 1 agent per domain per chunk.
 
 ### Security-auditor scoping
 
@@ -114,11 +136,17 @@ Skip rules: architect → |Δ| ≤ 5 ∧ ¬arch keywords | product-lead → spec
 # SYNC REQUIRED: inline class list must match review-classes.yml slugs — see #149
 ### Spawn template
 
+**Single-chunk (|chunks| = 1):** identical to pre-Slice-2 — agents receive full diff.
+
+**Multi-chunk (|chunks| > 1) — Lane A per-chunk:**
+
+For each chunk `c_i`, spawn the applicable domain agents in parallel:
+
 ```
 Task(
   subagent_type: "dev-core:{agent}",
-  description: "{agent} review — {PR#|branch}",
-  prompt: "Code review task. Focus: {focus}. Output Conventional Comments findings only. ¬TaskCreate.\n\nFormat per finding:\n<label>: <description>\n  <file>:<line>\n  -- {agent}\n  Root cause: <why>\n  Class: [<canonical-class>, ...] [candidate/<slug>?]  ← 0–N canonical from review-classes.yml + 0–1 candidate; omit field if no class applies\n  Raw callsites: [{file: <path>, line: <n>}, ...]  ← all locations of this anti-pattern; required when Class is set; never empty\n  Solutions:\n    1. <primary> (recommended)\n    2. <alternative>\n  Confidence: N%\n\nCanonical classes (use slug only): test-tautology, generator-drift, parallel-path-drift, bash-arithmetic-trap, bash-error-suppression, shell-injection, sql-injection, missing-error-handling, missing-input-validation, secret-leak, bare-except, path-traversal, unbounded-loop. Free-text labels not in this list or candidate/* namespace are invalid. Candidate slugs must match ^candidate/[a-z][a-z0-9-]{1,48}$. Subsumption: bare-except subsumes missing-error-handling — when both apply, tag bare-except only.\n\n---DIFF---\n{diff}\n\n---FILES---\n{changed file contents}\n\n---SPEC---\n{spec contents if ∃, else omit section}"
+  description: "{agent} review — chunk {i}/{N} — {PR#|branch}",
+  prompt: "Code review task. Focus: {focus}. Output Conventional Comments findings only. ¬TaskCreate.\n\nYou are reviewing chunk {i} of {N}. Review ONLY the files in this chunk.\n\nFormat per finding:\n<label>: <description>\n  <file>:<line>\n  -- {agent}\n  Root cause: <why>\n  Class: [<canonical-class>, ...] [candidate/<slug>?]  ← 0–N canonical from review-classes.yml + 0–1 candidate; omit field if no class applies\n  Raw callsites: [{file: <path>, line: <n>}, ...]  ← all locations of this anti-pattern; required when Class is set; never empty\n  Solutions:\n    1. <primary> (recommended)\n    2. <alternative>\n  Confidence: N%\n\nCanonical classes (use slug only): test-tautology, generator-drift, parallel-path-drift, bash-arithmetic-trap, bash-error-suppression, shell-injection, sql-injection, missing-error-handling, missing-input-validation, secret-leak, bare-except, path-traversal, unbounded-loop. Free-text labels not in this list or candidate/* namespace are invalid. Candidate slugs must match ^candidate/[a-z][a-z0-9-]{1,48}$. Subsumption: bare-except subsumes missing-error-handling — when both apply, tag bare-except only.\n\n---CHUNK DIFF (chunk {i})---\n{c_i.hunk_text for all files in chunk}\n\n---CHUNK FILES---\n{contents of files in c_i}\n\n---BOUNDARY DIGESTS (other chunks)---\n{format_digest_for_agent(d) for d in digests if d.chunk_index != i}\n\n---SPEC---\n{spec contents if ∃, else omit section}"
 )
 ```
 
@@ -126,7 +154,9 @@ Agent name map: `security-auditor` → `dev-core:security-auditor` | `architect`
 
 ### Agent payload
 
-Each agent receives: full diff + Δ + spec (if ∃) + "output Conventional Comments".
+**Single-chunk:** each agent receives full diff + Δ + spec (if ∃) + "output Conventional Comments".
+
+**Multi-chunk (Lane A):** each agent receives chunk diff + chunk file contents + boundary digests of all *other* chunks + spec (if ∃).
 
 ### Review dimensions
 correctness | security | performance | architecture | tests | readability | observability

--- a/plugins/dev-core/skills/code-review/SKILL.md
+++ b/plugins/dev-core/skills/code-review/SKILL.md
@@ -136,6 +136,8 @@ Skip rules: architect → |Δ| ≤ 5 ∧ ¬arch keywords | product-lead → spec
 # SYNC REQUIRED: inline class list must match review-classes.yml slugs — see #149
 ### Spawn template
 
+> **Note (orchestrator):** The `{format_digest_for_agent(d) for d in digests if d.chunk_index != i}` placeholder is a Python expression evaluated by the orchestrator (Claude main context) BEFORE the Task call — substitute its rendered value into the prompt string. It is NOT a runtime-resolved placeholder. All other `{...}` placeholders are simple value substitutions.
+
 **Single-chunk (|chunks| = 1):** identical to pre-Slice-2 — agents receive full diff.
 
 **Multi-chunk (|chunks| > 1) — Lane A per-chunk:**

--- a/plugins/dev-core/skills/code-review/chunker.py
+++ b/plugins/dev-core/skills/code-review/chunker.py
@@ -51,7 +51,8 @@ class Chunk:
 # ---------------------------------------------------------------------------
 
 # Matches "diff --git a/... b/..."
-_DIFF_HEADER = re.compile(r'^diff --git a/(.+) b/(.+)$')
+# Non-greedy first group to handle paths containing literal ' b/'
+_DIFF_HEADER = re.compile(r'^diff --git a/(.+?) b/(.+)$')
 # Matches rename/copy "rename from ..." / "rename to ..." headers
 _RENAME_FROM = re.compile(r'^rename from (.+)$')
 _RENAME_TO = re.compile(r'^rename to (.+)$')
@@ -82,6 +83,8 @@ def parse_diff(raw_diff: str) -> list[DiffFile]:
 
         a_path = m.group(1)
         b_path = m.group(2)
+        if not a_path or not b_path:
+            raise ValueError(f'Degenerate diff --git header: {line!r}')
         i += 1
 
         # Collect extended headers (index, mode, rename from/to, …)
@@ -104,7 +107,8 @@ def parse_diff(raw_diff: str) -> list[DiffFile]:
             i += 1
 
         hunk_text = '\n'.join(hunk_lines)
-        loc = len(hunk_lines)
+        # Exclude @@ separator lines from LOC count; they are preserved in hunk_text
+        loc = sum(1 for l in hunk_lines if not l.startswith('@@'))
 
         # Canonical path: b-side (rename target) if rename; otherwise b-path
         if rename_from is not None and rename_to is not None:
@@ -161,16 +165,19 @@ def compute_budget(context_window_tokens: int, fraction: float = 0.4) -> int:
 # Core chunker
 # ---------------------------------------------------------------------------
 
-def _top_dir(path: str) -> str:
-    """Return the top-level directory component of a path.
+def _top_dir(path: str, depth: int = 1) -> str:
+    """Return the top directory component(s) of a path up to *depth* levels.
 
-    'src/lyra/core/foo.py' → 'src'
-    'README.md'            → '.'   (root-level file)
+    'src/lyra/core/foo.py', depth=1 → 'src'
+    'src/lyra/core/foo.py', depth=2 → 'src/lyra'
+    'README.md',            depth=1 → '.'   (root-level file)
+
+    Default depth=1 preserves existing behaviour.
     """
     parts = PurePosixPath(path).parts
     if len(parts) <= 1:
         return '.'
-    return parts[0]
+    return '/'.join(parts[:depth]) or '.'
 
 
 def chunk(

--- a/plugins/dev-core/skills/code-review/chunker.py
+++ b/plugins/dev-core/skills/code-review/chunker.py
@@ -1,0 +1,236 @@
+"""Chunker — directory-cohesion + LOC-bounded fallback.
+
+Slice 2 of the code-review redesign (see docs/analysis-review-fix-strategy.md §3 O2).
+
+Design rules (O2):
+  - Primary unit: stable directory tree (all files under the same top-level
+    directory belong to one chunk, preserving cohesion across PRs).
+  - Fallback: LOC-bounded split only when a single directory exceeds the budget.
+  - Budget: 0.4 × active_model_context_window — dynamic, not a hard constant.
+  - Pure Python stdlib; raises on malformed input (¬silent None/False coercion).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Sequence
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DiffFile:
+    """Parsed metadata for a single file in a unified diff."""
+
+    path: str       # canonical path (b-side for renames, a-side for deletes)
+    old_path: str | None  # populated on renames/copies; None otherwise
+    lines: int      # total diff lines (context + added + removed) for this file
+    hunk_text: str  # raw hunk content (everything after the file header)
+
+
+@dataclass
+class Chunk:
+    """A group of DiffFiles assigned to one Lane-A agent."""
+
+    files: list[DiffFile] = field(default_factory=list)
+
+    @property
+    def total_lines(self) -> int:
+        return sum(f.lines for f in self.files)
+
+    @property
+    def paths(self) -> list[str]:
+        return [f.path for f in self.files]
+
+
+# ---------------------------------------------------------------------------
+# Diff parsing
+# ---------------------------------------------------------------------------
+
+# Matches "diff --git a/... b/..."
+_DIFF_HEADER = re.compile(r'^diff --git a/(.+) b/(.+)$')
+# Matches rename/copy "rename from ..." / "rename to ..." headers
+_RENAME_FROM = re.compile(r'^rename from (.+)$')
+_RENAME_TO = re.compile(r'^rename to (.+)$')
+
+
+def parse_diff(raw_diff: str) -> list[DiffFile]:
+    """Parse a unified git diff into a list of DiffFile objects.
+
+    Raises ValueError with an excerpt of the offending input if the diff
+    cannot be parsed (e.g. truncated header, ambiguous path).
+
+    An empty diff returns an empty list (not an error).
+    """
+    if not raw_diff or not raw_diff.strip():
+        return []
+
+    files: list[DiffFile] = []
+    lines = raw_diff.splitlines()
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        line = lines[i]
+        m = _DIFF_HEADER.match(line)
+        if not m:
+            i += 1
+            continue
+
+        a_path = m.group(1)
+        b_path = m.group(2)
+        i += 1
+
+        # Collect extended headers (index, mode, rename from/to, …)
+        rename_from: str | None = None
+        rename_to: str | None = None
+        hunk_lines: list[str] = []
+
+        while i < n and not _DIFF_HEADER.match(lines[i]):
+            current = lines[i]
+            rf = _RENAME_FROM.match(current)
+            rt = _RENAME_TO.match(current)
+            if rf:
+                rename_from = rf.group(1)
+            elif rt:
+                rename_to = rt.group(1)
+            else:
+                # Everything from the first @@ onward is hunk text
+                if current.startswith('@@') or hunk_lines:
+                    hunk_lines.append(current)
+            i += 1
+
+        hunk_text = '\n'.join(hunk_lines)
+        loc = len(hunk_lines)
+
+        # Canonical path: b-side (rename target) if rename; otherwise b-path
+        if rename_from is not None and rename_to is not None:
+            canonical = rename_to
+            old = rename_from
+        elif b_path == '/dev/null':
+            # Pure deletion — use a-path
+            canonical = a_path
+            old = None
+        else:
+            canonical = b_path
+            old = a_path if a_path != b_path else None
+
+        files.append(DiffFile(
+            path=canonical,
+            old_path=old,
+            lines=loc,
+            hunk_text=hunk_text,
+        ))
+
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Budget
+# ---------------------------------------------------------------------------
+
+def compute_budget(context_window_tokens: int, fraction: float = 0.4) -> int:
+    """Return LOC budget as 0.4 × context window (or custom fraction).
+
+    The token-to-LOC mapping is 1:1 for planning purposes — the budget is
+    expressed in diff lines, not characters, so the caller can compare it
+    directly against DiffFile.lines.
+
+    Args:
+        context_window_tokens: active model context window size (tokens).
+        fraction: proportion of the context window to use as budget (default 0.4).
+
+    Raises:
+        ValueError: if context_window_tokens ≤ 0 or fraction not in (0, 1].
+    """
+    if context_window_tokens <= 0:
+        raise ValueError(
+            f'context_window_tokens must be > 0, got {context_window_tokens}'
+        )
+    if not (0 < fraction <= 1.0):
+        raise ValueError(
+            f'fraction must be in (0, 1], got {fraction}'
+        )
+    return int(context_window_tokens * fraction)
+
+
+# ---------------------------------------------------------------------------
+# Core chunker
+# ---------------------------------------------------------------------------
+
+def _top_dir(path: str) -> str:
+    """Return the top-level directory component of a path.
+
+    'src/lyra/core/foo.py' → 'src'
+    'README.md'            → '.'   (root-level file)
+    """
+    parts = PurePosixPath(path).parts
+    if len(parts) <= 1:
+        return '.'
+    return parts[0]
+
+
+def chunk(
+    files: Sequence[DiffFile],
+    budget: int,
+) -> list[Chunk]:
+    """Partition DiffFiles into Chunks respecting the LOC budget.
+
+    Algorithm:
+      1. Group files by top-level directory (directory-cohesion).
+      2. For each directory group:
+         a. If total LOC ≤ budget → one Chunk for the whole group.
+         b. Else → LOC-bounded split within the group (greedy bin-packing).
+      3. Any oversized single file (LOC > budget) gets its own Chunk
+         (can't split a file further at this layer).
+
+    Returns:
+      List of Chunk objects (may be empty if files is empty).
+
+    Raises:
+      ValueError: if budget ≤ 0.
+    """
+    if budget <= 0:
+        raise ValueError(f'budget must be > 0, got {budget}')
+
+    if not files:
+        return []
+
+    # Group by top-level directory, preserving insertion order
+    dir_groups: dict[str, list[DiffFile]] = {}
+    for f in files:
+        key = _top_dir(f.path)
+        dir_groups.setdefault(key, []).append(f)
+
+    result: list[Chunk] = []
+
+    for dir_files in dir_groups.values():
+        dir_loc = sum(f.lines for f in dir_files)
+
+        if dir_loc <= budget:
+            # Entire directory fits in one chunk
+            result.append(Chunk(files=list(dir_files)))
+        else:
+            # LOC-bounded greedy split within the directory
+            current = Chunk()
+            for f in dir_files:
+                if f.lines > budget:
+                    # Single oversized file → its own chunk
+                    if current.files:
+                        result.append(current)
+                        current = Chunk()
+                    result.append(Chunk(files=[f]))
+                elif current.total_lines + f.lines > budget:
+                    # Current chunk would overflow → start a new one
+                    result.append(current)
+                    current = Chunk(files=[f])
+                else:
+                    current.files.append(f)
+
+            if current.files:
+                result.append(current)
+
+    return result

--- a/plugins/dev-core/skills/code-review/digest.py
+++ b/plugins/dev-core/skills/code-review/digest.py
@@ -1,0 +1,170 @@
+"""Boundary digest emitter — Slice 2 of code-review redesign.
+
+A boundary digest is a compact summary of what a Chunk contains, sent to
+Lane-A agents reviewing *other* chunks so they can detect cross-chunk
+anti-patterns (RC-3 / parallel-path-drift) without receiving the full diff.
+
+Design intent (docs/analysis-review-fix-strategy.md §5 F2):
+  "Digest must include call-graph edges to named entry points + modified
+   ACL/contract hunks (not just signatures)"
+
+What we emit per chunk:
+  - List of changed file paths (canonical)
+  - Renamed files (old → new) for cross-directory rename detection
+  - Summary line-count per file
+  - Extracted function/class/def signatures from hunk text (best-effort)
+
+Recall wiring is deferred to Slice 3.
+"""
+from __future__ import annotations
+
+import re
+import sys as _sys
+from dataclasses import dataclass, field
+from pathlib import Path as _Path
+
+# Allow both package-style and direct-script imports
+_sys.path.insert(0, str(_Path(__file__).parent))
+from chunker import Chunk, DiffFile  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FileDigest:
+    """Compact representation of one file's contribution to a chunk."""
+
+    path: str
+    old_path: str | None    # populated on renames; None otherwise
+    lines: int              # diff line count
+    signatures: list[str]   # function/class/method names visible in the diff
+
+
+@dataclass
+class BoundaryDigest:
+    """Digest emitted for one Chunk, consumed by agents reviewing other chunks."""
+
+    chunk_index: int
+    files: list[FileDigest] = field(default_factory=list)
+
+    @property
+    def total_lines(self) -> int:
+        return sum(f.lines for f in self.files)
+
+    @property
+    def paths(self) -> list[str]:
+        return [f.path for f in self.files]
+
+    @property
+    def renames(self) -> list[tuple[str, str]]:
+        """Return list of (old_path, new_path) pairs for renamed files."""
+        return [
+            (f.old_path, f.path)
+            for f in self.files
+            if f.old_path is not None
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Signature extraction (best-effort, stdlib only)
+# ---------------------------------------------------------------------------
+
+# Match Python/TS/JS function and class definitions in diff context/added lines.
+# We intentionally ignore removed lines (prefix '-') — they represent what changed away.
+_SIG_PATTERNS = [
+    # Python: def foo(...) / async def foo(...) / class Foo(...):
+    re.compile(r'^[+ ][ \t]*(?:async\s+)?def\s+([A-Za-z_][A-Za-z0-9_]*)'),
+    re.compile(r'^[+ ][ \t]*class\s+([A-Za-z_][A-Za-z0-9_]*)'),
+    # TypeScript/JavaScript: function foo / export function foo / const foo = (
+    re.compile(r'^[+ ][ \t]*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][A-Za-z0-9_$]*)'),
+    re.compile(r'^[+ ][ \t]*(?:export\s+)?const\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:async\s*)?\('),
+    # Arrow: export const foo = async (...) =>
+    re.compile(r'^[+ ][ \t]*(?:export\s+)?(?:default\s+)?(?:async\s+)?([A-Za-z_$][A-Za-z0-9_$]*)\s*(?:=\s*)?(?:async\s*)?\(.*\)\s*(?::\s*\S+\s*)?=>'),
+]
+
+# Dunder/private names to skip from signatures (not useful for cross-chunk analysis)
+_SKIP_NAMES = frozenset({
+    '__init__', '__repr__', '__str__', '__eq__', '__hash__',
+    '__lt__', '__le__', '__gt__', '__ge__', '__ne__',
+})
+
+
+def _extract_signatures(hunk_text: str) -> list[str]:
+    """Return deduplicated function/class names visible in hunk_text.
+
+    Only scans added/context lines (prefix '+' or ' '). Removed lines are
+    excluded — they represent the before state, not what the agent is reviewing.
+    """
+    seen: dict[str, None] = {}  # ordered set via dict keys
+    for line in hunk_text.splitlines():
+        for pat in _SIG_PATTERNS:
+            m = pat.match(line)
+            if m:
+                name = m.group(1)
+                if name not in _SKIP_NAMES and not name.startswith('__'):
+                    seen[name] = None
+                break
+    return list(seen.keys())
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def emit_digest(chunk: Chunk, chunk_index: int) -> BoundaryDigest:
+    """Produce a BoundaryDigest for a single Chunk.
+
+    Args:
+        chunk:       The Chunk to summarise.
+        chunk_index: Zero-based index of this chunk in the full chunk list.
+
+    Returns:
+        BoundaryDigest with per-file summaries and extracted signatures.
+    """
+    file_digests: list[FileDigest] = []
+    for diff_file in chunk.files:
+        sigs = _extract_signatures(diff_file.hunk_text)
+        file_digests.append(FileDigest(
+            path=diff_file.path,
+            old_path=diff_file.old_path,
+            lines=diff_file.lines,
+            signatures=sigs,
+        ))
+    return BoundaryDigest(chunk_index=chunk_index, files=file_digests)
+
+
+def emit_all_digests(chunks: list[Chunk]) -> list[BoundaryDigest]:
+    """Emit a BoundaryDigest for every chunk in the list.
+
+    Returns an empty list if chunks is empty.
+    """
+    return [emit_digest(c, i) for i, c in enumerate(chunks)]
+
+
+def format_digest_for_agent(digest: BoundaryDigest) -> str:
+    """Render a BoundaryDigest as human-readable Markdown for agent prompts.
+
+    Agents reviewing *other* chunks receive this text so they can flag
+    cross-chunk concerns (e.g. parallel-path-drift) without reading the
+    full diff of that chunk.
+    """
+    lines: list[str] = [
+        f'## Boundary digest — chunk {digest.chunk_index}',
+        f'Total diff lines: {digest.total_lines}',
+        '',
+    ]
+
+    if digest.renames:
+        lines.append('### Renames')
+        for old, new in digest.renames:
+            lines.append(f'  {old} → {new}')
+        lines.append('')
+
+    lines.append('### Files')
+    for fd in digest.files:
+        sig_str = ', '.join(fd.signatures) if fd.signatures else '—'
+        lines.append(f'  {fd.path}  ({fd.lines} lines)  sigs: {sig_str}')
+
+    return '\n'.join(lines)

--- a/plugins/dev-core/skills/code-review/digest.py
+++ b/plugins/dev-core/skills/code-review/digest.py
@@ -19,13 +19,18 @@ Recall wiring is deferred to Slice 3.
 from __future__ import annotations
 
 import re
-import sys as _sys
 from dataclasses import dataclass, field
-from pathlib import Path as _Path
 
-# Allow both package-style and direct-script imports
-_sys.path.insert(0, str(_Path(__file__).parent))
-from chunker import Chunk, DiffFile  # noqa: E402
+try:
+    from .chunker import Chunk, DiffFile
+except ImportError:
+    from chunker import Chunk, DiffFile  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Format versioning
+# ---------------------------------------------------------------------------
+
+FORMAT_VERSION = '1'
 
 
 # ---------------------------------------------------------------------------
@@ -68,6 +73,20 @@ class BoundaryDigest:
 
 
 # ---------------------------------------------------------------------------
+# Path sanitization (render-stage concern)
+# ---------------------------------------------------------------------------
+
+def _sanitize_path(path: str) -> str:
+    """Escape control characters that could break prompt delimiters.
+
+    Replaces literal newlines/carriage-returns with visible placeholders so
+    that untrusted file paths from a diff cannot escape ``---SPEC---`` or
+    similar section boundaries in the agent prompt.
+    """
+    return path.replace('\n', '<LF>').replace('\r', '<CR>')
+
+
+# ---------------------------------------------------------------------------
 # Signature extraction (best-effort, stdlib only)
 # ---------------------------------------------------------------------------
 
@@ -80,22 +99,21 @@ _SIG_PATTERNS = [
     # TypeScript/JavaScript: function foo / export function foo / const foo = (
     re.compile(r'^[+ ][ \t]*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][A-Za-z0-9_$]*)'),
     re.compile(r'^[+ ][ \t]*(?:export\s+)?const\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:async\s*)?\('),
-    # Arrow: export const foo = async (...) =>
-    re.compile(r'^[+ ][ \t]*(?:export\s+)?(?:default\s+)?(?:async\s+)?([A-Za-z_$][A-Za-z0-9_$]*)\s*(?:=\s*)?(?:async\s*)?\(.*\)\s*(?::\s*\S+\s*)?=>'),
+    # Arrow with const anchor: export const foo = async (...) => / export default const foo = ...
+    re.compile(r'^[+ ][ \t]*(?:export\s+)?(?:default\s+)?(?:async\s+)?const\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:async\s*)?\(.*\)\s*(?::\s*\S+\s*)?=>'),
 ]
-
-# Dunder/private names to skip from signatures (not useful for cross-chunk analysis)
-_SKIP_NAMES = frozenset({
-    '__init__', '__repr__', '__str__', '__eq__', '__hash__',
-    '__lt__', '__le__', '__gt__', '__ge__', '__ne__',
-})
-
 
 def _extract_signatures(hunk_text: str) -> list[str]:
     """Return deduplicated function/class names visible in hunk_text.
 
     Only scans added/context lines (prefix '+' or ' '). Removed lines are
     excluded — they represent the before state, not what the agent is reviewing.
+
+    Dunder names (starting with '__') are skipped — not useful for cross-chunk
+    analysis. Single-underscore privates are intentionally INCLUDED in signatures.
+
+    TODO(Slice3): extract call-edge patterns per §5 F2 (call-graph edges to
+    named entry points + modified ACL/contract hunks).
     """
     seen: dict[str, None] = {}  # ordered set via dict keys
     for line in hunk_text.splitlines():
@@ -103,7 +121,7 @@ def _extract_signatures(hunk_text: str) -> list[str]:
             m = pat.match(line)
             if m:
                 name = m.group(1)
-                if name not in _SKIP_NAMES and not name.startswith('__'):
+                if not name.startswith('__'):
                     seen[name] = None
                 break
     return list(seen.keys())
@@ -126,9 +144,12 @@ def emit_digest(chunk: Chunk, chunk_index: int) -> BoundaryDigest:
     file_digests: list[FileDigest] = []
     for diff_file in chunk.files:
         sigs = _extract_signatures(diff_file.hunk_text)
+        # Sanitize paths at construction time (render-stage boundary).
+        # Newlines in file paths (untrusted diff data) could escape prompt
+        # section delimiters (e.g. ---SPEC---) in format_digest_for_agent.
         file_digests.append(FileDigest(
-            path=diff_file.path,
-            old_path=diff_file.old_path,
+            path=_sanitize_path(diff_file.path),
+            old_path=_sanitize_path(diff_file.old_path) if diff_file.old_path is not None else None,
             lines=diff_file.lines,
             signatures=sigs,
         ))
@@ -151,7 +172,7 @@ def format_digest_for_agent(digest: BoundaryDigest) -> str:
     full diff of that chunk.
     """
     lines: list[str] = [
-        f'## Boundary digest — chunk {digest.chunk_index}',
+        f'## Boundary digest v{FORMAT_VERSION} — chunk {digest.chunk_index}',
         f'Total diff lines: {digest.total_lines}',
         '',
     ]

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -82,8 +82,10 @@ class TestTopDir:
     def test_root_level(self):
         assert _top_dir('README.md') == '.'
 
-    def test_two_levels(self):
-        assert _top_dir('plugins/code-review.py') == 'plugins'
+    def test_depth_two(self):
+        """depth=2 splits packages/auth/... from packages/billing/..."""
+        assert _top_dir('packages/auth/service.py', depth=2) == 'packages/auth'
+        assert _top_dir('packages/billing/invoice.py', depth=2) == 'packages/billing'
 
 
 # ---------------------------------------------------------------------------
@@ -165,15 +167,21 @@ class TestBalancedSplit:
             assert c.total_lines <= budget
 
     def test_large_directory_splits_into_multiple_chunks(self):
-        """When a single directory exceeds budget, it splits into sub-chunks."""
+        """When a single directory exceeds budget, it splits into sub-chunks.
+
+        10 files × 100 LOC, budget=350 → greedy first-fit:
+          chunk 0: files 0,1,2 = 300 LOC (adding file3 would be 400 > 350)
+          chunk 1: files 3,4,5 = 300 LOC
+          chunk 2: files 6,7,8 = 300 LOC
+          chunk 3: file9      = 100 LOC
+        → 4 chunks.
+        """
         files = [make_file(f'src/file{i}.py', lines=100) for i in range(10)]
-        budget = 350  # fits 3 files per chunk
+        budget = 350  # fits 3 files per chunk (3×100=300 ≤ 350; 4×100=400 > 350)
         result = chunk(files, budget=budget)
-        assert len(result) > 1
+        assert len(result) == 4
         for c in result:
-            # Each chunk must be within budget (unless it's a single oversized file)
-            if len(c.files) > 1:
-                assert c.total_lines <= budget
+            assert c.total_lines <= budget
 
     def test_all_files_fit_in_one_budget(self):
         files = [
@@ -236,7 +244,7 @@ class TestCrossDirectoryRename:
         budget = 1000
         result = chunk(files, budget=budget)
         # 'new/' files → one chunk; 'unrelated/' → another
-        new_chunks = [c for c in result if any('new/' in p for p in c.paths)]
+        new_chunks = [c for c in result if all(p.startswith('new/') for p in c.paths)]
         assert len(new_chunks) == 1
         assert set(new_chunks[0].paths) == {'new/foo.py', 'new/bar.py'}
 
@@ -280,7 +288,9 @@ class TestParseDiff:
         assert len(files) == 1
         assert files[0].path == 'src/app.py'
         assert files[0].old_path is None
-        assert files[0].lines == 3  # @@ header + 2 content lines
+        assert files[0].lines == 2  # 2 content lines; @@ separator excluded from LOC
+        # hunk_text still preserves the @@ line for context
+        assert '@@' in files[0].hunk_text
 
     def test_deletion(self):
         raw = (
@@ -308,6 +318,77 @@ class TestParseDiff:
         assert len(files) == 2
         assert [f.path for f in files] == ['a.py', 'b.py']
 
+    def test_empty_group(self):
+        """Empty diff string → empty list (not an error)."""
+        assert parse_diff('') == []
+
+    def test_path_with_b_in_name(self):
+        """Non-greedy first group correctly splits when a-path is shorter than b-path."""
+        # When a_path and b_path are different, non-greedy correctly takes the
+        # shortest prefix before ' b/' as a_path.
+        raw = 'diff --git a/src/foo.py b/lib/foo.py\n'
+        files = parse_diff(raw)
+        assert len(files) == 1
+        assert files[0].path == 'lib/foo.py'
+
+    def test_deletion_exercises_dev_null_guard(self):
+        """b_path == '/dev/null' → canonical path is a_path (pure deletion guard)."""
+        raw = (
+            'diff --git a/gone.py b/gone.py\n'
+            'deleted file mode 100644\n'
+            '--- a/gone.py\n'
+            '+++ b/gone.py\n'
+            '@@ -1 +0,0 @@\n'
+            '-deleted\n'
+        )
+        # Standard deletion via /dev/null in b-side:
+        raw_null = (
+            'diff --git a/gone.py b//dev/null\n'
+            'deleted file mode 100644\n'
+            '--- a/gone.py\n'
+            '+++ /dev/null\n'
+            '@@ -1 +0,0 @@\n'
+            '-deleted\n'
+        )
+        files = parse_diff(raw_null)
+        assert len(files) == 1
+        assert files[0].path == 'gone.py'
+
+    def test_loc_excludes_hunk_headers(self):
+        """@@ separator lines must not be counted in LOC but must be in hunk_text."""
+        raw = (
+            'diff --git a/x.py b/x.py\n'
+            '@@ -1,2 +1,3 @@\n'
+            ' line1\n'
+            '+line2\n'
+        )
+        files = parse_diff(raw)
+        assert files[0].lines == 2  # only content lines
+        assert '@@ -1,2 +1,3 @@' in files[0].hunk_text
+
+
+# ---------------------------------------------------------------------------
+# Chunk validation (moved from TestParseDiff — misclassification fix F4)
+# ---------------------------------------------------------------------------
+
+class TestChunkValidation:
     def test_invalid_budget_raises(self):
         with pytest.raises(ValueError, match='budget'):
             chunk([make_file('a.py')], budget=0)
+
+
+# ---------------------------------------------------------------------------
+# Chunk ordering stability
+# ---------------------------------------------------------------------------
+
+class TestChunkOrdering:
+    def test_insertion_order_preserved(self):
+        """chunk() must preserve insertion order of files within a directory."""
+        files = [
+            make_file('zebra/a.py', lines=10),
+            make_file('alpha/b.py', lines=10),
+        ]
+        result = chunk(files, budget=1000)
+        # Two separate directories → two chunks; zebra comes first (insertion order)
+        assert result[0].paths == ['zebra/a.py']
+        assert result[1].paths == ['alpha/b.py']

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,313 @@
+"""Tests for plugins/dev-core/skills/code-review/chunker.py.
+
+Acceptance criteria (§ Slice 2):
+  1. Empty diff → empty chunk list
+  2. Single oversized file → one chunk (can't split further)
+  3. Balanced split → multiple chunks each within budget
+  4. Cross-directory rename → rename metadata preserved; file lands in new-path directory
+
+Budget is computed dynamically: compute_budget(ctx_window) = int(ctx_window * 0.4)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the code-review skill directory importable without installing a package
+_SKILL_DIR = Path(__file__).resolve().parents[1] / 'plugins' / 'dev-core' / 'skills' / 'code-review'
+sys.path.insert(0, str(_SKILL_DIR))
+
+from chunker import (  # noqa: E402
+    DiffFile,
+    Chunk,
+    compute_budget,
+    chunk,
+    parse_diff,
+    _top_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_file(path: str, lines: int = 10, old_path: str | None = None) -> DiffFile:
+    return DiffFile(path=path, old_path=old_path, lines=lines, hunk_text='')
+
+
+# ---------------------------------------------------------------------------
+# compute_budget
+# ---------------------------------------------------------------------------
+
+class TestComputeBudget:
+    def test_forty_percent(self):
+        assert compute_budget(100_000) == 40_000
+
+    def test_custom_fraction(self):
+        assert compute_budget(200_000, fraction=0.2) == 40_000
+
+    def test_small_window(self):
+        assert compute_budget(10) == 4
+
+    def test_invalid_zero(self):
+        with pytest.raises(ValueError, match='context_window_tokens'):
+            compute_budget(0)
+
+    def test_invalid_negative(self):
+        with pytest.raises(ValueError, match='context_window_tokens'):
+            compute_budget(-1)
+
+    def test_fraction_out_of_range(self):
+        with pytest.raises(ValueError, match='fraction'):
+            compute_budget(100_000, fraction=0.0)
+
+    def test_fraction_above_one(self):
+        with pytest.raises(ValueError, match='fraction'):
+            compute_budget(100_000, fraction=1.1)
+
+    def test_fraction_exactly_one(self):
+        assert compute_budget(100_000, fraction=1.0) == 100_000
+
+
+# ---------------------------------------------------------------------------
+# _top_dir helper
+# ---------------------------------------------------------------------------
+
+class TestTopDir:
+    def test_nested(self):
+        assert _top_dir('src/lyra/core/foo.py') == 'src'
+
+    def test_root_level(self):
+        assert _top_dir('README.md') == '.'
+
+    def test_two_levels(self):
+        assert _top_dir('plugins/code-review.py') == 'plugins'
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 1: Empty diff → empty list
+# ---------------------------------------------------------------------------
+
+class TestEmptyDiff:
+    def test_empty_files_list(self):
+        result = chunk([], budget=1000)
+        assert result == []
+
+    def test_empty_diff_string(self):
+        files = parse_diff('')
+        assert files == []
+        result = chunk(files, budget=1000)
+        assert result == []
+
+    def test_whitespace_only_diff(self):
+        files = parse_diff('   \n\n  ')
+        assert files == []
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: Single oversized file → one chunk
+# ---------------------------------------------------------------------------
+
+class TestOversizedFile:
+    def test_single_file_exceeds_budget(self):
+        """A file larger than the budget must still be returned in its own chunk."""
+        files = [make_file('src/big.py', lines=5000)]
+        budget = compute_budget(10_000)  # 4000 lines
+        result = chunk(files, budget=budget)
+        assert len(result) == 1
+        assert result[0].paths == ['src/big.py']
+        assert result[0].total_lines == 5000
+
+    def test_oversized_file_among_normal_files(self):
+        """Oversized file splits off; normal files may form their own chunk."""
+        files = [
+            make_file('src/big.py', lines=5000),
+            make_file('src/small.py', lines=100),
+        ]
+        budget = compute_budget(10_000)  # 4000 lines
+        result = chunk(files, budget=budget)
+        # big.py must be alone
+        oversized = [c for c in result if 'src/big.py' in c.paths]
+        assert len(oversized) == 1
+        assert oversized[0].paths == ['src/big.py']
+
+    def test_multiple_oversized_files_each_gets_own_chunk(self):
+        files = [
+            make_file('src/a.py', lines=5000),
+            make_file('src/b.py', lines=6000),
+        ]
+        budget = 4000
+        result = chunk(files, budget=budget)
+        assert len(result) == 2
+        assert {r.paths[0] for r in result} == {'src/a.py', 'src/b.py'}
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 3: Balanced split → chunks within budget
+# ---------------------------------------------------------------------------
+
+class TestBalancedSplit:
+    def test_two_directories_one_chunk_each(self):
+        """Files in different directories → separate chunks, each within budget."""
+        files = [
+            make_file('frontend/App.tsx', lines=50),
+            make_file('frontend/index.tsx', lines=30),
+            make_file('backend/api.py', lines=40),
+            make_file('backend/models.py', lines=60),
+        ]
+        budget = compute_budget(1_000)  # 400 lines — each dir fits
+        result = chunk(files, budget=budget)
+        # Should be 2 chunks: one per directory
+        assert len(result) == 2
+        for c in result:
+            assert c.total_lines <= budget
+
+    def test_large_directory_splits_into_multiple_chunks(self):
+        """When a single directory exceeds budget, it splits into sub-chunks."""
+        files = [make_file(f'src/file{i}.py', lines=100) for i in range(10)]
+        budget = 350  # fits 3 files per chunk
+        result = chunk(files, budget=budget)
+        assert len(result) > 1
+        for c in result:
+            # Each chunk must be within budget (unless it's a single oversized file)
+            if len(c.files) > 1:
+                assert c.total_lines <= budget
+
+    def test_all_files_fit_in_one_budget(self):
+        files = [
+            make_file('src/a.py', lines=10),
+            make_file('src/b.py', lines=20),
+        ]
+        budget = 1000
+        result = chunk(files, budget=budget)
+        assert len(result) == 1
+        assert result[0].total_lines == 30
+
+    def test_root_level_files_grouped(self):
+        """Root-level files (no directory) all go under '.' → one chunk."""
+        files = [
+            make_file('setup.py', lines=5),
+            make_file('pyproject.toml', lines=10),
+            make_file('README.md', lines=20),
+        ]
+        budget = 1000
+        result = chunk(files, budget=budget)
+        assert len(result) == 1
+        assert result[0].total_lines == 35
+
+    def test_budget_exactly_met(self):
+        """Files whose combined LOC equals budget exactly → single chunk."""
+        files = [make_file('src/a.py', lines=200), make_file('src/b.py', lines=200)]
+        budget = 400
+        result = chunk(files, budget=budget)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 4: Cross-directory rename
+# ---------------------------------------------------------------------------
+
+class TestCrossDirectoryRename:
+    def test_rename_preserved_in_diff_file(self):
+        raw = (
+            'diff --git a/old/path/foo.py b/new/path/foo.py\n'
+            'rename from old/path/foo.py\n'
+            'rename to new/path/foo.py\n'
+            '@@ -1,3 +1,3 @@\n'
+            ' line1\n'
+            '-old line\n'
+            '+new line\n'
+        )
+        files = parse_diff(raw)
+        assert len(files) == 1
+        f = files[0]
+        assert f.path == 'new/path/foo.py'
+        assert f.old_path == 'old/path/foo.py'
+
+    def test_renamed_file_lands_in_new_directory_chunk(self):
+        """After rename, file groups by its new (destination) directory."""
+        files = [
+            DiffFile(path='new/foo.py', old_path='old/foo.py', lines=20, hunk_text=''),
+            DiffFile(path='new/bar.py', old_path=None, lines=15, hunk_text=''),
+            DiffFile(path='unrelated/baz.py', old_path=None, lines=10, hunk_text=''),
+        ]
+        budget = 1000
+        result = chunk(files, budget=budget)
+        # 'new/' files → one chunk; 'unrelated/' → another
+        new_chunks = [c for c in result if any('new/' in p for p in c.paths)]
+        assert len(new_chunks) == 1
+        assert set(new_chunks[0].paths) == {'new/foo.py', 'new/bar.py'}
+
+    def test_cross_directory_rename_two_separate_dirs(self):
+        """Rename from src/ to lib/ — the file goes into lib/ chunk."""
+        files = [
+            DiffFile(path='lib/utils.py', old_path='src/utils.py', lines=30, hunk_text=''),
+            DiffFile(path='lib/helpers.py', old_path=None, lines=10, hunk_text=''),
+        ]
+        budget = 1000
+        result = chunk(files, budget=budget)
+        assert len(result) == 1
+        assert 'lib/utils.py' in result[0].paths
+
+    def test_old_path_not_used_for_grouping(self):
+        """Only the canonical (new) path determines the directory bucket."""
+        files = [
+            DiffFile(path='newdir/module.py', old_path='olddir/module.py', lines=5, hunk_text=''),
+        ]
+        budget = 1000
+        result = chunk(files, budget=budget)
+        assert result[0].paths == ['newdir/module.py']
+
+
+# ---------------------------------------------------------------------------
+# parse_diff — additional coverage
+# ---------------------------------------------------------------------------
+
+class TestParseDiff:
+    def test_simple_modification(self):
+        raw = (
+            'diff --git a/src/app.py b/src/app.py\n'
+            'index abc..def 100644\n'
+            '--- a/src/app.py\n'
+            '+++ b/src/app.py\n'
+            '@@ -1,2 +1,3 @@\n'
+            ' existing\n'
+            '+added\n'
+        )
+        files = parse_diff(raw)
+        assert len(files) == 1
+        assert files[0].path == 'src/app.py'
+        assert files[0].old_path is None
+        assert files[0].lines == 3  # @@ header + 2 content lines
+
+    def test_deletion(self):
+        raw = (
+            'diff --git a/old.py b/old.py\n'
+            'deleted file mode 100644\n'
+            '--- a/old.py\n'
+            '+++ /dev/null\n'
+            '@@ -1 +0,0 @@\n'
+            '-gone\n'
+        )
+        files = parse_diff(raw)
+        assert len(files) == 1
+        assert files[0].path == 'old.py'
+
+    def test_multiple_files(self):
+        raw = (
+            'diff --git a/a.py b/a.py\n'
+            '@@ -1 +1 @@\n'
+            ' x\n'
+            'diff --git a/b.py b/b.py\n'
+            '@@ -1 +1 @@\n'
+            ' y\n'
+        )
+        files = parse_diff(raw)
+        assert len(files) == 2
+        assert [f.path for f in files] == ['a.py', 'b.py']
+
+    def test_invalid_budget_raises(self):
+        with pytest.raises(ValueError, match='budget'):
+            chunk([make_file('a.py')], budget=0)

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -13,6 +13,7 @@ from chunker import Chunk, DiffFile  # noqa: E402
 from digest import (  # noqa: E402
     BoundaryDigest,
     FileDigest,
+    FORMAT_VERSION,
     emit_digest,
     emit_all_digests,
     format_digest_for_agent,
@@ -68,10 +69,18 @@ class TestExtractSignatures:
         sigs = _extract_signatures(hunk)
         assert 'handleRequest' in sigs
 
-    def test_typescript_const_arrow(self):
+    def test_typescript_const_function(self):
+        # const pattern: const processData = async (input) => {
         hunk = '+const processData = async (input) => {\n'
         sigs = _extract_signatures(hunk)
         assert 'processData' in sigs
+
+    def test_typescript_bare_arrow_no_const(self):
+        # Bare arrow without const keyword should NOT match the const-anchored pattern
+        hunk = '+ processData = (x) => {\n'
+        sigs = _extract_signatures(hunk)
+        # No const anchor → should not be captured by any signature pattern
+        assert 'processData' not in sigs
 
     def test_dunder_names_skipped(self):
         hunk = '+def __init__(self):\n+def __repr__(self):\n'
@@ -181,6 +190,13 @@ class TestFormatDigestForAgent:
         rendered = format_digest_for_agent(digest)
         assert 'chunk 2' in rendered
 
+    def test_format_version_in_header(self):
+        """Rendered output must embed FORMAT_VERSION (Architect F5)."""
+        digest = emit_digest(make_chunk(make_diff_file('a.py')), chunk_index=0)
+        rendered = format_digest_for_agent(digest)
+        assert f'v{FORMAT_VERSION}' in rendered
+        assert 'v1' in rendered
+
     def test_contains_file_path(self):
         digest = emit_digest(make_chunk(make_diff_file('src/main.py', lines=42)), 0)
         rendered = format_digest_for_agent(digest)
@@ -205,3 +221,43 @@ class TestFormatDigestForAgent:
         digest = emit_digest(make_chunk(f), 0)
         rendered = format_digest_for_agent(digest)
         assert 'compute' in rendered
+
+
+# ---------------------------------------------------------------------------
+# Path sanitization (B1 — prompt-injection-via-path)
+# ---------------------------------------------------------------------------
+
+class TestPathSanitization:
+    def test_newline_in_path_is_escaped(self):
+        """File path with \\n must render as <LF>, not a real newline (B1)."""
+        f = make_diff_file('src/foo\nbar.py', lines=10)
+        digest = emit_digest(make_chunk(f), chunk_index=0)
+        # The stored path must have the escape applied
+        assert digest.files[0].path == 'src/foo<LF>bar.py'
+
+    def test_carriage_return_in_path_is_escaped(self):
+        f = make_diff_file('src/foo\rbar.py', lines=5)
+        digest = emit_digest(make_chunk(f), chunk_index=0)
+        assert digest.files[0].path == 'src/foo<CR>bar.py'
+
+    def test_newline_in_path_renders_without_actual_newline(self):
+        """Rendered output must contain <LF> placeholder, no actual newline mid-path."""
+        f = make_diff_file('evil\npath.py', lines=3)
+        digest = emit_digest(make_chunk(f), chunk_index=0)
+        rendered = format_digest_for_agent(digest)
+        assert '<LF>' in rendered
+        # No raw newline in the file-path segment of the rendered line
+        lines = rendered.splitlines()
+        assert any('<LF>' in line for line in lines)
+
+    def test_old_path_sanitized_on_rename(self):
+        """old_path must also be sanitized at construction time."""
+        f = make_diff_file('new/foo.py', old_path='old/\nfoo.py')
+        digest = emit_digest(make_chunk(f), chunk_index=0)
+        assert digest.files[0].old_path == 'old/<LF>foo.py'
+
+    def test_clean_path_unchanged(self):
+        """Normal paths must pass through without modification."""
+        f = make_diff_file('src/normal/path.py', lines=20)
+        digest = emit_digest(make_chunk(f), chunk_index=0)
+        assert digest.files[0].path == 'src/normal/path.py'

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1,0 +1,207 @@
+"""Tests for plugins/dev-core/skills/code-review/digest.py."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SKILL_DIR = Path(__file__).resolve().parents[1] / 'plugins' / 'dev-core' / 'skills' / 'code-review'
+sys.path.insert(0, str(_SKILL_DIR))
+
+from chunker import Chunk, DiffFile  # noqa: E402
+from digest import (  # noqa: E402
+    BoundaryDigest,
+    FileDigest,
+    emit_digest,
+    emit_all_digests,
+    format_digest_for_agent,
+    _extract_signatures,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_diff_file(path: str, lines: int = 10, hunk_text: str = '', old_path: str | None = None) -> DiffFile:
+    return DiffFile(path=path, old_path=old_path, lines=lines, hunk_text=hunk_text)
+
+
+def make_chunk(*files: DiffFile) -> Chunk:
+    return Chunk(files=list(files))
+
+
+# ---------------------------------------------------------------------------
+# _extract_signatures
+# ---------------------------------------------------------------------------
+
+class TestExtractSignatures:
+    def test_python_def(self):
+        hunk = '+def my_function(x, y):\n+    return x + y\n'
+        sigs = _extract_signatures(hunk)
+        assert 'my_function' in sigs
+
+    def test_python_async_def(self):
+        hunk = '+async def fetch_data(url):\n+    pass\n'
+        sigs = _extract_signatures(hunk)
+        assert 'fetch_data' in sigs
+
+    def test_python_class(self):
+        hunk = '+class MyService:\n+    pass\n'
+        sigs = _extract_signatures(hunk)
+        assert 'MyService' in sigs
+
+    def test_context_line_included(self):
+        # Context lines (no prefix or ' ' prefix) also captured
+        hunk = ' def unchanged_func():\n'
+        sigs = _extract_signatures(hunk)
+        assert 'unchanged_func' in sigs
+
+    def test_removed_line_excluded(self):
+        hunk = '-def old_function():\n'
+        sigs = _extract_signatures(hunk)
+        assert 'old_function' not in sigs
+
+    def test_typescript_function(self):
+        hunk = '+export function handleRequest(req, res) {\n'
+        sigs = _extract_signatures(hunk)
+        assert 'handleRequest' in sigs
+
+    def test_typescript_const_arrow(self):
+        hunk = '+const processData = async (input) => {\n'
+        sigs = _extract_signatures(hunk)
+        assert 'processData' in sigs
+
+    def test_dunder_names_skipped(self):
+        hunk = '+def __init__(self):\n+def __repr__(self):\n'
+        sigs = _extract_signatures(hunk)
+        assert '__init__' not in sigs
+        assert '__repr__' not in sigs
+
+    def test_deduplication(self):
+        hunk = '+def foo():\n+def foo():\n'
+        sigs = _extract_signatures(hunk)
+        assert sigs.count('foo') == 1
+
+    def test_empty_hunk(self):
+        assert _extract_signatures('') == []
+
+
+# ---------------------------------------------------------------------------
+# emit_digest
+# ---------------------------------------------------------------------------
+
+class TestEmitDigest:
+    def test_basic_structure(self):
+        f = make_diff_file('src/app.py', lines=50)
+        c = make_chunk(f)
+        digest = emit_digest(c, chunk_index=0)
+        assert isinstance(digest, BoundaryDigest)
+        assert digest.chunk_index == 0
+        assert len(digest.files) == 1
+        assert digest.files[0].path == 'src/app.py'
+        assert digest.files[0].lines == 50
+
+    def test_total_lines(self):
+        c = make_chunk(
+            make_diff_file('a.py', lines=30),
+            make_diff_file('b.py', lines=20),
+        )
+        digest = emit_digest(c, chunk_index=1)
+        assert digest.total_lines == 50
+
+    def test_paths_property(self):
+        c = make_chunk(
+            make_diff_file('x.py'),
+            make_diff_file('y.py'),
+        )
+        digest = emit_digest(c, 0)
+        assert digest.paths == ['x.py', 'y.py']
+
+    def test_rename_detected(self):
+        f = make_diff_file('new/path/foo.py', old_path='old/path/foo.py')
+        c = make_chunk(f)
+        digest = emit_digest(c, 0)
+        assert digest.renames == [('old/path/foo.py', 'new/path/foo.py')]
+
+    def test_no_rename_is_empty(self):
+        f = make_diff_file('src/bar.py')
+        c = make_chunk(f)
+        digest = emit_digest(c, 0)
+        assert digest.renames == []
+
+    def test_signatures_extracted(self):
+        hunk = '+def my_handler(request):\n+    pass\n'
+        f = make_diff_file('src/handler.py', hunk_text=hunk)
+        c = make_chunk(f)
+        digest = emit_digest(c, 0)
+        assert 'my_handler' in digest.files[0].signatures
+
+    def test_chunk_index_set(self):
+        digest = emit_digest(make_chunk(make_diff_file('a.py')), chunk_index=3)
+        assert digest.chunk_index == 3
+
+    def test_empty_chunk(self):
+        digest = emit_digest(Chunk(files=[]), chunk_index=0)
+        assert digest.files == []
+        assert digest.total_lines == 0
+
+
+# ---------------------------------------------------------------------------
+# emit_all_digests
+# ---------------------------------------------------------------------------
+
+class TestEmitAllDigests:
+    def test_empty_input(self):
+        assert emit_all_digests([]) == []
+
+    def test_indices_are_sequential(self):
+        chunks = [
+            make_chunk(make_diff_file('a.py')),
+            make_chunk(make_diff_file('b.py')),
+            make_chunk(make_diff_file('c.py')),
+        ]
+        digests = emit_all_digests(chunks)
+        assert [d.chunk_index for d in digests] == [0, 1, 2]
+
+    def test_count_matches_chunks(self):
+        chunks = [make_chunk(make_diff_file(f'file{i}.py')) for i in range(5)]
+        digests = emit_all_digests(chunks)
+        assert len(digests) == 5
+
+
+# ---------------------------------------------------------------------------
+# format_digest_for_agent
+# ---------------------------------------------------------------------------
+
+class TestFormatDigestForAgent:
+    def test_contains_chunk_index(self):
+        digest = emit_digest(make_chunk(make_diff_file('a.py')), chunk_index=2)
+        rendered = format_digest_for_agent(digest)
+        assert 'chunk 2' in rendered
+
+    def test_contains_file_path(self):
+        digest = emit_digest(make_chunk(make_diff_file('src/main.py', lines=42)), 0)
+        rendered = format_digest_for_agent(digest)
+        assert 'src/main.py' in rendered
+        assert '42' in rendered
+
+    def test_contains_rename(self):
+        f = make_diff_file('lib/utils.py', old_path='src/utils.py')
+        digest = emit_digest(make_chunk(f), 0)
+        rendered = format_digest_for_agent(digest)
+        assert 'src/utils.py' in rendered
+        assert 'lib/utils.py' in rendered
+
+    def test_no_rename_section_when_empty(self):
+        digest = emit_digest(make_chunk(make_diff_file('a.py')), 0)
+        rendered = format_digest_for_agent(digest)
+        assert 'Renames' not in rendered
+
+    def test_signature_shown(self):
+        hunk = '+def compute(x):\n'
+        f = make_diff_file('calc.py', hunk_text=hunk)
+        digest = emit_digest(make_chunk(f), 0)
+        rendered = format_digest_for_agent(digest)
+        assert 'compute' in rendered


### PR DESCRIPTION
## Summary

- Adds `chunker.py`: directory-cohesion partitioner with LOC-bounded fallback. Budget = `0.4 × active_model_context_window` (dynamic, not hard-coded). Single oversized files get their own chunk; greedy bin-packing splits oversized directories.
- Adds `digest.py`: `BoundaryDigest` emitter — compact per-chunk summary (paths, renames, extracted signatures) formatted for direct inclusion in Lane-A agent prompts so agents can flag cross-chunk patterns without receiving full diffs.
- Edits Phase 3 of `code-review/SKILL.md`: single-chunk path is unchanged (backward compatible); multi-chunk path dispatches per-chunk Lane-A agents with chunk diff + boundary digests of other chunks.

Closes #142

## Test plan

- [x] `uv run --with pytest python3 -m pytest tests/test_chunker.py tests/test_digest.py -q` — 56 tests pass
- [x] Empty diff → empty chunk list (`TestEmptyDiff`)
- [x] Single oversized file → isolated chunk, no split (`TestOversizedFile`)
- [x] Balanced split → multiple chunks each within budget (`TestBalancedSplit`)
- [x] Cross-directory rename → file lands in new-path directory bucket, `old_path` preserved (`TestCrossDirectoryRename`)
- [x] Digest: renames surfaced, signatures extracted, formatted Markdown output
- [x] `bun run lint` — no issues (TS-only, no-op for Python)
- [x] `bun run typecheck` — clean
- [x] All pre-commit + pre-push lefthook hooks passed (501 TS tests, TruffleHog, typecheck, commitlint)

## Deferred (per issue scope)

- Recall wiring (cross-chunk class join + trigger) → Slice 3
- Lane B reduce path → Slice 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)