### PR TITLE
feat(promote): auto-pin uv git deps from branch= to tag= during staging→main

### DIFF
--- a/docs/release-convention.md
+++ b/docs/release-convention.md
@@ -1,0 +1,49 @@
+# Release Convention
+
+## Tag format
+
+```
+<component>/vX.Y.Z     # monorepo subdir package (e.g. roxabi-nats/v1.2.3)
+vX.Y.Z                 # single-package repo (e.g. v0.5.0)
+```
+
+PRs: merge-commit only (¬squash) — squash causes history divergence on next promotion.
+
+## Branch convention for uv git deps
+
+Roxabi Python repos consume cross-repo deps via `[tool.uv.sources]` in `pyproject.toml`.
+
+| Branch | Ref style | When |
+|--------|-----------|------|
+| `staging` | `branch = "staging"` | Development — tracks latest staging SHA |
+| `main` | `tag = "vX.Y.Z"` | Production — pinned to exact release tag |
+
+This means `pyproject.toml` on `staging` uses `branch=`, and on `main` uses `tag=`. The swap is automated by `/promote` (Step 1b — pin-swap phase).
+
+## `/promote` pin-swap phase
+
+At promotion time (staging→main), `/promote` automatically:
+
+1. Detects `[tool.uv.sources]` entries with `branch=`
+2. Resolves the SHA pinned in `uv.lock` to a release tag on the remote (`git ls-remote --tags`)
+3. Shows a DP(A) diff: `branch=staging → tag=vX.Y.Z`
+4. On Apply: rewrites `pyproject.toml`, regenerates `uv.lock`, stages both
+
+If no release tag exists at the locked SHA, promotion FAILS with:
+
+```
+FAIL: No release tag found at <pkg>@<sha8>.
+Cut a release tag (e.g. <pkg>/vX.Y.Z) at <sha8> upstream first.
+```
+
+This is intentional friction — promotion must ship exactly what staging tested.
+
+## Scope
+
+uv-only (`[tool.uv.sources]`). pip / poetry / pnpm deferred until a real consumer appears.
+
+## References
+
+- `/promote` SKILL.md — Step 1b full spec
+- `lib/pin-swap.ts` — implementation (pure functions, I/O-injected)
+- `__tests__/pin-swap.test.ts` — unit tests

--- a/plugins/dev-core/skills/promote/README.md
+++ b/plugins/dev-core/skills/promote/README.md
@@ -20,6 +20,7 @@ Triggers: `"promote staging"` | `"release"` | `"deploy"` | `"cut a release"` | `
 ## How it works
 
 1. **Pre-flight** — checks commits ahead of main, open PRs on staging, CI status. Refuses if nothing to promote.
+1b. **Pin-swap** — detects `branch=` git deps in `[tool.uv.sources]`, resolves each to a release tag at the locked SHA, rewrites `pyproject.toml`, regenerates `uv.lock`. No-op if zero `branch=` git deps. Fails loud if SHA has no matching tag (forces upstream to cut a release first).
 2. **Version + changelog** — bumps version, writes changelog (see `references/release-artifacts.md`).
 3. **Deploy preview** (optional) — triggers `deploy-preview.yml` workflow and waits for it.
 4. **Summary** — shows version, commit count, file count, CI status, preview result.

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -23,6 +23,7 @@ Let: σ := staging | μ := main | V := release version (vX.Y.Z) | Q := DP(A)
 | Step | ID | Required | Verifies via | Notes |
 |------|----|----------|---------------|-------|
 | 1 | pre-flight | ✓ | ¬REFUSE | — |
+| 1b | pin-swap | — | ¬branch= deps remain | no-op if zero branch= deps |
 | 2 | version | ✓ | V detected | — |
 | 3 | changelog | ✓ | CHANGELOG.md updated | — |
 | 4 | commit | ✓ | `git log` shows commit | — |
@@ -62,6 +63,81 @@ Emits: `commits_ahead`, `status`, commit log, diff stat, open PRs on staging, CI
 | No commits | `commits_ahead=0` | **REFUSE.** Stop. |
 | Open PRs on σ | open_prs section non-empty | **WARN** + Q: **Continue** \| **Wait** |
 | CI status | ci section | **WARN** if ¬passing |
+
+## Step 1b — Pin-swap Phase
+
+Runs after pre-flight, before version bump. Rewrites mutable `branch=` git deps in `[tool.uv.sources]` to immutable `tag=` pins for the promotion commit.
+
+**Trigger:** `pyproject.toml` exists AND `[tool.uv.sources]` contains at least one entry with `branch=`.
+
+**No-op:** if zero `branch=` git deps found → silent skip, continue to Step 2.
+
+### Detection
+
+Scan `pyproject.toml` `[tool.uv.sources]`:
+
+```toml
+# Detected — has branch=
+roxabi-nats = { git = "https://github.com/Roxabi/roxabi-nats", branch = "staging" }
+
+# Ignored — already pinned
+roxabi-nats = { git = "https://github.com/Roxabi/roxabi-nats", tag = "v1.2.3" }
+```
+
+### Resolution
+
+For each detected dep:
+1. Read pinned SHA from `uv.lock` (`rev = "<sha>"` in package source)
+2. Run `git ls-remote --tags <gitUrl>` on the remote
+3. Match SHA → release tag at that exact commit
+4. Tag matching: prefer `<pkg>/vX.Y.Z` (monorepo subdirectory style), fall back to bare `vX.Y.Z`
+
+### DP(A) gate
+
+```
+── Decision: Pin uv git deps ──
+Context:     N branch= git deps found; will be rewritten for promotion
+Target:      Immutable tag pins in pyproject.toml before staging→main
+Path:        Rewrite pyproject.toml, run uv lock, stage both files
+
+Deps:
+  - roxabi-nats: branch=staging → tag=roxabi-nats/v1.2.3 (SHA: abc123def456)
+
+Options:
+  1. Apply — rewrite + regenerate uv.lock + stage
+  2. Abort — stop promotion, no changes
+Recommended: Option 1
+```
+
+### On Apply
+
+```bash
+# Rewrite pyproject.toml (branch= → tag=) for each dep
+# Then regenerate:
+uv lock
+git add pyproject.toml uv.lock
+```
+
+### On Abort
+
+Revert `pyproject.toml` to original (no changes were written). Stop promotion.
+
+### Error: no tag at SHA
+
+```
+FAIL: No release tag found at roxabi-nats@abc123def4 on https://github.com/Roxabi/roxabi-nats.
+Cut a release tag (e.g. roxabi-nats/vX.Y.Z) at abc123def4 upstream first.
+```
+
+Stops promotion. User must cut a tag upstream before retrying.
+
+### `--dry-run`
+
+Show pin-swap plan (deps + resolved tags) but do NOT write files. Continue to show version/changelog summary, then stop.
+
+### Implementation
+
+Logic lives in `lib/pin-swap.ts` (pure functions, I/O-injected). Tests in `__tests__/pin-swap.test.ts`.
 
 ## Steps 2-4 — Version, Changelog, Commit
 

--- a/plugins/dev-core/skills/promote/__tests__/pin-swap.test.ts
+++ b/plugins/dev-core/skills/promote/__tests__/pin-swap.test.ts
@@ -187,12 +187,13 @@ describe('resolveTagAtSha', () => {
     expect(tag).toBeNull()
   })
 
-  it('returns null when ls-remote fails', async () => {
+  it('throws with remote details when ls-remote fails (network/auth/timeout)', async () => {
     const deps: Pick<Deps, 'run'> = {
-      run: vi.fn().mockRejectedValue(new Error('network error')),
+      run: vi.fn().mockRejectedValue(new Error('Connection timed out')),
     }
-    const tag = await resolveTagAtSha(gitUrl, sha, 'roxabi-nats', deps)
-    expect(tag).toBeNull()
+    await expect(resolveTagAtSha(gitUrl, sha, 'roxabi-nats', deps)).rejects.toThrow(
+      /Failed to query.*for tags at.*Connection timed out/,
+    )
   })
 
   it('returns null when ls-remote output is empty', async () => {
@@ -206,6 +207,18 @@ describe('resolveTagAtSha', () => {
     const deps = makeDeps(lsRemote)
     const tag = await resolveTagAtSha(gitUrl, sha, 'roxabi-nats', deps)
     expect(tag).toBeNull()
+  })
+
+  it('picks highest semver tag numerically, not lexicographically', async () => {
+    // lexicographic would pick v1.9.0 over v1.10.0 — numeric must pick v1.10.0
+    const lsRemote = [
+      `${sha}\trefs/tags/v1.10.0^{}`,
+      `${sha}\trefs/tags/v1.9.0^{}`,
+      `${sha}\trefs/tags/v1.2.0^{}`,
+    ].join('\n')
+    const deps = makeDeps(lsRemote)
+    const tag = await resolveTagAtSha(gitUrl, sha, 'some-pkg', deps)
+    expect(tag).toBe('v1.10.0')
   })
 })
 
@@ -428,6 +441,25 @@ describe('applyPinSwap', () => {
     }
     const result = await applyPinSwap('/repo', plan, deps)
     expect(result).toEqual({ written: true, staged: true })
+  })
+
+  it('restores original pyproject.toml and rethrows when uv lock fails', async () => {
+    const writes: [string, string][] = []
+    const deps: Deps = {
+      readFile: vi.fn(() => pyproject),
+      writeFile: vi.fn((path, content) => writes.push([path, content])),
+      run: vi.fn(async (cmd: string[]) => {
+        if (cmd[0] === 'uv') throw new Error('lock resolution failed')
+        return ''
+      }),
+    }
+    await expect(applyPinSwap('/repo', plan, deps)).rejects.toThrow(
+      /uv lock failed; pyproject\.toml restored: lock resolution failed/,
+    )
+    // writeFile called twice: once to write new content, once to restore original
+    expect(writes).toHaveLength(2)
+    const [, restoredContent] = writes[1]
+    expect(restoredContent).toBe(pyproject)
   })
 })
 

--- a/plugins/dev-core/skills/promote/__tests__/pin-swap.test.ts
+++ b/plugins/dev-core/skills/promote/__tests__/pin-swap.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  applyPinSwap,
+  buildPinSwapPlan,
+  type Deps,
+  formatPlan,
+  type PinSwapPlan,
+  parseUvGitDeps,
+  readLockedSha,
+  resolveTagAtSha,
+  rewritePyproject,
+} from '../lib/pin-swap'
+
+// ─── parseUvGitDeps ───────────────────────────────────────────────────────────
+
+describe('parseUvGitDeps', () => {
+  it('returns empty array when no [tool.uv.sources] section', () => {
+    const toml = '[tool.poetry]\nname = "myapp"\n'
+    expect(parseUvGitDeps(toml)).toEqual([])
+  })
+
+  it('returns empty array when sources section has no git entries', () => {
+    const toml = '[tool.uv.sources]\nlibA = { url = "https://example.com/lib.tar.gz" }\n'
+    expect(parseUvGitDeps(toml)).toEqual([])
+  })
+
+  it('returns empty array when git source has no branch= (tag= instead)', () => {
+    const toml = '[tool.uv.sources]\nlibA = { git = "https://github.com/org/libA", tag = "v1.0.0" }\n'
+    expect(parseUvGitDeps(toml)).toEqual([])
+  })
+
+  it('parses inline table with branch=', () => {
+    const toml = [
+      '[tool.uv.sources]',
+      'roxabi-nats = { git = "https://github.com/Roxabi/roxabi-nats", branch = "staging" }',
+    ].join('\n')
+    const result = parseUvGitDeps(toml)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      name: 'roxabi-nats',
+      source: { git: 'https://github.com/Roxabi/roxabi-nats', branch: 'staging' },
+    })
+  })
+
+  it('parses multiple inline table entries', () => {
+    const toml = [
+      '[tool.uv.sources]',
+      'libA = { git = "https://github.com/org/libA", branch = "staging" }',
+      'libB = { git = "https://github.com/org/libB", branch = "dev" }',
+    ].join('\n')
+    const result = parseUvGitDeps(toml)
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.name)).toEqual(['libA', 'libB'])
+  })
+
+  it('skips entries without branch= even when git= is present', () => {
+    const toml = [
+      '[tool.uv.sources]',
+      'libA = { git = "https://github.com/org/libA", rev = "abc123" }',
+      'libB = { git = "https://github.com/org/libB", branch = "staging" }',
+    ].join('\n')
+    const result = parseUvGitDeps(toml)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('libB')
+  })
+
+  it('parses sub-table form', () => {
+    const toml = [
+      '[tool.uv.sources.roxabi-nats]',
+      'git = "https://github.com/Roxabi/roxabi-nats"',
+      'branch = "staging"',
+    ].join('\n')
+    const result = parseUvGitDeps(toml)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      name: 'roxabi-nats',
+      source: { git: 'https://github.com/Roxabi/roxabi-nats', branch: 'staging' },
+    })
+  })
+
+  it('stops parsing sources at the next unrelated section header', () => {
+    const toml = [
+      '[tool.uv.sources]',
+      'libA = { git = "https://github.com/org/libA", branch = "staging" }',
+      '[tool.ruff]',
+      'libB = { git = "https://github.com/org/libB", branch = "staging" }',
+    ].join('\n')
+    const result = parseUvGitDeps(toml)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('libA')
+  })
+})
+
+// ─── readLockedSha ────────────────────────────────────────────────────────────
+
+describe('readLockedSha', () => {
+  const uvLock = [
+    '[[package]]',
+    'name = "roxabi-nats"',
+    'version = "0.2.0"',
+    'source = { git = "https://github.com/Roxabi/roxabi-nats", rev = "abc123def456abc123def456abc123def456abc1" }',
+    '',
+    '[[package]]',
+    'name = "other-lib"',
+    'version = "1.0.0"',
+    'source = { git = "https://github.com/org/other", rev = "111222333444111222333444111222333444abcd" }',
+  ].join('\n')
+
+  it('returns SHA for a known package', () => {
+    const sha = readLockedSha(uvLock, 'roxabi-nats')
+    expect(sha).toBe('abc123def456abc123def456abc123def456abc1')
+  })
+
+  it('returns SHA for another package', () => {
+    const sha = readLockedSha(uvLock, 'other-lib')
+    expect(sha).toBe('111222333444111222333444111222333444abcd')
+  })
+
+  it('returns null for unknown package', () => {
+    expect(readLockedSha(uvLock, 'unknown-pkg')).toBeNull()
+  })
+
+  it('normalizes hyphens to underscores for matching', () => {
+    const lock = [
+      '[[package]]',
+      'name = "roxabi_nats"',
+      'source = { git = "https://github.com/Roxabi/roxabi-nats", rev = "aaabbbcccdddeeefffaaabbbcccdddeeefffaaab" }',
+    ].join('\n')
+    expect(readLockedSha(lock, 'roxabi-nats')).toBe('aaabbbcccdddeeefffaaabbbcccdddeeefffaaab')
+  })
+
+  it('returns null when source has no rev field', () => {
+    const lock = ['[[package]]', 'name = "roxabi-nats"', 'source = { url = "https://example.com/pkg.tar.gz" }'].join(
+      '\n',
+    )
+    expect(readLockedSha(lock, 'roxabi-nats')).toBeNull()
+  })
+})
+
+// ─── resolveTagAtSha ─────────────────────────────────────────────────────────
+
+describe('resolveTagAtSha', () => {
+  const sha = 'abc123def456abc123def456abc123def456abc1'
+  const gitUrl = 'https://github.com/Roxabi/roxabi-nats'
+
+  function makeDeps(lsRemoteOutput: string): Pick<Deps, 'run'> {
+    return {
+      run: vi.fn().mockResolvedValue(lsRemoteOutput),
+    }
+  }
+
+  it('returns monorepo-style tag when SHA matches', async () => {
+    const lsRemote = [
+      `${sha}\trefs/tags/roxabi-nats/v1.2.3^{}`,
+      `deadbeef0000deadbeef0000deadbeef0000dead\trefs/tags/roxabi-nats/v1.2.3`,
+    ].join('\n')
+    const deps = makeDeps(lsRemote)
+    const tag = await resolveTagAtSha(gitUrl, sha, 'roxabi-nats', deps)
+    expect(tag).toBe('roxabi-nats/v1.2.3')
+  })
+
+  it('prefers monorepo-style tag over bare vX.Y.Z when both match', async () => {
+    const lsRemote = [
+      `${sha}\trefs/tags/v1.2.3^{}`,
+      `deadbeef0000deadbeef0000deadbeef0000dead\trefs/tags/v1.2.3`,
+      `${sha}\trefs/tags/roxabi-nats/v1.2.3^{}`,
+      `deadbeef0000deadbeef0000deadbeef0000dead\trefs/tags/roxabi-nats/v1.2.3`,
+    ].join('\n')
+    const deps = makeDeps(lsRemote)
+    const tag = await resolveTagAtSha(gitUrl, sha, 'roxabi-nats', deps)
+    expect(tag).toBe('roxabi-nats/v1.2.3')
+  })
+
+  it('falls back to bare vX.Y.Z tag when no monorepo tag matches', async () => {
+    const lsRemote = [`${sha}\trefs/tags/v0.5.0^{}`, `deadbeef0000deadbeef0000deadbeef0000dead\trefs/tags/v0.5.0`].join(
+      '\n',
+    )
+    const deps = makeDeps(lsRemote)
+    const tag = await resolveTagAtSha(gitUrl, sha, 'some-pkg', deps)
+    expect(tag).toBe('v0.5.0')
+  })
+
+  it('returns null when SHA has no matching tag', async () => {
+    const lsRemote = [`0000000000000000000000000000000000000000\trefs/tags/v1.0.0^{}`].join('\n')
+    const deps = makeDeps(lsRemote)
+    const tag = await resolveTagAtSha(gitUrl, sha, 'roxabi-nats', deps)
+    expect(tag).toBeNull()
+  })
+
+  it('returns null when ls-remote fails', async () => {
+    const deps: Pick<Deps, 'run'> = {
+      run: vi.fn().mockRejectedValue(new Error('network error')),
+    }
+    const tag = await resolveTagAtSha(gitUrl, sha, 'roxabi-nats', deps)
+    expect(tag).toBeNull()
+  })
+
+  it('returns null when ls-remote output is empty', async () => {
+    const deps = makeDeps('')
+    const tag = await resolveTagAtSha(gitUrl, sha, 'roxabi-nats', deps)
+    expect(tag).toBeNull()
+  })
+
+  it('ignores non-release tags (no vX.Y.Z pattern)', async () => {
+    const lsRemote = [`${sha}\trefs/tags/latest^{}`, `${sha}\trefs/tags/staging^{}`].join('\n')
+    const deps = makeDeps(lsRemote)
+    const tag = await resolveTagAtSha(gitUrl, sha, 'roxabi-nats', deps)
+    expect(tag).toBeNull()
+  })
+})
+
+// ─── rewritePyproject ─────────────────────────────────────────────────────────
+
+describe('rewritePyproject', () => {
+  it('rewrites branch= to tag= in inline table form', () => {
+    const input = [
+      '[tool.uv.sources]',
+      'roxabi-nats = { git = "https://github.com/Roxabi/roxabi-nats", branch = "staging" }',
+    ].join('\n')
+    const output = rewritePyproject(input, 'roxabi-nats', 'roxabi-nats/v1.2.3')
+    expect(output).toContain('tag = "roxabi-nats/v1.2.3"')
+    expect(output).not.toContain('branch =')
+  })
+
+  it('rewrites only the target package, not others', () => {
+    const input = [
+      '[tool.uv.sources]',
+      'libA = { git = "https://github.com/org/libA", branch = "staging" }',
+      'libB = { git = "https://github.com/org/libB", branch = "staging" }',
+    ].join('\n')
+    const output = rewritePyproject(input, 'libA', 'v2.0.0')
+    expect(output).toContain('libA = { git = "https://github.com/org/libA", tag = "v2.0.0" }')
+    expect(output).toContain('libB = { git = "https://github.com/org/libB", branch = "staging" }')
+  })
+
+  it('rewrites branch= to tag= in sub-table form', () => {
+    const input = [
+      '[tool.uv.sources.roxabi-nats]',
+      'git = "https://github.com/Roxabi/roxabi-nats"',
+      'branch = "staging"',
+    ].join('\n')
+    const output = rewritePyproject(input, 'roxabi-nats', 'roxabi-nats/v1.2.3')
+    expect(output).toContain('tag = "roxabi-nats/v1.2.3"')
+    expect(output).not.toContain('branch =')
+  })
+
+  it('preserves lines outside sources section unchanged', () => {
+    const input = [
+      '[project]',
+      'name = "myapp"',
+      'version = "1.0.0"',
+      '',
+      '[tool.uv.sources]',
+      'roxabi-nats = { git = "https://github.com/Roxabi/roxabi-nats", branch = "staging" }',
+      '',
+      '[tool.ruff]',
+      'line-length = 120',
+    ].join('\n')
+    const output = rewritePyproject(input, 'roxabi-nats', 'v1.2.3')
+    expect(output).toContain('[project]')
+    expect(output).toContain('name = "myapp"')
+    expect(output).toContain('[tool.ruff]')
+    expect(output).toContain('line-length = 120')
+  })
+
+  it('does not mutate the input string', () => {
+    const input = '[tool.uv.sources]\nlibA = { git = "url", branch = "staging" }\n'
+    const original = input
+    rewritePyproject(input, 'libA', 'v1.0.0')
+    expect(input).toBe(original)
+  })
+})
+
+// ─── buildPinSwapPlan ─────────────────────────────────────────────────────────
+
+describe('buildPinSwapPlan', () => {
+  const sha = 'abc123def456abc123def456abc123def456abc1'
+
+  function makeDeps(overrides: Partial<Deps> = {}): Deps {
+    const pyproject = [
+      '[tool.uv.sources]',
+      `roxabi-nats = { git = "https://github.com/Roxabi/roxabi-nats", branch = "staging" }`,
+    ].join('\n')
+
+    const uvLock = [
+      '[[package]]',
+      'name = "roxabi-nats"',
+      `source = { git = "https://github.com/Roxabi/roxabi-nats", rev = "${sha}" }`,
+    ].join('\n')
+
+    const lsRemote = [
+      `${sha}\trefs/tags/roxabi-nats/v1.2.3^{}`,
+      `deadbeef0000deadbeef0000deadbeef0000dead\trefs/tags/roxabi-nats/v1.2.3`,
+    ].join('\n')
+
+    return {
+      readFile: vi.fn((path: string) => {
+        if (path.endsWith('pyproject.toml')) return pyproject
+        if (path.endsWith('uv.lock')) return uvLock
+        throw new Error(`unexpected readFile: ${path}`)
+      }),
+      writeFile: vi.fn(),
+      run: vi.fn().mockResolvedValue(lsRemote),
+      ...overrides,
+    }
+  }
+
+  it('returns empty candidates when no branch= git deps', async () => {
+    const deps = makeDeps({
+      readFile: vi.fn(() => '[tool.uv.sources]\nlibA = { url = "https://example.com/a.tar.gz" }\n'),
+    })
+    const plan = await buildPinSwapPlan('/repo', deps)
+    expect(plan.candidates).toHaveLength(0)
+  })
+
+  it('builds a plan with resolved candidate', async () => {
+    const deps = makeDeps()
+    const plan = await buildPinSwapPlan('/repo', deps)
+    expect(plan.candidates).toHaveLength(1)
+    expect(plan.candidates[0]).toMatchObject({
+      name: 'roxabi-nats',
+      branch: 'staging',
+      sha,
+      tag: 'roxabi-nats/v1.2.3',
+    })
+  })
+
+  it('throws when SHA not found in uv.lock', async () => {
+    const deps = makeDeps({
+      readFile: vi.fn((path: string) => {
+        if (path.endsWith('pyproject.toml')) {
+          return '[tool.uv.sources]\nroxabi-nats = { git = "https://github.com/Roxabi/roxabi-nats", branch = "staging" }\n'
+        }
+        return '[[package]]\nname = "other"\nsource = { url = "x" }\n'
+      }),
+    })
+    await expect(buildPinSwapPlan('/repo', deps)).rejects.toThrow(/no rev found in uv\.lock/)
+  })
+
+  it('throws with actionable message when no tag at SHA', async () => {
+    const deps = makeDeps({
+      run: vi.fn().mockResolvedValue(`0000000000000000000000000000000000000000\trefs/tags/v1.0.0^{}`),
+    })
+    await expect(buildPinSwapPlan('/repo', deps)).rejects.toThrow(/Cut a release tag.*upstream first/)
+  })
+})
+
+// ─── applyPinSwap ─────────────────────────────────────────────────────────────
+
+describe('applyPinSwap', () => {
+  const sha = 'abc123def456abc123def456abc123def456abc1'
+  const pyproject = [
+    '[tool.uv.sources]',
+    'roxabi-nats = { git = "https://github.com/Roxabi/roxabi-nats", branch = "staging" }',
+  ].join('\n')
+
+  const plan: PinSwapPlan = {
+    candidates: [
+      {
+        name: 'roxabi-nats',
+        gitUrl: 'https://github.com/Roxabi/roxabi-nats',
+        branch: 'staging',
+        sha,
+        tag: 'roxabi-nats/v1.2.3',
+      },
+    ],
+  }
+
+  it('returns written=false when plan has no candidates', async () => {
+    const deps: Deps = {
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      run: vi.fn().mockResolvedValue(''),
+    }
+    const result = await applyPinSwap('/repo', { candidates: [] }, deps)
+    expect(result).toEqual({ written: false, staged: false })
+    expect(deps.writeFile).not.toHaveBeenCalled()
+  })
+
+  it('writes rewritten pyproject.toml', async () => {
+    const writes: [string, string][] = []
+    const deps: Deps = {
+      readFile: vi.fn(() => pyproject),
+      writeFile: vi.fn((path, content) => writes.push([path, content])),
+      run: vi.fn().mockResolvedValue(''),
+    }
+    await applyPinSwap('/repo', plan, deps)
+    expect(writes).toHaveLength(1)
+    const [path, content] = writes[0]
+    expect(path).toBe('/repo/pyproject.toml')
+    expect(content).toContain('tag = "roxabi-nats/v1.2.3"')
+    expect(content).not.toContain('branch =')
+  })
+
+  it('runs uv lock to regenerate lock file', async () => {
+    const runs: string[][] = []
+    const deps: Deps = {
+      readFile: vi.fn(() => pyproject),
+      writeFile: vi.fn(),
+      run: vi.fn(async (cmd: string[]) => {
+        runs.push(cmd)
+        return ''
+      }),
+    }
+    await applyPinSwap('/repo', plan, deps)
+    expect(runs).toContainEqual(['uv', 'lock'])
+  })
+
+  it('stages pyproject.toml and uv.lock', async () => {
+    const runs: string[][] = []
+    const deps: Deps = {
+      readFile: vi.fn(() => pyproject),
+      writeFile: vi.fn(),
+      run: vi.fn(async (cmd: string[]) => {
+        runs.push(cmd)
+        return ''
+      }),
+    }
+    await applyPinSwap('/repo', plan, deps)
+    expect(runs).toContainEqual(['git', 'add', 'pyproject.toml', 'uv.lock'])
+  })
+
+  it('returns written=true and staged=true on success', async () => {
+    const deps: Deps = {
+      readFile: vi.fn(() => pyproject),
+      writeFile: vi.fn(),
+      run: vi.fn().mockResolvedValue(''),
+    }
+    const result = await applyPinSwap('/repo', plan, deps)
+    expect(result).toEqual({ written: true, staged: true })
+  })
+})
+
+// ─── formatPlan ───────────────────────────────────────────────────────────────
+
+describe('formatPlan', () => {
+  it('reports skip message for empty plan', () => {
+    const out = formatPlan({ candidates: [] })
+    expect(out).toContain('no branch= git deps found')
+  })
+
+  it('shows candidate diff for non-empty plan', () => {
+    const plan: PinSwapPlan = {
+      candidates: [
+        {
+          name: 'roxabi-nats',
+          gitUrl: 'https://github.com/Roxabi/roxabi-nats',
+          branch: 'staging',
+          sha: 'abc123def456abc123def456abc123def456abc1',
+          tag: 'roxabi-nats/v1.2.3',
+        },
+      ],
+    }
+    const out = formatPlan(plan)
+    expect(out).toContain('roxabi-nats')
+    expect(out).toContain('branch=staging')
+    expect(out).toContain('tag=roxabi-nats/v1.2.3')
+    expect(out).toContain('abc123def456')
+  })
+})

--- a/plugins/dev-core/skills/promote/lib/pin-swap.ts
+++ b/plugins/dev-core/skills/promote/lib/pin-swap.ts
@@ -181,8 +181,8 @@ export async function resolveTagAtSha(
   let lsRemoteOut: string
   try {
     lsRemoteOut = await deps.run(['git', 'ls-remote', '--tags', gitUrl])
-  } catch {
-    return null
+  } catch (err) {
+    throw new Error(`Failed to query ${gitUrl} for tags at ${sha}: ${err instanceof Error ? err.message : String(err)}`)
   }
 
   if (!lsRemoteOut) return null
@@ -223,8 +223,17 @@ export async function resolveTagAtSha(
   const monorepoMatch = matchingTags.find((t) => t.toLowerCase().startsWith(`${normalizedPkg}/`))
   if (monorepoMatch) return monorepoMatch
 
-  // Fall back to bare version tag
-  return matchingTags.sort().reverse()[0] ?? null
+  // Fall back to bare version tag — sort numerically to avoid lexicographic misorder (v1.9 > v1.10)
+  const parseVersion = (tag: string): [number, number, number] => {
+    const m = tag.replace(/^v/, '').match(/^(\d+)\.(\d+)\.(\d+)/)
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : [0, 0, 0]
+  }
+  const compareSemver = (a: string, b: string) => {
+    const [a1, a2, a3] = parseVersion(a)
+    const [b1, b2, b3] = parseVersion(b)
+    return a1 - b1 || a2 - b2 || a3 - b3
+  }
+  return [...matchingTags].sort(compareSemver).reverse()[0] ?? null
 }
 
 // ─── pyproject rewriting ──────────────────────────────────────────────────────
@@ -348,7 +357,8 @@ export async function buildPinSwapPlan(cwd: string, deps: Deps): Promise<PinSwap
 export async function applyPinSwap(cwd: string, plan: PinSwapPlan, deps: Deps): Promise<ApplyResult> {
   if (plan.candidates.length === 0) return { written: false, staged: false }
 
-  let pyprojectText = deps.readFile(`${cwd}/pyproject.toml`)
+  const originalPyproject = deps.readFile(`${cwd}/pyproject.toml`)
+  let pyprojectText = originalPyproject
 
   for (const candidate of plan.candidates) {
     pyprojectText = rewritePyproject(pyprojectText, candidate.name, candidate.tag)
@@ -356,8 +366,13 @@ export async function applyPinSwap(cwd: string, plan: PinSwapPlan, deps: Deps): 
 
   deps.writeFile(`${cwd}/pyproject.toml`, pyprojectText)
 
-  // Regenerate lock file
-  await deps.run(['uv', 'lock'], cwd)
+  // Regenerate lock file — restore pyproject on failure to avoid corrupted working tree
+  try {
+    await deps.run(['uv', 'lock'], cwd)
+  } catch (err) {
+    deps.writeFile(`${cwd}/pyproject.toml`, originalPyproject)
+    throw new Error(`uv lock failed; pyproject.toml restored: ${err instanceof Error ? err.message : String(err)}`)
+  }
 
   // Stage both files
   await deps.run(['git', 'add', 'pyproject.toml', 'uv.lock'], cwd)

--- a/plugins/dev-core/skills/promote/lib/pin-swap.ts
+++ b/plugins/dev-core/skills/promote/lib/pin-swap.ts
@@ -1,0 +1,386 @@
+/**
+ * pin-swap.ts — uv git-dep pin-swap phase for /promote
+ *
+ * Detects [tool.uv.sources] entries with branch= and rewrites them to tag=
+ * using the SHA pinned in uv.lock resolved to a matching release tag.
+ *
+ * Designed for pure-logic testability: all I/O is injected via Deps interface.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface UvGitSource {
+  git: string
+  branch: string
+}
+
+export interface GitDep {
+  name: string
+  source: UvGitSource
+}
+
+export interface PinCandidate {
+  name: string
+  gitUrl: string
+  branch: string
+  sha: string
+  tag: string
+}
+
+export interface PinSwapPlan {
+  candidates: PinCandidate[]
+}
+
+export interface ApplyResult {
+  written: boolean
+  staged: boolean
+}
+
+// ─── Dependencies (injected for testability) ──────────────────────────────────
+
+export interface Deps {
+  /** Read a file from disk, return its text content. */
+  readFile: (path: string) => string
+  /** Write text content to a file on disk. */
+  writeFile: (path: string, content: string) => void
+  /** Run a shell command, return trimmed stdout. Throws on non-zero exit. */
+  run: (cmd: string[], cwd?: string) => Promise<string>
+}
+
+// ─── Parsing ──────────────────────────────────────────────────────────────────
+
+/**
+ * Parse [tool.uv.sources] from pyproject.toml text.
+ * Returns only entries that have both `git =` and `branch =` fields.
+ *
+ * Handles TOML inline tables: { git = "...", branch = "..." }
+ * and multi-key blocks under [tool.uv.sources.<name>].
+ */
+export function parseUvGitDeps(pyprojectText: string): GitDep[] {
+  const deps: GitDep[] = []
+  const lines = pyprojectText.split('\n')
+
+  // State machine: inside [tool.uv.sources] block?
+  let inSources = false
+  let currentName: string | null = null
+  let currentGit: string | null = null
+  let currentBranch: string | null = null
+
+  function flushBlock() {
+    if (currentName && currentGit && currentBranch) {
+      deps.push({ name: currentName, source: { git: currentGit, branch: currentBranch } })
+    }
+    currentName = null
+    currentGit = null
+    currentBranch = null
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    // Section header detection
+    if (trimmed.startsWith('[')) {
+      flushBlock()
+
+      // Sub-table header: [tool.uv.sources.name] — sets inSources + currentName
+      const subTableMatch = trimmed.match(/^\[tool\.uv\.sources\.([^\]]+)\]$/)
+      if (subTableMatch) {
+        inSources = true
+        currentName = subTableMatch[1]
+        continue
+      }
+
+      if (trimmed === '[tool.uv.sources]') {
+        inSources = true
+        continue
+      }
+
+      // Any other section header ends sources block
+      inSources = false
+      continue
+    }
+
+    if (!inSources) continue
+
+    // Inline table: name = { git = "...", branch = "..." }
+    const inlineMatch = trimmed.match(/^(\S+)\s*=\s*\{([^}]*)\}/)
+    if (inlineMatch && !currentName) {
+      const name = inlineMatch[1]
+      const body = inlineMatch[2]
+      const gitMatch = body.match(/git\s*=\s*["']([^"']+)["']/)
+      const branchMatch = body.match(/branch\s*=\s*["']([^"']+)["']/)
+      if (gitMatch && branchMatch) {
+        deps.push({ name, source: { git: gitMatch[1], branch: branchMatch[1] } })
+      }
+      continue
+    }
+
+    // Key = value inside a sub-table
+    if (currentName) {
+      const gitVal = trimmed.match(/^git\s*=\s*["']([^"']+)["']/)
+      if (gitVal) {
+        currentGit = gitVal[1]
+        continue
+      }
+      const branchVal = trimmed.match(/^branch\s*=\s*["']([^"']+)["']/)
+      if (branchVal) {
+        currentBranch = branchVal[1]
+      }
+    }
+  }
+
+  flushBlock()
+  return deps
+}
+
+// ─── Lock file parsing ────────────────────────────────────────────────────────
+
+/**
+ * Read the pinned SHA for a package from uv.lock.
+ *
+ * uv.lock format (TOML-like):
+ *   [[package]]
+ *   name = "pkg-name"
+ *   ...
+ *   source = { git = "https://...", rev = "<sha>" }
+ */
+export function readLockedSha(uvLockText: string, pkgName: string): string | null {
+  const blocks = uvLockText.split(/(?=\[\[package\]\])/g)
+  for (const block of blocks) {
+    // Check name matches (normalize hyphens/underscores for comparison)
+    const nameMatch = block.match(/^name\s*=\s*["']([^"']+)["']/m)
+    if (!nameMatch) continue
+    const blockName = nameMatch[1].toLowerCase().replace(/-/g, '_')
+    const target = pkgName.toLowerCase().replace(/-/g, '_')
+    if (blockName !== target) continue
+
+    // Extract rev from source line
+    const revMatch = block.match(/rev\s*=\s*["']([a-f0-9]{40})["']/)
+    if (revMatch) return revMatch[1]
+  }
+  return null
+}
+
+// ─── Tag resolution ───────────────────────────────────────────────────────────
+
+/**
+ * Resolve a SHA to a release tag at that exact commit on the remote.
+ *
+ * Fetches tags via `git ls-remote --tags <gitUrl>` and matches
+ * tags pointing at the given SHA. Supports monorepo-style tags
+ * like `<pkg>/vX.Y.Z` as well as flat `vX.Y.Z`.
+ *
+ * Returns the best match (prefer `<pkgName>/vX.Y.Z`, fall back to `vX.Y.Z`).
+ */
+export async function resolveTagAtSha(
+  gitUrl: string,
+  sha: string,
+  pkgName: string,
+  deps: Pick<Deps, 'run'>,
+): Promise<string | null> {
+  let lsRemoteOut: string
+  try {
+    lsRemoteOut = await deps.run(['git', 'ls-remote', '--tags', gitUrl])
+  } catch {
+    return null
+  }
+
+  if (!lsRemoteOut) return null
+
+  // Parse ls-remote output: "<sha>\trefs/tags/<tag>"
+  // Annotated tags have a "^{}" dereference line with the commit SHA
+  const tagLines = lsRemoteOut.split('\n').filter(Boolean)
+
+  // Build map: tagName → set of SHAs (commit SHA from ^{} line, or direct)
+  const tagToShas = new Map<string, Set<string>>()
+  for (const line of tagLines) {
+    const parts = line.split('\t')
+    if (parts.length < 2) continue
+    const lineSha = parts[0].trim()
+    const ref = parts[1].trim()
+    // refs/tags/<name>^{} = dereferenced (points to commit), refs/tags/<name> = tag object
+    const tagMatch = ref.match(/^refs\/tags\/(.+?)(\^\{\})?$/)
+    if (!tagMatch) continue
+    const tagName = tagMatch[1]
+    if (!tagToShas.has(tagName)) tagToShas.set(tagName, new Set())
+    tagToShas.get(tagName)?.add(lineSha)
+  }
+
+  // Filter to release-style tags matching the SHA
+  const matchingTags: string[] = []
+  const normalizedPkg = pkgName.replace(/_/g, '-').toLowerCase()
+
+  for (const [tagName, shas] of tagToShas) {
+    if (!shas.has(sha)) continue
+    // Accept: vX.Y.Z, <pkg>/vX.Y.Z, <pkg>/vX.Y.Z-suffix
+    if (!/v\d+\.\d+\.\d+/.test(tagName)) continue
+    matchingTags.push(tagName)
+  }
+
+  if (matchingTags.length === 0) return null
+
+  // Prefer <pkgName>/vX.Y.Z (monorepo-style) over bare vX.Y.Z
+  const monorepoMatch = matchingTags.find((t) => t.toLowerCase().startsWith(`${normalizedPkg}/`))
+  if (monorepoMatch) return monorepoMatch
+
+  // Fall back to bare version tag
+  return matchingTags.sort().reverse()[0] ?? null
+}
+
+// ─── pyproject rewriting ──────────────────────────────────────────────────────
+
+/**
+ * Rewrite [tool.uv.sources] in pyproject.toml text:
+ * replace `branch = "<branch>"` with `tag = "<tag>"` for the given package.
+ *
+ * Handles both inline table and sub-table forms.
+ * Returns the rewritten text (does NOT mutate the input).
+ */
+export function rewritePyproject(pyprojectText: string, pkgName: string, tag: string): string {
+  const lines = pyprojectText.split('\n')
+  const result: string[] = []
+  let inSources = false
+  let inPkgBlock = false
+  let foundAndRewroteInline = false
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const trimmed = line.trim()
+
+    if (trimmed.startsWith('[')) {
+      inPkgBlock = false
+      if (trimmed === '[tool.uv.sources]') {
+        inSources = true
+      } else if (trimmed === `[tool.uv.sources.${pkgName}]`) {
+        // Direct sub-table header — sets both inSources and inPkgBlock
+        inSources = true
+        inPkgBlock = true
+      } else if (inSources && trimmed.startsWith('[tool.uv.sources.')) {
+        // Another sub-table inside sources, but not our target
+        inSources = true
+      } else {
+        inSources = false
+      }
+      result.push(line)
+      continue
+    }
+
+    // Inline table form: pkgName = { git = "...", branch = "staging" }
+    if (inSources && !foundAndRewroteInline) {
+      const inlineRegex = new RegExp(`^(\\s*${pkgName}\\s*=\\s*\\{[^}]*)branch\\s*=\\s*["'][^"']*["']([^}]*\\})`)
+      if (inlineRegex.test(line)) {
+        const rewritten = line.replace(/branch\s*=\s*["'][^"']*["']/, `tag = "${tag}"`)
+        result.push(rewritten)
+        foundAndRewroteInline = true
+        continue
+      }
+    }
+
+    // Sub-table form: inside [tool.uv.sources.<pkgName>], replace branch = ... line
+    if (inPkgBlock && /^\s*branch\s*=/.test(line)) {
+      const indent = line.match(/^(\s*)/)?.[1] ?? ''
+      result.push(`${indent}tag = "${tag}"`)
+      continue
+    }
+
+    result.push(line)
+  }
+
+  return result.join('\n')
+}
+
+// ─── Plan building ────────────────────────────────────────────────────────────
+
+/**
+ * Build the pin-swap plan: detect branch= git deps, resolve SHAs and tags.
+ *
+ * Returns { candidates } where each candidate has: name, gitUrl, branch, sha, tag.
+ * Throws with an actionable message if a SHA cannot be resolved to a tag.
+ *
+ * @param cwd  Working directory containing pyproject.toml and uv.lock
+ */
+export async function buildPinSwapPlan(cwd: string, deps: Deps): Promise<PinSwapPlan> {
+  const pyprojectText = deps.readFile(`${cwd}/pyproject.toml`)
+  const uvLockText = deps.readFile(`${cwd}/uv.lock`)
+
+  const gitDeps = parseUvGitDeps(pyprojectText)
+  if (gitDeps.length === 0) return { candidates: [] }
+
+  const candidates: PinCandidate[] = []
+
+  for (const dep of gitDeps) {
+    const sha = readLockedSha(uvLockText, dep.name)
+    if (!sha) {
+      throw new Error(
+        `pin-swap: ${dep.name} has branch=${dep.source.branch} in pyproject.toml but no rev found in uv.lock.\n` +
+          `Run 'uv lock' to sync the lock file first.`,
+      )
+    }
+
+    const tag = await resolveTagAtSha(dep.source.git, sha, dep.name, deps)
+    if (!tag) {
+      throw new Error(
+        `pin-swap: No release tag found at ${dep.name}@${sha.slice(0, 8)} on ${dep.source.git}.\n` +
+          `Cut a release tag (e.g. ${dep.name}/vX.Y.Z) at ${sha.slice(0, 8)} upstream first.`,
+      )
+    }
+
+    candidates.push({
+      name: dep.name,
+      gitUrl: dep.source.git,
+      branch: dep.source.branch,
+      sha,
+      tag,
+    })
+  }
+
+  return { candidates }
+}
+
+// ─── Apply ────────────────────────────────────────────────────────────────────
+
+/**
+ * Apply the pin-swap plan: rewrite pyproject.toml, regenerate uv.lock, stage both.
+ *
+ * @param cwd  Working directory
+ * @param plan  Plan from buildPinSwapPlan
+ */
+export async function applyPinSwap(cwd: string, plan: PinSwapPlan, deps: Deps): Promise<ApplyResult> {
+  if (plan.candidates.length === 0) return { written: false, staged: false }
+
+  let pyprojectText = deps.readFile(`${cwd}/pyproject.toml`)
+
+  for (const candidate of plan.candidates) {
+    pyprojectText = rewritePyproject(pyprojectText, candidate.name, candidate.tag)
+  }
+
+  deps.writeFile(`${cwd}/pyproject.toml`, pyprojectText)
+
+  // Regenerate lock file
+  await deps.run(['uv', 'lock'], cwd)
+
+  // Stage both files
+  await deps.run(['git', 'add', 'pyproject.toml', 'uv.lock'], cwd)
+
+  return { written: true, staged: true }
+}
+
+// ─── Dry-run formatting ───────────────────────────────────────────────────────
+
+/**
+ * Format a pin-swap plan as a human-readable diff for display.
+ */
+export function formatPlan(plan: PinSwapPlan): string {
+  if (plan.candidates.length === 0) {
+    return 'pin-swap: no branch= git deps found — skipping.'
+  }
+
+  const lines = ['Pin-swap plan:', '']
+  for (const c of plan.candidates) {
+    lines.push(`  ${c.name}`)
+    lines.push(`    branch=${c.branch}  →  tag=${c.tag}`)
+    lines.push(`    SHA: ${c.sha.slice(0, 12)}`)
+    lines.push('')
+  }
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Summary

- Adds Step 1b **pin-swap phase** to `/promote` between pre-flight and version bump
- Detects `[tool.uv.sources]` entries with `branch=`, resolves each to a release tag via `uv.lock` SHA + `git ls-remote`, shows DP(A) diff, rewrites `pyproject.toml`, regenerates `uv.lock`, stages both
- Fails loud when SHA has no matching tag; no-op when zero `branch=` git deps; `--dry-run` shows plan only

## Acceptance criteria

- [x] `/promote` detects `branch=` entries in `[tool.uv.sources]` and lists them in pre-flight output
- [x] For each, resolves `uv.lock` SHA → `<pkg>/vX.Y.Z` tag (subdirectory-aware for monorepo subdir packages)
- [x] DP(A) gate before mutating `pyproject.toml` / `uv.lock`
- [x] On apply: rewrite source block, run `uv lock`, stage both files for the promotion commit
- [x] On abort: revert pyproject.toml + uv.lock cleanly (DP gate prevents writes)
- [x] If SHA has no matching tag → fail loud with actionable message ("cut `<pkg>/vX.Y.Z` at `<sha>` upstream first")
- [x] No-op + silent skip when zero git deps with `branch=` are found
- [x] `--dry-run` shows the swap plan without writing
- [x] Works for repos that release as containers (phase runs before image build, orthogonal to container flow)
- [x] Documented in `docs/release-convention.md` (new file)

## Files changed

- `plugins/dev-core/skills/promote/lib/pin-swap.ts` — new, pure-logic implementation (I/O injected via Deps interface)
- `plugins/dev-core/skills/promote/__tests__/pin-swap.test.ts` — 36 vitest unit tests
- `plugins/dev-core/skills/promote/SKILL.md` — Step 1b documented
- `plugins/dev-core/skills/promote/README.md` — pin-swap added to how-it-works list
- `docs/release-convention.md` — new file documenting branch/tag convention + pin-swap

## Test plan

- [x] `bun run test` — 543 tests pass (36 new in pin-swap suite)
- [x] `bun run lint` — biome clean
- [x] pre-commit + pre-push hooks pass (lint, typecheck, trufflehog, conventional-commits)

## Follow-up (out of scope, flagged)

- `~/projects/CLAUDE.md` Release Convention block should reference pin-swap behavior — this file is outside the repo and cannot be edited in this PR. Flag for manual update.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)