### PR TITLE
feat(cocoindex-code): mirror upstream ccc skill as Roxabi plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -117,6 +117,13 @@
       "source": "./plugins/gitnexus",
       "category": "development",
       "version": "0.1.0"
+    },
+    {
+      "name": "cocoindex-code",
+      "description": "AST-based semantic code search via the ccc CLI — mirrored from cocoindex-io/cocoindex-code under Apache-2.0. CLI-only, no MCP required.",
+      "source": "./plugins/cocoindex-code",
+      "category": "development",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/cocoindex-code/.claude-plugin/plugin.json
+++ b/plugins/cocoindex-code/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "cocoindex-code",
+  "version": "0.1.0",
+  "description": "AST-based semantic code search via the ccc CLI — mirrored from cocoindex-io/cocoindex-code under Apache-2.0.",
+  "author": {
+    "name": "Roxabi"
+  },
+  "homepage": "https://github.com/cocoindex-io/cocoindex-code",
+  "repository": "https://github.com/Roxabi/roxabi-plugins",
+  "license": "Apache-2.0",
+  "keywords": [
+    "semantic-search",
+    "code-search",
+    "ast",
+    "rag",
+    "indexing"
+  ]
+}

--- a/plugins/cocoindex-code/README.md
+++ b/plugins/cocoindex-code/README.md
@@ -1,0 +1,36 @@
+# cocoindex-code
+
+AST-based semantic code search via the [`ccc`](https://github.com/cocoindex-io/cocoindex-code) CLI, packaged as a Claude Code plugin.
+
+## What it does
+
+Wraps the upstream `ccc` CLI so coding agents can:
+
+- Run semantic search across the current codebase (`ccc search "user authentication"`).
+- Auto-init and auto-index on first use (no MCP, no daemon to wire up manually).
+- Refresh the index on demand (`ccc index`, `ccc search --refresh`).
+
+## Install
+
+```bash
+# 1. Install the CLI (one-time, global)
+pipx install 'cocoindex-code[full]'
+
+# 2. Install this plugin from the Roxabi marketplace
+/plugin marketplace add Roxabi/roxabi-plugins
+/plugin install cocoindex-code@roxabi-marketplace
+```
+
+The skill triggers automatically when the agent needs code search; you can also nudge it explicitly with `search the codebase X` or `/cocoindex-code:ccc`.
+
+## Why mirror upstream?
+
+Upstream ships its own [Claude Code marketplace](https://github.com/cocoindex-io/cocoindex-code) (PR pending). This mirror exists so Roxabi users get the skill from the standard `Roxabi/roxabi-plugins` marketplace they already trust, without adding a second marketplace source.
+
+When upstream merges its own marketplace manifest, you can switch to it directly with `/plugin marketplace add cocoindex-io/cocoindex-code`. Both flows install the same skill.
+
+## Attribution
+
+Skill content (`skills/ccc/SKILL.md`, `references/management.md`, `references/settings.md`) is mirrored verbatim from [`cocoindex-io/cocoindex-code`](https://github.com/cocoindex-io/cocoindex-code) under the **Apache License 2.0**. Copyright remains with the CocoIndex authors. See [LICENSE](https://github.com/cocoindex-io/cocoindex-code/blob/main/LICENSE) upstream.
+
+The `ccc` binary itself is **not** vendored — it is installed separately via `pipx`/`uv tool` and called from the skill.

--- a/plugins/cocoindex-code/skills/ccc/SKILL.md
+++ b/plugins/cocoindex-code/skills/ccc/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: ccc
+description: "This skill should be used when code search is needed (whether explicitly requested or as part of completing a task), when indexing the codebase after changes, or when the user asks about ccc, cocoindex-code, or the codebase index. Trigger phrases include 'search the codebase', 'find code related to', 'update the index', 'ccc', 'cocoindex-code'."
+---
+
+# ccc - Semantic Code Search & Indexing
+
+`ccc` is the CLI for CocoIndex Code, providing semantic search over the current codebase and index management.
+
+## Ownership
+
+The agent owns the `ccc` lifecycle for the current project — initialization, indexing, and searching. Do not ask the user to perform these steps; handle them automatically.
+
+- **Initialization**: If `ccc search` or `ccc index` fails with an initialization error (e.g., "Not in an initialized project directory"), run `ccc init` from the project root directory, then `ccc index` to build the index, then retry the original command.
+- **Index freshness**: Keep the index up to date by running `ccc index` (or `ccc search --refresh`) when the index may be stale — e.g., at the start of a session, or after making significant code changes (new files, refactors, renamed modules). There is no need to re-index between consecutive searches if no code was changed in between.
+- **Installation**: If `ccc` itself is not found (command not found), refer to [management.md](references/management.md) for installation instructions and inform the user.
+
+## Searching the Codebase
+
+To perform a semantic search:
+
+```bash
+ccc search <query terms>
+```
+
+The query should describe the concept, functionality, or behavior to find, not exact code syntax. For example:
+
+```bash
+ccc search database connection pooling
+ccc search user authentication flow
+ccc search error handling retry logic
+```
+
+### Filtering Results
+
+- **By language** (`--lang`, repeatable): restrict results to specific languages.
+
+  ```bash
+  ccc search --lang python --lang markdown database schema
+  ```
+
+- **By path** (`--path`): restrict results to a glob pattern relative to project root. If omitted, defaults to the current working directory (only results under that subdirectory are returned).
+
+  ```bash
+  ccc search --path 'src/api/*' request validation
+  ```
+
+### Pagination
+
+Results default to the first page. To retrieve additional results:
+
+```bash
+ccc search --offset 5 --limit 5 database schema
+```
+
+If all returned results look relevant, use `--offset` to fetch the next page — there are likely more useful matches beyond the first page.
+
+### Working with Search Results
+
+Search results include file paths and line ranges. To explore a result in more detail:
+
+- Use the editor's built-in file reading capabilities (e.g., the `Read` tool) to load the matched file and read lines around the returned range for full context.
+- When working in a terminal without a file-reading tool, use `sed -n '<start>,<end>p' <file>` to extract a specific line range.
+
+## Settings
+
+To view or edit embedding model configuration, include/exclude patterns, or language overrides, see [settings.md](references/settings.md).
+
+## Management & Troubleshooting
+
+For installation, initialization, daemon management, troubleshooting, and cleanup commands, see [management.md](references/management.md).

--- a/plugins/cocoindex-code/skills/ccc/references/management.md
+++ b/plugins/cocoindex-code/skills/ccc/references/management.md
@@ -1,0 +1,110 @@
+# ccc Management
+
+## Installation
+
+Install CocoIndex Code via pipx. Two install styles:
+
+```bash
+pipx install 'cocoindex-code[full]'      # batteries included (local embeddings via sentence-transformers)
+pipx install cocoindex-code              # slim (LiteLLM-only; requires a cloud embedding provider + API key)
+```
+
+The `[full]` extra pulls in `sentence-transformers` so the first-run default (local embeddings, no API key) works out of the box. The slim install is for environments where you don't want the torch/transformers deps and plan to use a LiteLLM-supported cloud provider instead.
+
+To upgrade to the latest version:
+
+```bash
+pipx upgrade cocoindex-code
+```
+
+After installation, the `ccc` command is available globally.
+
+## Project Initialization
+
+Run from the root directory of the project to index:
+
+```bash
+ccc init
+```
+
+**First run (global settings don't exist yet)** — `ccc init` prompts interactively for the embedding provider (sentence-transformers / litellm) and model, then runs a one-off test embed via the daemon to confirm the model works. Accept the defaults for the sentence-transformers path, or pick litellm and enter a model identifier.
+
+**Subsequent runs** (global settings already exist) — prompts are skipped; only project settings and `.gitignore` are set up.
+
+To skip the interactive prompts on the first run (e.g. in a script or container), pass `--litellm-model MODEL`:
+
+```bash
+ccc init --litellm-model openai/text-embedding-3-small
+```
+
+This is also the only way to pick a LiteLLM model when stdin isn't a TTY and you've done a slim install.
+
+`ccc init` creates:
+- `~/.cocoindex_code/global_settings.yml` (user-level, embedding config + env vars).
+- `.cocoindex_code/settings.yml` (project-level, include/exclude patterns).
+
+If `.git` exists in the directory, `.cocoindex_code/` is automatically added to `.gitignore`.
+
+Use `-f` to skip the confirmation prompt if `ccc init` detects a potential parent project root.
+
+After initialization, edit the settings files if needed (see [settings.md](settings.md) for format details), then run `ccc index` to build the initial index. If the model test printed `[FAIL]` during `init`, edit `global_settings.yml` (and optionally add API keys under the commented `envs:` block) and verify with `ccc doctor` before indexing.
+
+## Troubleshooting
+
+### Diagnostics
+
+Run `ccc doctor` to check system health end-to-end:
+
+```bash
+ccc doctor
+```
+
+This checks global settings, daemon status, embedding model (runs a test embedding), and — if run from within a project — file matching (walks files using the same logic as the indexer) and index status. Results stream incrementally. Always points to `daemon.log` at the end for further investigation.
+
+### Checking Project Status
+
+To view the current project's index status:
+
+```bash
+ccc status
+```
+
+This shows whether indexing is ongoing and index statistics.
+
+### Daemon Management
+
+The daemon starts automatically on first use. To check its status:
+
+```bash
+ccc daemon status
+```
+
+This shows whether the daemon is running, its version, uptime, and loaded projects.
+
+To restart the daemon (useful if it gets into a bad state):
+
+```bash
+ccc daemon restart
+```
+
+To stop the daemon:
+
+```bash
+ccc daemon stop
+```
+
+## Cleanup
+
+To reset a project's index (removes databases, keeps settings):
+
+```bash
+ccc reset
+```
+
+To fully remove all CocoIndex Code data for a project (including settings):
+
+```bash
+ccc reset --all
+```
+
+Both commands prompt for confirmation. Use `-f` to skip.

--- a/plugins/cocoindex-code/skills/ccc/references/settings.md
+++ b/plugins/cocoindex-code/skills/ccc/references/settings.md
@@ -1,0 +1,126 @@
+# ccc Settings
+
+Configuration lives in two YAML files, both created automatically by `ccc init`.
+
+## User-Level Settings (`~/.cocoindex_code/global_settings.yml`)
+
+Shared across all projects. Controls the embedding model and extra environment variables for the daemon.
+
+```yaml
+embedding:
+  provider: sentence-transformers   # or "litellm" (default when provider is omitted)
+  model: Snowflake/snowflake-arctic-embed-xs
+  device: mps                       # optional: cpu, cuda, mps (auto-detected if omitted)
+  min_interval_ms: 300              # optional: pace LiteLLM embedding requests to reduce 429s; defaults to 5 for LiteLLM
+
+envs:                               # extra environment variables for the daemon
+  OPENAI_API_KEY: your-key          # only needed if not already in the shell environment
+```
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| `embedding.provider` | `sentence-transformers` for local models, `litellm` (or omit) for cloud/remote models |
+| `embedding.model` | Model identifier — format depends on provider (see examples below) |
+| `embedding.device` | Optional. `cpu`, `cuda`, or `mps`. Auto-detected if omitted. Only relevant for `sentence-transformers`. |
+| `embedding.min_interval_ms` | Optional. Minimum delay between LiteLLM embedding requests in milliseconds. Defaults to `5` for LiteLLM and is ignored by `sentence-transformers`. Set explicitly to override the default. |
+| `envs` | Key-value map of environment variables injected into the daemon. Use for API keys not already in the shell environment. |
+
+### Embedding Model Examples
+
+**Local (sentence-transformers, no API key needed):**
+
+```yaml
+embedding:
+  provider: sentence-transformers
+  model: Snowflake/snowflake-arctic-embed-xs        # default, lightweight
+```
+
+```yaml
+embedding:
+  provider: sentence-transformers
+  model: nomic-ai/CodeRankEmbed                     # better code retrieval, needs GPU (~1 GB VRAM)
+```
+
+**Ollama (local):**
+
+```yaml
+embedding:
+  model: ollama/nomic-embed-text
+```
+
+**OpenAI:**
+
+```yaml
+embedding:
+  model: text-embedding-3-small
+  min_interval_ms: 300
+envs:
+  OPENAI_API_KEY: your-api-key
+```
+
+**Gemini:**
+
+```yaml
+embedding:
+  model: gemini/gemini-embedding-001
+envs:
+  GEMINI_API_KEY: your-api-key
+```
+
+**Voyage (code-optimized):**
+
+```yaml
+embedding:
+  model: voyage/voyage-code-3
+envs:
+  VOYAGE_API_KEY: your-api-key
+```
+
+For the full list of supported cloud providers and model identifiers, see [LiteLLM Embedding Models](https://docs.litellm.ai/docs/embedding/supported_embedding).
+
+### Important
+
+Switching embedding models changes vector dimensions — you must re-index after changing the model:
+
+```bash
+ccc reset && ccc index
+```
+
+## Project-Level Settings (`<project>/.cocoindex_code/settings.yml`)
+
+Per-project. Controls which files to index. Created by `ccc init` and automatically added to `.gitignore`.
+
+```yaml
+include_patterns:
+  - "**/*.py"
+  - "**/*.js"
+  - "**/*.ts"
+  # ... (sensible defaults for 28+ file types)
+
+exclude_patterns:
+  - "**/.*"              # hidden directories
+  - "**/__pycache__"
+  - "**/node_modules"
+  - "**/dist"
+  # ...
+
+language_overrides:
+  - ext: inc             # treat .inc files as PHP
+    lang: php
+```
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| `include_patterns` | Glob patterns for files to index. Defaults cover common languages (Python, JS/TS, Rust, Go, Java, C/C++, C#, SQL, Shell, Markdown, PHP, Lua, etc.). |
+| `exclude_patterns` | Glob patterns for files/directories to skip. Defaults exclude hidden dirs, `node_modules`, `dist`, `__pycache__`, `vendor`, etc. |
+| `language_overrides` | List of `{ext, lang}` pairs to override language detection for specific file extensions. |
+
+### Editing Tips
+
+- To index additional file types, append glob patterns to `include_patterns` (e.g. `"**/*.proto"`).
+- To exclude a directory, append to `exclude_patterns` (e.g. `"**/generated"`).
+- After editing, run `ccc index` to re-index with the new settings.


### PR DESCRIPTION
## Summary

- Mirrors the [`ccc` skill](https://github.com/cocoindex-io/cocoindex-code/tree/main/skills/ccc) from `cocoindex-io/cocoindex-code` into the Roxabi marketplace as a new `cocoindex-code` plugin.
- Skill content (SKILL.md + references/) is copied **verbatim** from upstream under Apache-2.0 — copyright retained, attribution in `plugins/cocoindex-code/README.md`.
- The `ccc` binary itself is **not** vendored — installed separately via `pipx install 'cocoindex-code[full]'` or `uv tool install cocoindex-code`.
- CLI-only path — no MCP server required.

## Why

Lets Roxabi users pull AST-based semantic code search from the marketplace they already trust, without adding a second source. Complements the existing `gitnexus` plugin (graph-based code intel) — `cocoindex-code` is the embedding-based counterpart.

## Companion PR upstream

A draft PR is open on the upstream repo to publish the same skill as a first-class Claude Code marketplace: [cocoindex-io/cocoindex-code#161](https://github.com/cocoindex-io/cocoindex-code/pull/161). When that lands, users can switch to `/plugin marketplace add cocoindex-io/cocoindex-code` directly — both flows install the same skill.

## What changed

| File | Change |
|---|---|
| `.claude-plugin/marketplace.json` | +7 lines — new entry for `cocoindex-code` after `gitnexus` |
| `plugins/cocoindex-code/.claude-plugin/plugin.json` | new — plugin manifest |
| `plugins/cocoindex-code/skills/ccc/SKILL.md` | new — verbatim from upstream |
| `plugins/cocoindex-code/skills/ccc/references/management.md` | new — verbatim from upstream |
| `plugins/cocoindex-code/skills/ccc/references/settings.md` | new — verbatim from upstream |
| `plugins/cocoindex-code/README.md` | new — Apache-2.0 attribution + install recipe |

## Test plan

- [ ] `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` — JSON valid (already verified locally)
- [ ] Install the upstream binary: `uv tool install cocoindex-code` (already verified locally — `ccc --help` shows full subcommand surface, no MCP launched)
- [ ] After merge: `/plugin marketplace update Roxabi/roxabi-plugins` then `/plugin install cocoindex-code@roxabi-marketplace`
- [ ] Trigger phrases work: "search the codebase X", "ccc", `/cocoindex-code:ccc`

## Notes

- License compliance: Apache-2.0 § 4 requires preserving copyright + attribution for derivative works. Done in `plugins/cocoindex-code/README.md`.
- No CLI / no daemon launched as part of this PR — install is opt-in by users running `pipx install` separately.