### PR TITLE
feat(frame): add premise-validity gate (success/failure/simplest_alternative)

### DIFF
--- a/plugins/dev-core/skills/frame/README.md
+++ b/plugins/dev-core/skills/frame/README.md
@@ -19,10 +19,15 @@ Triggers: `"frame"` | `"frame this"` | `"what's the problem"` | `"define the pro
 
 1. **Parse + Seed** — reads the GitHub issue (title, body, labels) or free text as context.
 2. **Interview** — asks 3–5 focused questions (skips what's already clear from the issue body): problem/pain, affected users, constraints, out-of-scope, related work.
-3. **Tier detection** — infers S / F-lite / F-full from complexity signals (file count, domain breadth, unknowns); lets you override.
-4. **Write frame doc** — creates `artifacts/frames/{N}-{slug}-frame.mdx` with status: `draft`.
-5. **User approval** — presents the frame for confirmation; loops on revisions until approved.
-6. **Commit + status update** — sets issue status to `Analysis` and commits the artifact.
+3. **Premise-validity gate** — required before tier classification. Captures three fields:
+   - `success_in_6mo` — what does success look like? (concrete, observable)
+   - `failure_in_6mo` — what does failure look like? (must be falsifiable)
+   - `simplest_alternative` + why it's insufficient — forces explicit comparison against the minimal solution
+   Cannot proceed without all three. Non-falsifiable failure modes trigger an abort prompt.
+4. **Tier detection** — infers S / F-lite / F-full from complexity signals (file count, domain breadth, unknowns); lets you override.
+5. **Write frame doc** — creates `artifacts/frames/{N}-{slug}-frame.mdx` with status: `draft`.
+6. **User approval** — presents the frame for confirmation; loops on revisions until approved.
+7. **Commit + status update** — sets issue status to `Analysis` and commits the artifact.
 
 ## Output artifact
 
@@ -30,7 +35,7 @@ Triggers: `"frame"` | `"frame this"` | `"what's the problem"` | `"define the pro
 artifacts/frames/{N}-{slug}-frame.mdx
 ```
 
-Fields: `title`, `issue`, `status: approved`, `tier`, `date`, Problem, Who, Constraints, Out of Scope, Complexity.
+Fields: `title`, `issue`, `status: approved`, `tier`, `date`, Problem, Who, Constraints, Out of Scope, Premise Validity (required: `success_in_6mo`, `failure_in_6mo`, `simplest_alternative` + why-not), Complexity.
 
 ## Chain position
 

--- a/plugins/dev-core/skills/frame/SKILL.md
+++ b/plugins/dev-core/skills/frame/SKILL.md
@@ -2,7 +2,7 @@
 name: frame
 argument-hint: '["idea" | --issue <N>]'
 description: Problem framing — capture problem, constraints, scope, tier. Triggers: "frame" | "frame this" | "what's the problem" | "define the problem" | "scope this out" | "define the scope" | "what are we solving" | "help me think through this problem" | "problem statement".
-version: 0.2.0
+version: 0.3.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, ToolSearch
 ---
 
@@ -35,6 +35,7 @@ Standalone-safe: callable without `/dev`. Output consumed by `/analyze`, `/spec`
 |------|----|----------|---------------|-------|
 | 0 | parse | ✓ | `gh issue view N` → JSON | — |
 | 1 | interview | — | — | 3–5 Q max |
+| 1b | premise | ✓ | 3 fields non-empty | **gate** — blocks Step 2 |
 | 2 | tier | ✓ | τ ∈ frontmatter | — |
 | 3 | write | ✓ | φ ∃ | — |
 | 4 | approval | ✓ | `status: approved` | gate |
@@ -43,7 +44,7 @@ Standalone-safe: callable without `/dev`. Output consumed by `/analyze`, `/spec`
 
 Success: φ written ∧ status: approved
 Evidence: `ls artifacts/frames/` after execution
-Steps: parse → interview → tier → write → approval
+Steps: parse → interview → premise-gate → tier → write → approval
 ¬clear → STOP + ask: "What problem are you solving?"
 
 ## Step 0 — Parse + Seed
@@ -78,6 +79,28 @@ Check ∃ φ:
 | 5 | Related work, prior attempts, adjacent issues? | ∅ context → optional |
 
 ¬ask all 5 if seed is rich — ask only what's missing.
+
+## Step 1b — Premise-Validity Gate
+
+**Gate: cannot proceed to Step 2 without all 3 fields answered.**
+
+Capture in a single AQ (present all 3 together):
+
+| Field | Prompt | Requirement |
+|-------|--------|-------------|
+| `success_in_6mo` | "What does success look like in 6 months?" | Concrete, observable outcome — ¬vague ("things are better") |
+| `failure_in_6mo` | "What does failure look like in 6 months?" | Must be **falsifiable** — a condition you could actually observe ∧ decide to abort |
+| `simplest_alternative` | "What's the simplest version that would meet the goal — and why isn't it enough?" | Forces explicit comparison; the "why not" is required, ¬optional |
+
+Evaluation rules:
+
+- `failure_in_6mo` ¬falsifiable (e.g. "people aren't happy") → reject, re-ask. Example of falsifiable: "DEBT count stays flat or rises despite 3 sprint cycles." Example of non-falsifiable: "the team doesn't feel better."
+- `simplest_alternative` answer omits the "why not" half → re-ask: "You described the simpler version — why won't it be enough?"
+- Any field empty or answered with ≤5 words → treat as unanswered, re-ask.
+
+**Abort signal:** if the user answers `failure_in_6mo` with a description that matches "we'd still have the problem but with extra bookkeeping" (i.e. the initiative measures proxy metrics, ¬the underlying issue) → surface: "This failure mode suggests the premise may be invalid. Do you want to reframe the problem or abort?" AQ: **Reframe** | **Abort**.
+
+Origin: pattern surfaced by Roxabi/lyra#1162 — quality-debt annotation infrastructure (~1100 LOC + 6 registry files) where the ratchet measured bookkeeping compliance, not code quality. A falsification check at /frame would have caught this.
 
 ## Step 2 — Tier Detection
 
@@ -125,6 +148,17 @@ date: {YYYY-MM-DD}
 ## Out of Scope
 
 - {explicit non-goals as bullets}
+
+## Premise Validity
+
+**Required — populated from Step 1b. ¬leave blank.**
+
+**Success in 6 months:** {concrete, observable outcome}
+
+**Failure in 6 months:** {falsifiable condition — observable ∧ actionable}
+
+**Simplest alternative:** {minimal version that meets the goal}
+**Why not simplest:** {explicit reason the simpler path is insufficient}
 
 ## Complexity
 

--- a/plugins/dev-core/skills/frame/SKILL.md
+++ b/plugins/dev-core/skills/frame/SKILL.md
@@ -94,11 +94,19 @@ Capture in a single AQ (present all 3 together):
 
 Evaluation rules:
 
+- `failure_in_6mo` falsifiability rule: must reference a **measurable outcome** (number, threshold, or boolean state) AND a **time horizon**. Vibes-only failure modes are rejected.
 - `failure_in_6mo` ¬falsifiable (e.g. "people aren't happy") → reject, re-ask. Example of falsifiable: "DEBT count stays flat or rises despite 3 sprint cycles." Example of non-falsifiable: "the team doesn't feel better."
 - `simplest_alternative` answer omits the "why not" half → re-ask: "You described the simpler version — why won't it be enough?"
 - Any field empty or answered with ≤5 words → treat as unanswered, re-ask.
 
 **Abort signal:** if the user answers `failure_in_6mo` with a description that matches "we'd still have the problem but with extra bookkeeping" (i.e. the initiative measures proxy metrics, ¬the underlying issue) → surface: "This failure mode suggests the premise may be invalid. Do you want to reframe the problem or abort?" AQ: **Reframe** | **Abort**.
+
+Canonical proxy-metric patterns (LLM anchors — any of these triggers the abort signal):
+- "compliance count stays the same / unchanged"
+- "annotation density doesn't move"
+- "ticket-close rate doesn't improve"
+- "dashboard stays red / metric won't budge"
+- "we'd still have the underlying problem but with extra bookkeeping"
 
 Origin: pattern surfaced by Roxabi/lyra#1162 — quality-debt annotation infrastructure (~1100 LOC + 6 registry files) where the ratchet measured bookkeeping compliance, not code quality. A falsification check at /frame would have caught this.
 


### PR DESCRIPTION
## Summary

- Adds **Step 1b** to \`/frame\` — a hard gate between interview and tier classification
- Three required fields: \`success_in_6mo\`, \`failure_in_6mo\` (must be falsifiable), \`simplest_alternative\` (with mandatory why-not)
- Frame artifact gains a **Premise Validity** section with all four sub-fields
- Non-falsifiable \`failure_in_6mo\` triggers a re-ask loop; proxy-metric failure modes surface an explicit **Reframe | Abort** prompt
- Version bump: \`0.2.0 → 0.3.0\`

Originating case: Roxabi/lyra#1162 — quality-debt annotation infrastructure (~1100 LOC + 6 registry files) where \`failure_in_6mo\` would have been "DEBT count stays flat despite 3 sprint cycles" and \`simplest_alternative\` would have pointed directly to a regression-cap ratchet (~130 LOC, ~95% of the value).

Closes #169

## Acceptance checklist

- [x] Concrete change to \`dev-core:frame\` skill
- [x] Roxabi/lyra#1162 referenced as originating example in SKILL.md Step 1b
- [x] All 3 fields required (block progression to Step 2)
- [x] \`failure_in_6mo\` falsifiability enforced with re-ask + abort signal
- [x] Frame artifact template updated with required Premise Validity section
- [x] README updated (step numbering, output fields)
- [x] lint pass | typecheck pass | 507 tests pass
- [ ] Out of scope: \`global-patterns.md\` documentation — **follow-up needed** (file is \`~/.claude/shared/global-patterns.md\`, out-of-tree for this repo; requires a separate cross-repo update)

## Coupling note

Issue #168 (\`/plan\` budget heuristic) is in-flight in parallel. Neither branch touches the same files — no conflict expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)