### PR TITLE
refactor(web-intel): rename LITELLM_MASTER_KEY → LLMCLI_API_KEY

### DIFF
--- a/plugins/web-intel/scripts/enricher.py
+++ b/plugins/web-intel/scripts/enricher.py
@@ -47,22 +47,22 @@ def _get_fireworks_token() -> str:
         return ""
 
     # 1. Check env vars
-    for key in ("FIREWORKS_TOKEN", "LITELLM_MASTER_KEY"):
+    for key in ("FIREWORKS_TOKEN", "LLMCLI_API_KEY"):
         token = os.environ.get(key, "")
         if token:
             return token
 
-    # 2. Check ~/.claude/.env (LITELLM_MASTER_KEY = proxy master key)
+    # 2. Check ~/.claude/.env (LLMCLI_API_KEY = proxy master key)
     claude_env = Path.home() / ".claude" / ".env"
     if claude_env.exists():
-        token = _parse_env_file(claude_env, "LITELLM_MASTER_KEY", "FIREWORKS_TOKEN")
+        token = _parse_env_file(claude_env, "LLMCLI_API_KEY", "FIREWORKS_TOKEN")
         if token:
             return token
 
     # 3. Check ~/.env
     env_path = Path.home() / ".env"
     if env_path.exists():
-        token = _parse_env_file(env_path, "FIREWORKS_TOKEN", "LITELLM_MASTER_KEY")
+        token = _parse_env_file(env_path, "FIREWORKS_TOKEN", "LLMCLI_API_KEY")
         if token:
             return token
 


### PR DESCRIPTION
## Summary

- Rename `LITELLM_MASTER_KEY` → `LLMCLI_API_KEY` in `enricher.py` (4 occurrences)
- Part of the infrastructure consolidation: llmcli becomes the central LLM portal (local + cloud passthrough) exposing a single operator-facing key

## Context

System-level changes already applied locally (not in this repo):
- `~/.claude/.env`: rename
- `~/.litellm/.env`: drop `LITELLM_MASTER_KEY`, keep `LLMCLI_API_KEY` only (unified value)
- `~/.litellm/config.yaml`: add `general_settings.master_key: os.environ/LLMCLI_API_KEY`
- `~/.bash_aliases`: rename in `_cc_fireworks` + `_cc_nvidia` helpers (3 lines)

The litellm proxy on `:4000` continues to authenticate clients with the same key value — only the env var **name** changed.

## Test plan

- [x] System-level smoke test: `curl -H "Authorization: Bearer \$LLMCLI_API_KEY" http://localhost:4000/v1/models` returns 200 (6 models listed)
- [x] Old keys correctly rejected (no auth → 401, old short value → 400)
- [ ] Re-run `enricher.py` against a sample Discord link to confirm the FIREWORKS_TOKEN fallback chain still resolves correctly