### PR TITLE
fix(checkup): complete removal of stack.yml gitignore audit rule

### DIFF
--- a/plugins/dev-core/skills/checkup/cookbooks/stack-checks.md
+++ b/plugins/dev-core/skills/checkup/cookbooks/stack-checks.md
@@ -42,7 +42,6 @@ Read `docs.path` from σ. ¬set → D⏭("docs.path not set"), skip doc checks.
 **Artifacts:** ∀ path ∈ `artifacts.*` → chk(∃, ✅, ⚠️ "dir not found: {path}").
 
 **Security:**
-- σ ∈ `.gitignore` → ✅ | ❌ "not in .gitignore".
 - δ ∈ `.gitignore` → ✅ | ❌ "not in .gitignore (contains project field IDs)".
 
 **Hooks formatter:** `build.formatter_fix_cmd` contains `biome` → confirm `hooks.json` PostToolUse runs `format.js` → ✅ | ⚠️ "formatter mismatch".

--- a/plugins/dev-core/skills/checkup/cookbooks/stack-checks.md
+++ b/plugins/dev-core/skills/checkup/cookbooks/stack-checks.md
@@ -41,9 +41,6 @@ Read `docs.path` from σ. ¬set → D⏭("docs.path not set"), skip doc checks.
 
 **Artifacts:** ∀ path ∈ `artifacts.*` → chk(∃, ✅, ⚠️ "dir not found: {path}").
 
-**Security:**
-- δ ∈ `.gitignore` → ✅ | ❌ "not in .gitignore (contains project field IDs)".
-
 **Hooks formatter:** `build.formatter_fix_cmd` contains `biome` → confirm `hooks.json` PostToolUse runs `format.js` → ✅ | ⚠️ "formatter mismatch".
 
 **Pre-commit hooks:**
@@ -125,7 +122,6 @@ Ask: **Fix all** | **Select** | **Skip**
 | `stack.yml.example missing` | `cp "${Φ}/stack.yml.example" .claude/stack.yml.example` |
 | `CLAUDE.md import missing` | Prepend `@.claude/stack.yml\n` to CLAUDE.md |
 | `Critical Rules missing/incomplete` | Run `bun $I_TS scaffold-rules`, then append/merge generated markdown into CLAUDE.md (same logic as `/init` Phase 2c) |
-| `dev-core.yml not in .gitignore` | ensureGitignore(`.claude/dev-core.yml`) |
 | `dev-core.yml missing` | Run `/init` |
 | `artifacts.* dir missing` | `mkdir -p {path}` ∀ missing |
 | `hooks.tool not set` | Append `hooks:\n  tool: auto` to σ |

--- a/plugins/dev-core/skills/env-setup/README.md
+++ b/plugins/dev-core/skills/env-setup/README.md
@@ -17,7 +17,7 @@ Triggers: `"env setup"` | `"setup environment"` | `"configure stack"` | `"scaffo
 
 ## Phases
 
-**Phase 1 — Stack configuration** — copies `stack.yml.example` to `.claude/stack.yml`, asks for critical fields (runtime, backend/frontend paths, test command), prepends `@.claude/stack.yml` import to CLAUDE.md. `stack.yml` is committed (project conventions, no secrets); only `.env` and `.claude/dev-core.yml` are gitignored.
+**Phase 1 — Stack configuration** — copies `stack.yml.example` to `.claude/stack.yml`, asks for critical fields (runtime, backend/frontend paths, test command), prepends `@.claude/stack.yml` import to CLAUDE.md. `stack.yml` is committed (project conventions, no secrets); only `.env` is gitignored.
 
 **Phase 1b — Global patterns** — copies `global-patterns.md` (decision protocol, agent discipline, git conventions) to `~/.claude/shared/` and references it from CLAUDE.md.
 
@@ -32,5 +32,5 @@ Triggers: `"env setup"` | `"setup environment"` | `"configure stack"` | `"scaffo
 ## Safety
 
 - Never overwrites existing `stack.yml` values without `--force` or confirmation
-- Commits `stack.yml` (project conventions); gitignores `.env` and `.claude/dev-core.yml` (per-machine secrets)
+- Commits `stack.yml` (project conventions); gitignores `.env` only
 - Idempotent — all phases skip already-configured items

--- a/plugins/dev-core/skills/env-setup/SKILL.md
+++ b/plugins/dev-core/skills/env-setup/SKILL.md
@@ -35,7 +35,7 @@ Set up σ early — later phases read runtime, package manager, commands, deploy
 5. ¬`.claude/stack.yml.example` → `cp "${Φ}/stack.yml.example" .claude/stack.yml.example`. D("stack.yml.example", "✅ Created (reference template)").
 6. existing → D("stack.yml", "✅ Already exists"), skip.
 
-Note: `.claude/stack.yml` is **committed** (project stack conventions — no secrets). Only `.env` and `.claude/dev-core.yml` are gitignored by dev-core.
+Note: `.claude/stack.yml` is **committed** (project stack conventions — no secrets). Only `.env` is gitignored by dev-core. `.claude/dev-core.yml` contains only public GitHub Project node IDs and is committed.
 
 ### Phase 1b — Global Patterns Injection
 
@@ -162,7 +162,7 @@ Next: run /seed-docs to populate docs stubs, or /github-setup to connect GitHub 
 
 1. **Never overwrite existing `.claude/stack.yml` values** without F or explicit confirmation
 2. **Always present decisions via protocol** before any write operation
-3. **Commit `.claude/stack.yml`** — it holds project stack conventions, not secrets. Gitignore `.env` and `.claude/dev-core.yml` instead.
+3. **Commit `.claude/stack.yml`** — it holds project stack conventions, not secrets. Gitignore `.env` only.
 4. **Idempotent** — skip already-configured items unless F
 
 $ARGUMENTS

--- a/plugins/dev-core/skills/github-setup/README.md
+++ b/plugins/dev-core/skills/github-setup/README.md
@@ -27,14 +27,14 @@ Triggers: `"github setup"` | `"setup github project"` | `"connect github board"`
 
 **Phase 2 — Confirm values** — displays the full configuration table; allows editing individual fields before writing.
 
-**Phase 3 — Write config** — writes `.claude/dev-core.yml` (gitignored); runs scaffold script for `.env` and `.env.example`; installs `roxabi` shim at `~/.local/bin/roxabi`.
+**Phase 3 — Write config** — writes `.claude/dev-core.yml`; runs scaffold script for `.env` and `.env.example`; installs `roxabi` shim at `~/.local/bin/roxabi`.
 
 **Phase 4 — Workspace registration** — registers the project in the shared `workspace.json`; scans for other dev-core-configured repos on the filesystem and offers to bulk-register them.
 
 ## Safety
 
 - Never overwrites `.claude/dev-core.yml` or `.env` without `--force` or confirmation
-- Both files are always added to `.gitignore`
+- `.env` is always added to `.gitignore`; `.claude/dev-core.yml` is committed (public GitHub Project node IDs)
 - Never stores secrets in `.env.example`
 
 ## Hub Enroll (opt-in, cross-repo taxonomy)

--- a/plugins/dev-core/skills/github-setup/SKILL.md
+++ b/plugins/dev-core/skills/github-setup/SKILL.md
@@ -251,7 +251,7 @@ Next: run /ci-setup to configure GitHub Actions and pre-commit hooks.
 
 1. **Never overwrite δ or `.env` values** without F or explicit confirmation
 2. **Always present decisions via protocol** before destructive or write operations
-3. **Never commit δ or `.env`** — ensure both are in `.gitignore`
+3. **Commit δ** (public GitHub Project node IDs); gitignore `.env` only
 4. **Never store secrets in `.env.example`** — use empty placeholder values
 5. **Idempotent** — safe to re-run, merges rather than overwrites
 

--- a/plugins/dev-core/skills/github-setup/SKILL.md
+++ b/plugins/dev-core/skills/github-setup/SKILL.md
@@ -153,8 +153,6 @@ size_options_json: '<json>'
 priority_options_json: '<json>'
 ```
 
-Ensure δ ∈ `.gitignore`.
-
 ### 3b. Scaffold (legacy .env + shim + artifacts)
 
 Run: `bun $I_TS scaffold --github-repo <owner/repo> --project-id <PVT_...> --status-field-id <PVTSSF_...> --size-field-id <PVTSSF_...> --priority-field-id <PVTSSF_...> --status-options-json '<json>' --size-options-json '<json>' --priority-options-json '<json>' [--vercel-token <token>] [--vercel-project-id <id>] [--vercel-team-id <id>] [--force]`

--- a/plugins/dev-core/skills/init/README.md
+++ b/plugins/dev-core/skills/init/README.md
@@ -39,5 +39,5 @@ Each sub-skill is independently re-runnable to reconfigure a single concern:
 
 ## Safety
 
-- Never commits secrets — `.claude/dev-core.yml` and `.env` are gitignored automatically.
+- Never commits secrets — `.env` is gitignored. `.claude/dev-core.yml` contains only public GitHub Project node IDs and is committed.
 - Idempotent — sub-skills skip already-configured items unless `--force`.

--- a/plugins/dev-core/skills/init/SKILL.md
+++ b/plugins/dev-core/skills/init/SKILL.md
@@ -84,7 +84,7 @@ Next steps:
 
 ## Safety Rules
 
-1. **Never commit secrets** — `.claude/dev-core.yml`, `.env` must be gitignored
+1. **Never commit secrets** — `.env` must be gitignored (`.claude/dev-core.yml` contains only public GitHub Project node IDs — commit it)
 2. **Always present decisions via protocol** before destructive operations (delegated to sub-skills)
 3. **Idempotent** — safe to re-run; sub-skills merge rather than overwrite
 

--- a/plugins/dev-core/skills/init/__tests__/scaffold.test.ts
+++ b/plugins/dev-core/skills/init/__tests__/scaffold.test.ts
@@ -211,5 +211,6 @@ describe('scaffold', () => {
     })
 
     expect(result.gitignoreUpdated).toBe(true)
+    expect(writtenFiles['.gitignore']).not.toContain('.claude/dev-core.yml')
   })
 })

--- a/plugins/dev-core/skills/init/lib/scaffold.ts
+++ b/plugins/dev-core/skills/init/lib/scaffold.ts
@@ -346,9 +346,6 @@ export async function scaffold(opts: ScaffoldOpts): Promise<ScaffoldResult> {
     if (!lines.some((l: string) => l.trim() === '.env')) {
       additions.push('.env')
     }
-    if (!lines.some((l: string) => l.trim() === '.claude/dev-core.yml')) {
-      additions.push('.claude/dev-core.yml')
-    }
     if (additions.length > 0) {
       fs.appendFileSync('.gitignore', `\n${additions.join('\n')}\n`)
       result.gitignoreUpdated = true

--- a/plugins/dev-core/skills/init/templates/docs/standards/configuration.md
+++ b/plugins/dev-core/skills/init/templates/docs/standards/configuration.md
@@ -21,7 +21,7 @@ TODO: Document environment variables.
   |------|---------|:---:|
   | .claude/stack.yml | Dev-core stack config | Yes |
   | .claude/stack.yml.example | Reference template for fresh clones | Yes |
-  | .claude/dev-core.yml | Dev-core plugin config (GitHub IDs, Vercel) | No (.gitignored) |
+  | .claude/dev-core.yml | Dev-core plugin config (GitHub IDs, Vercel) | Yes |
   | .env | Per-machine secrets / env vars | No (.gitignored) |
   | biome.json | Linter/formatter config | Yes |
   | tsconfig.json | TypeScript config | Yes |

--- a/plugins/dev-core/skills/stack-setup/SKILL.md
+++ b/plugins/dev-core/skills/stack-setup/SKILL.md
@@ -154,7 +154,7 @@ Assemble σ. Omit `none`/empty keys entirely.
 
 ```yaml
 # .claude/stack.yml — dev-core stack configuration
-# Commit this file with the project. Secrets live in .env / .claude/dev-core.yml.
+# Commit this file with the project. Secrets live in .env only.
 schema_version: "1.0"
 
 runtime: {RUNTIME}
@@ -247,7 +247,7 @@ artifacts:
 1. **@import:** `head -1 CLAUDE.md` ≠ `@.claude/stack.yml` → prepend; else already present.
 2. **Example:** `.claude/stack.yml.example` ∄ → copy σ → "Created as reference template."
 
-Note: `.claude/stack.yml` itself is committed (project stack conventions — no secrets). Only `.env` and `.claude/dev-core.yml` are gitignored by dev-core.
+Note: `.claude/stack.yml` itself is committed (project stack conventions — no secrets). Only `.env` is gitignored by dev-core. `.claude/dev-core.yml` contains only public GitHub Project node IDs and is committed.
 
 ## Phase 6 — Summary
 

--- a/plugins/dev-core/stack.yml.example
+++ b/plugins/dev-core/stack.yml.example
@@ -1,7 +1,7 @@
 # .claude/stack.yml — dev-core stack configuration
 # COMMIT this file — it declares project stack conventions (paths, commands,
-# formatter, test runner). No secrets go here; `.env` and `.claude/dev-core.yml`
-# hold per-machine credentials and stay gitignored.
+# formatter, test runner). No secrets go here; only `.env` stays gitignored.
+# `.claude/dev-core.yml` holds GitHub Project node IDs (public, not secrets) — commit it too.
 #
 # stack.yml.example remains as a reference template for fresh clones.
 #


### PR DESCRIPTION
## Summary

Drops the conventions that `.claude/stack.yml` and `.claude/dev-core.yml` must be gitignored.

Neither file contains secrets:
- **`.claude/stack.yml`** — project stack conventions (paths, commands, runtime). PR #102 established this.
- **`.claude/dev-core.yml`** — GitHub Project V2 node IDs (`GITHUB_REPO`, `GH_PROJECT_ID`, `STATUS/SIZE/PRIORITY` field IDs). These are public identifiers queryable by anyone with repo access via the GitHub API.

The convention is: **only `.env`** (and platform-specific credential files) are gitignored.

## Changes

**Commit `e1f1d8d` — stack.yml (PR #102 mirror):**
- `checkup/cookbooks/stack-checks.md`: remove `σ ∈ .gitignore` Security audit line + Phase 2 Fix table row
- `init/SKILL.md`: update safety rule — only `.env` gitignored
- `env-setup/SKILL.md`: remove `ensureGitignore(.claude/stack.yml)` from Phase 1

**Commit `bb40695` — dev-core.yml:**
- `checkup/cookbooks/stack-checks.md`: remove `δ ∈ .gitignore` Security audit block + Phase 2 Fix table row
- `github-setup/SKILL.md`: drop "Ensure δ ∈ .gitignore" step from Phase 3a
- `github-setup/README.md`: update Safety section
- `env-setup/SKILL.md` + `README.md`: update notes and safety rules
- `init/SKILL.md` + `README.md`: update safety rule #1
- `stack-setup/SKILL.md`: update template comment and Phase 5 note
- `init/lib/scaffold.ts`: remove `.claude/dev-core.yml` gitignore insertion
- `init/templates/docs/standards/configuration.md`: mark dev-core.yml as committed (Yes)
- `stack.yml.example`: update header comment

## Test plan

- [x] `bun test plugins/dev-core/skills/init/__tests__/scaffold.test.ts` — 13 pass, 0 fail
- [x] Final grep: `grep -rn "dev-core\.yml" plugins/dev-core/ | grep -iE "gitignore|secret|do.?not.?commit|ignored"` — only updated explanatory lines remain (no enforcement refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)