### PR TITLE
feat(dev-core): add /recheck phase to dev pipeline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "dev-core",
-      "description": "Full development workflow — frame, shape, plan, implement, review, ship. Opinionated Roxabi process with 32 skills, 9 agents, and safety hooks.",
+      "description": "Full development workflow — frame, shape, plan, implement, review, ship. Opinionated Roxabi process with 33 skills, 9 agents, and safety hooks.",
       "source": "./plugins/dev-core",
       "category": "development",
       "version": "0.3.2"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Plugins are project-agnostic: they read your stack from `.claude/stack.yml` at r
 
 | Plugin | Description |
 |--------|-------------|
-| [dev-core](plugins/dev-core/README.md) | Full dev workflow — frame, analyze, spec, plan, implement, review, ship. 32 skills, 9 agents, safety hooks. Project-agnostic via `stack.yml`. Quality gates (Python): file-length / folder-size / import-layer pre-commit hooks via `quality_gates:` in `stack.yml` |
+| [dev-core](plugins/dev-core/README.md) | Full dev workflow — frame, analyze, spec, plan, implement, review, ship. 33 skills, 9 agents, safety hooks. Project-agnostic via `stack.yml`. Quality gates (Python): file-length / folder-size / import-layer pre-commit hooks via `quality_gates:` in `stack.yml` |
 
 ### Research & analysis
 

--- a/artifacts/frames/181-add-recheck-phase-frame.mdx
+++ b/artifacts/frames/181-add-recheck-phase-frame.mdx
@@ -1,0 +1,57 @@
+---
+title: Add /recheck phase to dev pipeline
+issue: 181
+status: approved
+tier: F-lite
+date: 2026-05-20
+---
+
+## Problem
+
+Issues sit in the backlog for days/weeks before being picked up. By the time `/dev #N` runs, the underlying code may have evolved — the bug might already be fixed, symbols referenced in the issue may have been renamed, or blocking dependencies may have been resolved. Today `/dev` jumps straight from `triage → frame` (or `triage → implement` for S-tier) with no staleness check.
+
+The S-tier path is the most dangerous: it skips `/frame`, `/analyze`, `/spec`, `/plan` entirely, going `triage → implement`. A stale S-tier issue silently turns into wasted work — code re-fixes itself, symbols are searched and not found, premises are wrong from the first commit.
+
+Observable impact today: no telemetry distinguishes "issue still relevant" from "issue silently obsolete." Every stale-issue cost is invisible.
+
+## Who
+
+- **Primary:** developers running `/dev #N` after issue has aged in the backlog. Most acute for S-tier (no gates, no frame).
+- **Secondary:** reviewers — they see PRs whose premise no longer holds and have to bounce them; issue-triage maintainers — they re-open closed-but-still-listed issues.
+
+## Constraints
+
+- **Position fixed:** between `triage` and `frame` in the `Frame` phase — issue already labelled, no artifact yet written.
+- **No skip-logic:** runs for every issue, every tier, every invocation of `/dev`. Decision made explicitly to avoid silent bypass on the riskiest path (S-tier).
+- **Behavior split:** informative when no drift signal fires (one-line "Issue still relevant" → silent continue); blocking via DP(A) when any signal fires.
+- **Skill must be standalone-callable** (`/recheck #N`) outside `/dev` — reusable in ad-hoc workflows.
+- **Determinism:** drift checks are deterministic (git log, grep, gh dependency state) — no ML scoring, no LLM judgement of "feels stale."
+- **Speed:** drift checks parallel, target <5s end-to-end (else `/dev` UX degrades).
+
+## Out of Scope
+
+- Auto-closing stale issues — `/recheck` *proposes* close via DP, user decides.
+- Recheck for non-`/dev` flows (raw `gh issue` work, manual coding).
+- ML-based staleness scoring or LLM "vibes" check.
+- Backfilling drift checks on already-running pipelines (only new `/dev` invocations).
+- Tracking historical drift signals across runs (no recheck-log artifact).
+
+## Premise Validity
+
+**Success in 6 months:** `/recheck` catches ≥1 stale issue per month before `/implement` runs; zero S-tier issues silently re-implement already-fixed bugs.
+
+**Failure in 6 months:** After 3 months of usage, `/recheck` has never blocked or modified a single `/dev` flow — i.e. it always says "still relevant" and produces no signal. OR users skip past `/recheck` >80% of the time when signals fire (signal-to-noise too low → step becomes ritual).
+
+**Simplest alternative:** A one-line `git log --since=<issue.created>` print inside `/dev`'s Step 1 scan-state — surfaces "N commits touched cited paths since issue creation" as info only.
+**Why not simplest:** No symbol/dependency check, no DP gate, no standalone callable form. Can't catch a renamed symbol or a resolved blocker. S-tier path still races to `/implement` without confirmation. The whole point is fail-fast with user decision, which an inline print can't deliver.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (dev-core plugin internals), no new architecture, well-bounded file set (~5–6 files), single integration surface (`/dev` SKILL.md + new skill dir).
+
+Signals observed:
+- Multi-file but single-domain (dev-core plugin only).
+- No new patterns — `/recheck` follows the existing skill template (SKILL.md + README.md + optional scripts).
+- Integration into `/dev` follows the same pattern used by other pipeline steps (Σ entry, STEPS array, invocation map, Tier Skip Matrix row).
+- No new dependencies, no schema migration, no cross-plugin coupling.
+- Tier-bounded between S (would skip the integration in `/dev`) and F-full (no multi-domain or unknowns).

--- a/artifacts/plans/181-add-recheck-phase-plan.mdx
+++ b/artifacts/plans/181-add-recheck-phase-plan.mdx
@@ -1,0 +1,438 @@
+---
+title: "Plan: Add /recheck phase to dev pipeline"
+issue: 181
+spec: artifacts/specs/181-add-recheck-phase-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-05-20
+---
+
+## Summary
+
+Create a standalone `/recheck` skill (Slice 1) and integrate it into the `/dev` pipeline between `triage` and `frame` (Slice 2), then update the marketplace + skill-index docs (Slice 3). All work is in `plugins/dev-core/`. No new dependencies, no new test framework — verification via file-existence + frontmatter + `bash`/`grep` smoke checks.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph Inputs
+      GH[gh issue view N]
+      GIT[git log --since]
+      GREP[grep cited symbols]
+      DEPS[gh issue view blockers]
+    end
+    subgraph RecheckSkill[skills/recheck/SKILL.md]
+      P[parse args / read issue]
+      C1[git-drift check]
+      C2[symbol-drift check]
+      C3[dep-drift check]
+      AGG[aggregate signals]
+      DP{any signal?}
+      S1[Issue still relevant.]
+      S2[render signals + DP A]
+    end
+    subgraph DevIntegration[skills/dev/SKILL.md]
+      WALK[Step 5 walker]
+      SCAN[scan-state.sh]
+      MAP[invocation map row]
+      MTX[Tier Skip Matrix row]
+    end
+    GH --> P
+    GIT --> C1
+    GREP --> C2
+    DEPS --> C3
+    P --> C1 & C2 & C3
+    C1 & C2 & C3 --> AGG --> DP
+    DP -- no --> S1 --> Return[return → /dev next step]
+    DP -- yes --> S2 --> User[user DP A]
+    SCAN --> WALK
+    WALK --> RecheckSkill
+    MAP -.invokes.-> RecheckSkill
+    MTX -.governs.-> WALK
+    style RecheckSkill fill:#dfe
+    style DevIntegration fill:#fed
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph New[NEW files]
+      NSKILL[skills/recheck/SKILL.md<br/>frontmatter + pipeline + drift logic + DP]
+      NREADME[skills/recheck/README.md<br/>signal types · DP outcomes · usage]
+    end
+    subgraph DevSkill[skills/dev/SKILL.md EDIT]
+      SIGMA[Σ map: add recheck null entry]
+      STEPS[STEPS array: add Frame/recheck row]
+      SKIP[Skip logic: explicit no-skip note]
+      INVK[Invocation map: recheck row]
+      MTX2[Tier Skip Matrix: recheck row run/run/run]
+      PHASE[Phases summary: triage→recheck→frame]
+    end
+    subgraph DevSh[skills/dev/scan-state.sh EDIT]
+      EMIT[emit recheck=session line]
+    end
+    subgraph Docs[DOCS EDIT]
+      DREADME[skills/dev/README.md flow blurb]
+      PREADME[plugins/dev-core/README.md skill table + 32→33]
+      PJSON[plugin.json description 32→33]
+      MJSON[.claude-plugin/marketplace.json description 32→33]
+      RREADME[root README.md 32 skills→33 skills]
+    end
+    NSKILL -.referenced by.-> INVK
+    SIGMA & STEPS & SKIP & INVK & MTX2 & PHASE -.same file.-> DevSkill
+    EMIT -.consumed by.-> SIGMA
+```
+
+## Bootstrap Context
+
+No analysis artifact (F-lite). Reference patterns:
+
+- Skill template: `plugins/dev-core/skills/frame/SKILL.md` (similar shape — gate skill with pipeline table, Exit section, Task Integration block).
+- Adv-skill pattern (for `/recheck` invocation in `/dev`): see `triage` row in `dev/SKILL.md` invocation map.
+- README pattern: `plugins/dev-core/skills/frame/README.md` (Why / Usage / Triggers / How it works).
+- `scan-state.sh` style: per-line `key=value` outputs, no JSON.
+
+## Agents
+
+| Agent instance | Files | Task count |
+|---|---|---|
+| `doc-writer-A` | `plugins/dev-core/skills/recheck/SKILL.md` (new) | 1 |
+| `doc-writer-B` | `plugins/dev-core/skills/recheck/README.md` (new) | 1 |
+| `doc-writer-C` | `plugins/dev-core/skills/dev/SKILL.md` (edit, 6 sections) | 1 |
+| `devops-A` | `plugins/dev-core/skills/dev/scan-state.sh` (edit) | 1 |
+| `doc-writer-D` | `plugins/dev-core/skills/dev/README.md` + `plugins/dev-core/README.md` + `plugins/dev-core/.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` + root `README.md` (skill count bumps + index row) | 1 |
+
+No tester — verification is file-existence + grep + manual smoke. No security-auditor — no auth/validation surface. No architect — pattern is established.
+
+## Wave Structure
+
+2 waves, max 5 parallel agents. Elapsed ~1 session vs ~5 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 5 ∥ | doc-writer-A: T1 · doc-writer-B: T2 · doc-writer-C: T3 · devops-A: T4 · doc-writer-D: T5 |
+| 2 | Wave 1 done | 1 | RED-GATE smoke: T6 |
+
+### Budget
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 create recheck SKILL.md | 1 | judgmental | 6 | — |
+| T2 create recheck README.md | 1 | bounded | 3 | — |
+| T3 edit dev/SKILL.md (6 sections) | 6 | judgmental | 8 | — |
+| T4 edit scan-state.sh | 1 | bounded | 3 | — |
+| T5 edit 5 doc files (counts + index) | 5 | bounded | 8 | — |
+| T6 smoke verify | — | bounded | 4 | — |
+
+**Total estimated ops: 32** — below the 50-op force-split threshold.
+
+## Consistency Report
+
+| Spec criterion | Covered by | Status |
+|---|---|---|
+| SC1 (SKILL.md frontmatter) | T1 | ✓ |
+| SC2 (<5s e2e) | T1 (parallel checks) + T6 smoke | ✓ |
+| SC3 (one-line clean print, no artifact) | T1 | ✓ |
+| SC4 (pipeline DP 4 options) | T1 | ✓ |
+| SC5 (standalone DP 3 options) | T1 | ✓ |
+| SC6 (scan-state recheck=) | T4 + T3 (Σ map) | ✓ |
+| SC7 (walker visits between triage and frame) | T3 | ✓ |
+| SC8 (skip logic returns false; Tier Matrix run/run/run) | T3 | ✓ |
+| SC9 (Update loop bounded to 1 iter) | T1 | ✓ |
+| SC10 (Close → gh close + abort) | T1 | ✓ |
+| SC11 (README signals + DP outcomes) | T2 | ✓ |
+| SC12 (root + plugin README index row) | T5 | ✓ |
+| SC13 (premise validation — deferred integration check) | T6 (smoke run + note for tracking) | partial — manual ongoing |
+
+Uncovered: SC13 ongoing tracking is manual (no automated catch-rate metric in this issue's scope per frame Out-of-Scope).
+Untraced: none.
+Exemptions: SC13's "≥3 runs over 1 month" is not testable in CI; tracked as a follow-up reminder in the cleanup phase.
+
+## Micro-Tasks
+
+### Slice V1 — Standalone /recheck skill
+
+**T1 [P] doc-writer-A — Create `plugins/dev-core/skills/recheck/SKILL.md`** *(judgmental, ~6 ops, 8 min, diff 3)*
+
+- File: `plugins/dev-core/skills/recheck/SKILL.md`
+- Skeleton:
+
+```mdx
+---
+name: recheck
+argument-hint: '[#N | --issue N]'
+description: Drift-check an issue before work begins — fails fast when code has evolved (git-drift, symbol-missing, dep-resolved). Triggers: "recheck" | "is this issue still valid" | "check drift" | "check issue staleness".
+version: 0.1.0
+allowed-tools: Bash, Read, Grep, Glob, Skill, ToolSearch
+---
+
+# Recheck
+
+## Success
+I := signals computed ∧ (¬signals → silent return) ∨ (signals → DP A presented)
+
+Let:
+  N := issue number
+  S := signal set { git-drift, symbol-missing, dep-resolved }
+  M := mode ∈ { pipeline, standalone }
+  DP := decision protocol (see ${CLAUDE_PLUGIN_ROOT}/../shared/references/decision-presentation.md)
+
+## Entry
+/recheck #N            standalone, signal-fire DP has 3 options
+(invoked by /dev)      pipeline, signal-fire DP has 4 options (adds Update)
+
+## Pipeline
+| Step | ID | Required | Notes |
+|------|----|----------|-------|
+| 0 | parse | ✓ | resolve N, detect M |
+| 1 | fetch | ✓ | gh issue view N --json body,createdAt,labels,parent,blockedBy |
+| 2 | extract | ✓ | cited paths, symbols, blocked-by from body |
+| 3 | check | ✓ | run 3 drift checks in parallel |
+| 4 | decide | ✓ | signal-clean → S1 ; signal-fire → S2 + DP |
+
+## Step 3 — Drift checks (parallel)
+git-drift   : git log --since=<createdAt> -- <cited paths> | wc -l > 0
+symbol-drift: ∀ symbol ∈ extracted → grep -r symbol → flag if miss
+dep-drift   : ∀ blocker ∈ blockedBy → gh issue view blocker --json state → flag if closed
+
+## Step 4 — Decide
+∀ signals == ∅ → print "Issue still relevant." (pipeline) or richer summary (standalone) ; exit 0.
+∃ signal → print Signals summary + DP.
+
+Pipeline DP options (4):
+  Proceed anyway         /dev continues, no mutation
+  Update issue first     re-invoke /issue-triage, re-run /recheck once
+                         (signals persist on 2nd run → DP re-presents w/o Update)
+  Close as resolved/obs. gh issue close N --reason completed ; abort /dev
+  Abort                  exit /dev cleanly
+
+Standalone DP options (3): Proceed | Close | Abort  (no Update — no /dev to loop)
+
+## State
+No on-disk artifact. /dev tracks recheck as Σ_s (session-only) like validate, ci-watch.
+
+## Task Integration
+- /dev owns the dev-pipeline task lifecycle externally
+- This skill does NOT update its own dev-pipeline task
+
+## Chain Position
+- Phase: Frame
+- Predecessor: /issue-triage
+- Successor: /frame (F-lite, F-full) or /implement (S, frame skipped)
+- Class: gate (when signals fire), adv (when clean)
+
+## Exit
+- Approved via /dev (clean): print one line → return silently
+- Approved via /dev (Proceed on signals): return → /dev re-scans → next step
+- Update via /dev: invoke skill: "issue-triage" then re-run self once
+- Close: gh issue close + abort
+- Standalone clean: print summary, return
+- Standalone signal: render DP, apply outcome
+
+$ARGUMENTS
+```
+
+- Verify: `test -f plugins/dev-core/skills/recheck/SKILL.md && head -8 plugins/dev-core/skills/recheck/SKILL.md | grep -E '^name: recheck$'`
+- Expected output: `name: recheck`
+- Pattern ref: `plugins/dev-core/skills/frame/SKILL.md`
+- Spec trace: SC1, SC2, SC3, SC4, SC5, SC9, SC10
+- Phase: GREEN
+
+**T2 [P] doc-writer-B — Create `plugins/dev-core/skills/recheck/README.md`** *(bounded, ~3 ops, 5 min, diff 1)*
+
+- File: `plugins/dev-core/skills/recheck/README.md`
+- Skeleton:
+
+```md
+# recheck
+
+Drift-check a GitHub issue before any work begins. Catches stale issues (code evolved, symbols renamed, blockers resolved) before /dev spends time on a premise that no longer holds.
+
+## Why
+Issues age. By the time /dev fires, the fix may already exist, symbols may be gone, or blockers may be resolved. /recheck is the fail-fast guard between /issue-triage and /frame, run for every tier (S, F-lite, F-full) with no skip path.
+
+## Usage
+/recheck #N            standalone — print drift signals, choose Proceed | Close | Abort
+(invoked by /dev)      pipeline mode — 4-option DP with Update issue first
+
+Triggers: "recheck" | "is this issue still valid" | "check drift" | "check issue staleness"
+
+## How it works
+3 deterministic checks run in parallel:
+
+| Signal | What it checks | Means |
+|---|---|---|
+| git-drift | git log --since=<issue.created> on cited paths | code moved in the area |
+| symbol-missing | grep cited symbols/error-strings | identifier vanished |
+| dep-resolved | gh state of every blocked-by issue | dependency closed |
+
+When **all clean**: prints `Issue still relevant.` and returns silently.
+
+When **any fires**: presents a DP. Pipeline mode (via /dev) shows 4 options; standalone mode shows 3:
+
+| Option | Pipeline | Standalone | Effect |
+|---|---|---|---|
+| Proceed anyway | ✓ | ✓ | continue with current premise |
+| Update issue first | ✓ | — | re-run /issue-triage, re-check exactly once |
+| Close as resolved/obsolete | ✓ | ✓ | gh issue close --reason completed + abort |
+| Abort | ✓ | ✓ | exit cleanly, no mutation |
+
+## State
+No on-disk artifact (per frame Out-of-Scope). /dev tracks recheck as session-only state — a new /dev session re-runs the check.
+```
+
+- Verify: `test -f plugins/dev-core/skills/recheck/README.md && grep -q 'git-drift\|symbol-missing\|dep-resolved' plugins/dev-core/skills/recheck/README.md && grep -q 'Update issue first' plugins/dev-core/skills/recheck/README.md`
+- Expected output: matches (exit 0)
+- Pattern ref: `plugins/dev-core/skills/frame/README.md`
+- Spec trace: SC11
+- Phase: GREEN
+
+### Slice V2 — /dev pipeline integration
+
+**T3 [P] doc-writer-C — Edit `plugins/dev-core/skills/dev/SKILL.md`** *(judgmental, ~8 ops, 10 min, diff 3)*
+
+6 distinct edits to the existing file:
+
+1. **Σ map** (Step 1 — Scan State): insert `recheck: null,  # Σ_s only` between `triage:` and `frame:`.
+2. **STEPS array** (Step 5): insert `(Frame, recheck, recheck),` between `(Frame, triage, ...)` and `(Frame, frame, ...)`.
+3. **Skip logic** (Step 4): add explicit note `recheck → false (never skipped — explicit decision per frame #181)` before `default → false`.
+4. **Invocation map** (Step 7): insert new row after `triage`:
+   `| recheck | adv | skill: "recheck", args: "#N" | frame |`
+5. **Tier Skip Matrix**: insert row after `triage`:
+   `| recheck | run | run | run |`
+6. **Phases + Gate Summary**: change `Frame | triage → frame` to `Frame | triage → recheck → frame`. Also update `Step 2b — Build active sequence` ordered list and `Step 3` Phase bar definition (`Frame:{triage,recheck,frame}`).
+
+- File: `plugins/dev-core/skills/dev/SKILL.md`
+- Verify (run all 6):
+
+```bash
+grep -nE 'recheck:\s+null' plugins/dev-core/skills/dev/SKILL.md
+grep -nE '\(Frame,\s+recheck,\s+recheck\)' plugins/dev-core/skills/dev/SKILL.md
+grep -nE 'recheck\s+→ false' plugins/dev-core/skills/dev/SKILL.md
+grep -nE '\|\s+recheck\s+\|\s+adv\s+\|' plugins/dev-core/skills/dev/SKILL.md
+grep -nE '\|\s+recheck\s+\|\s+run\s+\|\s+run\s+\|\s+run\s+\|' plugins/dev-core/skills/dev/SKILL.md
+grep -nE 'triage\s+→\s+recheck\s+→\s+frame' plugins/dev-core/skills/dev/SKILL.md
+```
+
+- Expected output: each grep returns ≥1 line.
+- Pattern ref: existing `frame`, `triage` rows in same file.
+- Spec trace: SC6, SC7, SC8
+- Phase: GREEN
+
+**T4 [P] devops-A — Edit `plugins/dev-core/skills/dev/scan-state.sh`** *(bounded, ~3 ops, 4 min, diff 1)*
+
+- File: `plugins/dev-core/skills/dev/scan-state.sh`
+- Change: between the `# frame` block and the existing `# analyze` block, emit a recheck line. Since recheck has no on-disk artifact, the line is constant `recheck=session` — `/dev` reads this as "always run via session state".
+
+```bash
+# recheck (session-only state — no on-disk artifact)
+echo "recheck=session"
+```
+
+- Verify:
+
+```bash
+bash plugins/dev-core/skills/dev/scan-state.sh 181 add-recheck-phase 2>/dev/null | grep -E '^recheck=session$'
+```
+
+- Expected output: `recheck=session`
+- Pattern ref: existing `# frame` block in same file.
+- Spec trace: SC6
+- Phase: GREEN
+
+### Slice V3 — Docs + marketplace metadata
+
+**T5 [P] doc-writer-D — Bump skill count + add skill index row** *(bounded, ~8 ops total across 5 files, 8 min, diff 2)*
+
+Files + edits:
+
+1. `plugins/dev-core/.claude-plugin/plugin.json` — change `"32 skills"` → `"33 skills"` in `description`.
+2. `.claude-plugin/marketplace.json` — same `32`→`33` in the dev-core entry's `description`.
+3. `plugins/dev-core/README.md` — `32 skills` → `33 skills` (both occurrences: lead paragraph + `## Skills` section header). Add a row to the Skills table:
+   `| recheck | Frame | Drift-check an issue (git/symbol/dep) before /dev work begins. No skip path. |`
+4. `README.md` (root) — change `32 skills` → `33 skills` in the dev-core plugin description (within the Development lifecycle table).
+5. `plugins/dev-core/skills/dev/README.md` — update the "How it works" sequence to mention recheck between triage and frame.
+
+- Verify:
+
+```bash
+grep -c '33 skills' plugins/dev-core/.claude-plugin/plugin.json .claude-plugin/marketplace.json plugins/dev-core/README.md README.md
+grep -cE '^\|\s*`?recheck`?\s*\|' plugins/dev-core/README.md
+grep -ci 'recheck' plugins/dev-core/skills/dev/README.md
+```
+
+- Expected output: counts > 0 for each file; recheck row present in plugins/dev-core/README.md.
+- Pattern ref: existing skill rows in `plugins/dev-core/README.md`.
+- Spec trace: SC12
+- Phase: GREEN
+
+### Slice V1+V2+V3 — RED-GATE sentinel
+
+**T6 devops-A — Smoke validate end-to-end** *(bounded, ~4 ops, 5 min, diff 1)*
+
+After Wave 1, run a smoke check that the integration is wired correctly without actually executing `/dev` on a real issue (which would require human DP responses).
+
+- Verify (composite):
+
+```bash
+# 1. recheck skill present + valid frontmatter
+test -f plugins/dev-core/skills/recheck/SKILL.md
+grep -E '^name: recheck$' plugins/dev-core/skills/recheck/SKILL.md
+
+# 2. /dev SKILL.md has recheck wired in all 6 places
+for pat in 'recheck:\s+null' '\(Frame,\s+recheck,\s+recheck\)' '\|\s+recheck\s+\|\s+adv\s+\|' '\|\s+recheck\s+\|\s+run\s+\|\s+run\s+\|\s+run\s+\|' 'triage\s+→\s+recheck\s+→\s+frame' 'recheck\s+→ false'; do
+  grep -qE "$pat" plugins/dev-core/skills/dev/SKILL.md || { echo "MISSING: $pat" ; exit 1 ; }
+done
+
+# 3. scan-state emits recheck line
+bash plugins/dev-core/skills/dev/scan-state.sh 181 add-recheck-phase 2>/dev/null | grep -q '^recheck=session$'
+
+# 4. Skill index includes recheck
+grep -qE '^\|\s*`?recheck`?\s*\|' plugins/dev-core/README.md
+
+# 5. Count bumped in all 4 metadata files
+for f in plugins/dev-core/.claude-plugin/plugin.json .claude-plugin/marketplace.json plugins/dev-core/README.md README.md; do
+  grep -q '33 skills' "$f" || { echo "Count not bumped in $f" ; exit 1 ; }
+done
+
+echo "RED-GATE: all wiring checks pass"
+```
+
+- Expected output: `RED-GATE: all wiring checks pass`
+- Spec trace: SC1-SC12 (smoke verifies wiring; SC13 deferred to manual ongoing)
+- Phase: RED-GATE
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject
+     blockedBy refs T-numbers within this list. -->
+
+### Wave 1 — no deps, 5 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | doc-writer-A | — | Create skills/recheck/SKILL.md (V1, GREEN) |
+| T2 | doc-writer-B | — | Create skills/recheck/README.md (V1, GREEN) |
+| T3 | doc-writer-C | — | Edit skills/dev/SKILL.md — 6 sections (V2, GREEN) |
+| T4 | devops-A | — | Edit skills/dev/scan-state.sh — emit recheck=session (V2, GREEN) |
+| T5 | doc-writer-D | — | Bump skill count + index row across 5 docs (V3, GREEN) |
+
+### Wave 2 — after Wave 1, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | devops-A | T1,T2,T3,T4,T5 | RED-GATE smoke verify wiring |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 12 — Create skills/recheck/SKILL.md (V1, GREEN)
+- T2: 13 — Create skills/recheck/README.md (V1, GREEN)
+- T3: 14 — Edit skills/dev/SKILL.md — 6 sections (V2, GREEN)
+- T4: 15 — Edit skills/dev/scan-state.sh — emit recheck=session (V2, GREEN)
+- T5: 16 — Bump skill count + add recheck row across 5 docs (V3, GREEN)
+- T6: 17 — RED-GATE smoke verify wiring

--- a/artifacts/specs/181-add-recheck-phase-spec.mdx
+++ b/artifacts/specs/181-add-recheck-phase-spec.mdx
@@ -1,0 +1,146 @@
+---
+title: Add /recheck phase to dev pipeline
+issue: 181
+status: approved
+tier: F-lite
+date: 2026-05-20
+promoted_from: artifacts/frames/181-add-recheck-phase-frame.mdx
+---
+
+## Context
+
+Promoted from frame [`artifacts/frames/181-add-recheck-phase-frame.mdx`](../frames/181-add-recheck-phase-frame.mdx).
+
+`/dev` jumps from `triage → frame` (or `triage → implement` for S-tier) without verifying the issue is still relevant. Aged issues silently produce stale work. Decisions captured in conversation: standalone `/recheck` skill, no skip-logic, informative-when-clean / blocking-when-signals (DP(A) Proceed | Update | Close | Abort), positioned between `triage` and `frame`.
+
+## Goal
+
+Add a `/recheck` skill that runs between `triage` and `frame` in `/dev`, detects issue staleness via deterministic drift signals, and blocks the pipeline via DP(A) when any signal fires.
+
+## Users
+
+- **Primary:** developers running `/dev #N` on aged issues, especially S-tier (no gates).
+- **Secondary:** standalone callers (`/recheck #N` outside `/dev` for ad-hoc validation).
+
+## Expected Behavior
+
+1. User runs `/dev #181` on an issue created 3 weeks ago.
+2. After `/issue-triage` completes, `/dev` invokes `/recheck #181`.
+3. `/recheck` reads issue body + metadata via `gh issue view` (created_at, body, parent/blocked-by links).
+4. Runs 3 drift checks in parallel (deterministic, no LLM):
+   - **git-drift:** `git log --since=<issue.created_at>` on paths/files cited in issue body → count commits.
+   - **symbol-drift:** grep symbols/error-strings cited in body → flag missing (symbol no longer in tree → likely renamed/removed → premise may be invalid).
+   - **dep-drift:** `gh issue view <blocker> --json state` for each `blocked-by` → flag any now closed. **Semantics:** closed blocker = signal regardless of meaning (could be "ready to proceed, re-verify scope" OR "this issue is now moot"). DP(A) surfaces the ambiguity; user decides.
+5. If all checks clean → print `Issue still relevant.` (one line) + return silently. `/dev` proceeds to next step. **No artifact written** (per frame Out-of-Scope: no recheck-log artifact).
+6. If any signal fires → present `## Drift Signals` summary (signal kind + evidence per signal) + DP(A):
+   - **Proceed anyway** — `/dev` continues, no mutation.
+   - **Update issue first** — re-invoke `/issue-triage`, then re-run `/recheck` exactly once. If signals still fire after re-triage, DP(A) re-presents with **Update** removed (force a terminal decision; no infinite loop).
+   - **Close as resolved/obsolete** — `gh issue close N --reason completed` + abort `/dev` (Step 7 marks task `cancelled`).
+   - **Abort** — exit `/dev` cleanly, no issue mutation.
+
+State tracking: `Σ.recheck` is session-only (`Σ_s`), like `validate` and `ci-watch` — no on-disk artifact means re-running `/dev #N` in a new session re-runs `/recheck`. Acceptable: deterministic checks are cheap and fresh state is more valuable than skip-on-resume.
+
+Standalone `/recheck #N` outside `/dev`: same flow, but on signal-clean path prints richer summary (signals checked + counts); on signal-fire path uses identical DP(A) **minus** the **Update issue first** option (no `/dev` context to loop back into — user re-runs `/issue-triage` manually instead).
+
+## Data Model & Consumers
+
+### Data shape (in-memory only)
+
+`RecheckResult` is ephemeral — built during `/recheck` execution, consumed by the DP(A) prompt, then discarded:
+
+- `issue_number: int`
+- `signals: Signal[]` — empty array on clean path
+- `blocking: bool` — `true` iff `signals` non-empty
+
+Each `Signal`:
+- `kind: "git-drift" | "symbol-missing" | "dep-resolved"`
+- `description: string` — one-line summary for DP(A)
+- `evidence: string[]` — commit shas, missing symbol names, closed blocker numbers
+
+No persistence: per frame Out-of-Scope, no `artifacts/rechecks/` is written.
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    GH[gh issue view] -->|body, created_at, labels, parent, blocked-by| RC[/recheck/]
+    GIT[git log --since] -->|commits on cited paths| RC
+    GREP[grep symbols] -->|hit/miss| RC
+    DEPS[gh blocker states] -->|open/closed| RC
+    RC -->|signal-clean| DEV1[/dev next step/]
+    RC -->|signals + DP A| USER{user decides}
+    USER -->|Proceed| DEV2[/dev next step/]
+    USER -->|Update| TRIAGE[/issue-triage re-run/]
+    USER -->|Close| CLOSE[gh issue close]
+    USER -->|Abort| EXIT[exit /dev]
+```
+
+### Consumer summary
+
+| Consumer | Fields consumed | When | Status |
+|---|---|---|---|
+| `/dev` Step 5 walker | `RecheckResult.blocking` | After triage, before frame | this issue |
+| User DP(A) prompt | `RecheckResult.signals[]` | On signal fire | this issue |
+| Standalone caller | full `RecheckResult` (stdout only) | `/recheck #N` outside `/dev` | this issue |
+
+## Breadboard
+
+### Affordances
+
+| ID | Affordance | Type | Handler | Data in | Data out |
+|---|---|---|---|---|---|
+| U1 | `/recheck #N` standalone invoke | Skill entry | parse-args | N | issue context |
+| U2 | `/dev` pipeline step | Pipeline hook | invoke-recheck | N from Σ | RecheckResult |
+| U3 | DP(A) Proceed/Update/Close/Abort | User decision | apply-decision | signals[] | next-action |
+| N1 | gh issue fetch | gh-cli | gh issue view N --json ... | N | body, created_at, labels, parent, blocked-by |
+| N2 | git-drift check | bash | git log --since=<ts> -- <paths> | created_at, paths | commit count |
+| N3 | symbol-drift check | bash | grep -r <symbol> | symbols | hit/miss |
+| N4 | dep-drift check | gh-cli | gh issue view <blocker> --json state | blocker N | open/closed |
+| S1 | signals summary print | output | format-signals | RecheckResult | stdout markdown |
+
+### Wiring
+
+```
+U1 ──┐
+     ├─→ N1 ──┬─→ N2 ──┐
+U2 ──┘        ├─→ N3 ──┼─→ aggregate → if blocking: S1+U3 → apply-decision
+              └─→ N4 ──┘                else: S1 (one-liner) → return
+```
+
+S2 (artifact write) intentionally absent — frame Out-of-Scope.
+
+## Slices
+
+| # | Slice | Demo | Independence |
+|---|---|---|---|
+| 1 | **Standalone `/recheck` skill** — SKILL.md + drift checks (N1+N2+N3+N4) + signals format (S1) + DP(A) (U3, 3 options in standalone mode). Callable as `/recheck #N`. ¬`/dev` integration. | `/recheck #181` runs end-to-end on a real issue, prints signals, accepts DP choice. | Demo-able without touching `/dev`. |
+| 2 | **`/dev` pipeline integration** — Edit `dev/SKILL.md` (Σ entry, STEPS array, no-skip logic, invocation map row, Tier Skip Matrix row, Phases summary, scan-state.sh recheck output). | Run `/dev #181` (or any test issue) and observe `recheck` step fires between `triage` and `frame`. | Builds on Slice 1; doesn't change `/recheck` itself. |
+| 3 | **Docs + index** — `plugins/dev-core/skills/recheck/README.md`, root `README.md` skill table row, optional `plugin.json` skill listing if applicable. | Skill index renders new entry; README explains drift signals + DP outcomes. | Pure docs; independent of code. |
+
+## Success Criteria
+
+- [ ] `/recheck #N` exists as a standalone callable skill (file `plugins/dev-core/skills/recheck/SKILL.md` with valid frontmatter — `name: recheck`, description, allowed-tools).
+- [ ] `/recheck #N` invocation against a real GitHub issue completes in **<5s** end-to-end (deterministic checks, parallel where possible) — matches frame constraint.
+- [ ] When no drift signal fires, `/recheck` prints exactly one informational line (form: `Issue still relevant.` in pipeline mode; richer summary in standalone mode) and exits cleanly with no on-disk artifact.
+- [ ] When any drift signal fires in pipeline mode, `/recheck` presents DP(A) with exactly 4 options: Proceed anyway | Update issue first | Close as resolved/obsolete | Abort.
+- [ ] In standalone mode (`/recheck #N` outside `/dev`), the signal-fire DP(A) presents exactly 3 options (Proceed | Close | Abort — no Update).
+- [ ] `/dev #N` Step 1 (scan-state.sh) emits a `recheck=<state>` line; Σ map records `recheck` as session-only (`Σ_s`, no artifact-based persistence).
+- [ ] `/dev #N` Step 5 walker visits `recheck` immediately after `triage` and immediately before `frame`.
+- [ ] `/dev` skip logic returns `false` for `recheck` for every tier (S, F-lite, F-full) — no path skips it. Tier Skip Matrix in `dev/SKILL.md` shows `recheck` row with `run` in all three tier columns.
+- [ ] **Update issue first** re-invokes `/issue-triage` then re-runs `/recheck` exactly once. If signals still fire on second run, DP(A) re-presents **without** the Update option (forces terminal decision; no infinite loop).
+- [ ] Selecting **Close as resolved/obsolete** invokes `gh issue close N --reason completed` and `/dev` aborts (no further steps run, task marked cancelled).
+- [ ] `plugins/dev-core/skills/recheck/README.md` documents the 3 drift signal types and both DP option sets (pipeline 4-option, standalone 3-option).
+- [ ] Root `README.md` skill index includes the new `recheck` row.
+- [ ] **Premise validation (post-ship integration check):** Across the first ≥3 `/dev` runs on issues aged >7 days (post-merge), at least one run produces a non-clean recheck (signal fires) — confirms the feature is doing real work and not always silent. Tracked manually for the first month; if 0/N runs fire signals after 3 months, revisit per frame failure-mode.
+
+## Pre-check
+
+Self-applied:
+
+| Check | Status | Note |
+|---|---|---|
+| Testable criteria | ✓ | Each `- [ ]` is binary; the premise-validation criterion is a deferred integration check, falsifiable per frame failure-mode. |
+| No dangling refs | ✓ | U1/U2/U3, N1–N4, S1 all appear in Slice 1 or 2. S2 removed (frame Out-of-Scope). |
+| Ambiguity budget | ✓ | 0 `[NEEDS CLARIFICATION]` items. |
+| Slice coverage | ✓ | Every affordance maps to ≥1 slice (U1+U3+N1–N4+S1 → Slice 1; U2 → Slice 2). |
+| Edge completeness | ✓ | DP(A) covers 4 outcomes in pipeline, 3 in standalone; signal-clean path explicit; loop bound capped at 1 Update iteration; dep-drift semantics explicit. |

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-core",
   "version": "0.3.2",
-  "description": "Full development workflow — frame, shape, plan, implement, review, ship. 32 skills, 9 agents, safety hooks.",
+  "description": "Full development workflow — frame, shape, plan, implement, review, ship. 33 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"
   }

--- a/plugins/dev-core/README.md
+++ b/plugins/dev-core/README.md
@@ -22,6 +22,20 @@ Install the plugin:
 claude plugin install dev-core
 ```
 
+### Keeping your install up to date
+
+`dev-core` ships through a hash-keyed cache at `~/.claude/plugins/cache/roxabi-marketplace/dev-core/<hash>/`. When new versions land on `staging`/`main`, pull the latest by either:
+
+```bash
+# preferred — re-installs the plugin from the marketplace
+claude plugin install dev-core
+
+# OR — for contributors with a local clone of roxabi-plugins
+./sync-plugins.sh --local
+```
+
+Without this step, recently-added skills (e.g. `/recheck`) won't appear in your trigger list even though they're in the repo.
+
 ## Getting Started
 
 After installing, run init to configure your project:

--- a/plugins/dev-core/README.md
+++ b/plugins/dev-core/README.md
@@ -1,6 +1,6 @@
 # dev-core
 
-Full development lifecycle orchestrator for Roxabi projects. Covers framing, analysis, specification, planning, implementation, review, and shipping. Opinionated workflow with 32 skills, 9 specialized agents, and safety hooks.
+Full development lifecycle orchestrator for Roxabi projects. Covers framing, analysis, specification, planning, implementation, review, and shipping. Opinionated workflow with 33 skills, 9 specialized agents, and safety hooks.
 
 ## Prerequisites
 
@@ -56,7 +56,7 @@ Where `#N` is a GitHub issue number. The orchestrator scans existing artifacts, 
 
 ## Skills
 
-32 skills organized by workflow phase:
+33 skills organized by workflow phase:
 
 | Skill | Phase | Description |
 |-------|-------|-------------|
@@ -69,6 +69,7 @@ Where `#N` is a GitHub issue number. The orchestrator scans existing artifacts, 
 | `seed-docs` | Setup | Populates scaffolded architecture/standards docs with real content — reads CLAUDE.md for conventions, optionally scans codebase (entry points, import graph, naming patterns), fills TODO stubs, writes AI Quick Reference sections. Idempotent: skips already-populated files |
 | `seed-community` | Setup | Bootstraps OSS community health files — CONTRIBUTING.md, LICENSE, SECURITY.md, CODE_OF_CONDUCT.md, README sections (Getting Started, Badges), `.github/PULL_REQUEST_TEMPLATE.md`, issue templates. Reads project metadata + CLAUDE.md; generates missing files idempotently |
 | `dev` | Orchestrator | Routes issues through the full workflow |
+| `recheck` | Frame | Drift-check an issue (git-drift, symbol-missing, dep-resolved) before /dev work begins. Runs between /issue-triage and /frame for every tier — no skip path. Signal-clean returns silently; signal-fire blocks with DP(A) (Proceed/Update/Close/Abort) |
 | `frame` | Frame | Creates initial feature frame from issue |
 | `analyze` | Shape | Deep analysis with expert consultation |
 | `consensus` | Shape | Multi-expert panel — spawns 3 domain agents (architect + 2 context-selected) to debate and agree on best long-term solution |

--- a/plugins/dev-core/skills/dev/README.md
+++ b/plugins/dev-core/skills/dev/README.md
@@ -16,7 +16,7 @@ Single entry point for the full dev lifecycle — scan artifacts, detect state, 
 
 ## How it works
 
-`/dev` scans existing artifacts (frames, analyses, specs, plans, worktrees, PRs) to determine where you left off, then drives the pipeline step by step without re-running completed work.
+`/dev` scans existing artifacts (frames, analyses, specs, plans, worktrees, PRs) to determine where you left off, then drives the pipeline step by step without re-running completed work. Between issue triage and framing, /dev runs /recheck — a drift check that catches stale issues (git/symbol/dep drift) before any artifact is written.
 
 Pipeline phases:
 

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -59,6 +59,7 @@ gh issue list --search "{text}" --json number,title,state --jq '.[:3]'
 
 | Step | Required artifacts |
 |------|-------------------|
+| recheck | issue (triage) — no on-disk prereq; always runs from session state |
 | frame | issue (triage) |
 | analyze | `artifacts/frames/{N}-{slug}-frame.mdx` or `artifacts/frames/{slug}-frame.mdx` (approved) |
 | spec | `artifacts/frames/{slug}-frame.mdx` or `artifacts/analyses/{N}-{slug}-analysis.mdx` |
@@ -162,6 +163,7 @@ Status: `✓ {name}` (done) | `skipped` | `pending` | `→ next`.
 ```
 should_skip(step, τ, Σ):
   triage   ∧ Σ.triage                    → skip (already done)
+  recheck                                 → false (never skipped — explicit decision per frame #181)
   frame    ∧ τ == S                       → skip
   analyze  ∧ τ ∈ {S, F-lite}             → skip (frame sufficient)
   spec     ∧ τ == S                       → skip
@@ -170,7 +172,6 @@ should_skip(step, τ, Σ):
   fix      ∧ (Σ.fix ∨ Σ_s.fix)            → skip (fixes already applied)
   promote                                  → skip (/promote is standalone staging→main; ¬auto-triggered by /dev)
   cleanup  ∧ ¬has_stale(N)               → skip
-  recheck                                 → false (never skipped — explicit decision per frame #181)
   default                                 → false
 ```
 
@@ -243,8 +244,8 @@ audit ∧ S* ∈ critical → reasoning audit per [reasoning-audit.md](${CLAUDE_
 
 | Step | Class | Skill invocation | On success → |
 |------|-------|------------------|--------------|
-| triage | adv | `skill: "issue-triage", args: "N"` | frame |
-| recheck | adv | `skill: "recheck", args: "#N"` | frame |
+| triage | adv | `skill: "issue-triage", args: "N"` | recheck |
+| recheck | adv | `skill: "recheck", args: "--from-dev #N"` | frame |
 | frame | gate | `skill: "frame", args: "--issue N"` | analyze (F-full) ∨ spec (F-lite) |
 | analyze | adv | `skill: "analyze", args: "--issue N"` | spec |
 | spec | gate | `skill: "spec", args: "--issue N"` | plan |

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -79,6 +79,7 @@ bash ${CLAUDE_SKILL_DIR}/scan-state.sh {N} {slug}
 
 Σ = {
   triage:    issue ∃,
+  recheck:   null,       # Σ_s only — runs every session, no on-disk state
   frame:     φ ∃ ∧ φ.status == 'approved',
   analyze:   analysis artifact ∃,
   spec:      spec artifact ∃,
@@ -113,7 +114,7 @@ Claude Code task list drives in-session progress for the dev pipeline. Treat it 
 
 Ordered step list:
 ```
-triage → frame → analyze → spec → plan → implement → pr →
+triage → recheck → frame → analyze → spec → plan → implement → pr →
 ci-watch → validate → review → fix → promote → cleanup
 ```
 
@@ -152,7 +153,7 @@ Wire dependencies sequentially — ∀ i > 0: `TaskUpdate(task[i].id, addBlocked
 → Next: {S*} — {one-line description}
 ```
 
-Bar: `██`=done/skipped, `░░`=pending. Phases: Frame:{triage,frame} | Shape:{analyze,spec} | Build:{plan,implement,pr} | Verify:{ci-watch,validate,review,fix} | Ship:{promote,cleanup}
+Bar: `██`=done/skipped, `░░`=pending. Phases: Frame:{triage,recheck,frame} | Shape:{analyze,spec} | Build:{plan,implement,pr} | Verify:{ci-watch,validate,review,fix} | Ship:{promote,cleanup}
 
 Status: `✓ {name}` (done) | `skipped` | `pending` | `→ next`.
 
@@ -169,6 +170,7 @@ should_skip(step, τ, Σ):
   fix      ∧ (Σ.fix ∨ Σ_s.fix)            → skip (fixes already applied)
   promote                                  → skip (/promote is standalone staging→main; ¬auto-triggered by /dev)
   cleanup  ∧ ¬has_stale(N)               → skip
+  recheck                                 → false (never skipped — explicit decision per frame #181)
   default                                 → false
 ```
 
@@ -179,6 +181,7 @@ should_skip(step, τ, Σ):
 ```
 STEPS = [
   (Frame,  triage,    issue-triage),
+  (Frame,  recheck,   recheck),
   (Frame,  frame,     frame),
   (Shape,  analyze,   analyze),
   (Shape,  spec,      spec),
@@ -241,6 +244,7 @@ audit ∧ S* ∈ critical → reasoning audit per [reasoning-audit.md](${CLAUDE_
 | Step | Class | Skill invocation | On success → |
 |------|-------|------------------|--------------|
 | triage | adv | `skill: "issue-triage", args: "N"` | frame |
+| recheck | adv | `skill: "recheck", args: "#N"` | frame |
 | frame | gate | `skill: "frame", args: "--issue N"` | analyze (F-full) ∨ spec (F-lite) |
 | analyze | adv | `skill: "analyze", args: "--issue N"` | spec |
 | spec | gate | `skill: "spec", args: "--issue N"` | plan |
@@ -282,7 +286,7 @@ adv → re-scan → Step 7 immediately.
 
 | Phase | Steps | Gate after |
 |-------|-------|-----------|
-| Frame | triage → frame | frame approval (status: approved) |
+| Frame | triage → recheck → frame | frame approval (status: approved) |
 | Shape | analyze → spec | spec approval |
 | Build | plan → implement → pr | plan approval (then auto-chains implement → pr) |
 | Verify | ci-watch → validate → review → fix | post-review: fix/merge/stop. Merge = feature→staging (via /code-review Phase 8). |
@@ -293,6 +297,7 @@ adv → re-scan → Step 7 immediately.
 | Step | S | F-lite | F-full |
 |------|---|--------|--------|
 | triage | run | run | run |
+| recheck | run | run | run |
 | frame | skip | run + gate | run + gate |
 | analyze | skip | skip | run |
 | spec | skip | run + gate | run + gate |

--- a/plugins/dev-core/skills/dev/scan-state.sh
+++ b/plugins/dev-core/skills/dev/scan-state.sh
@@ -15,7 +15,9 @@ FRAME=$(ls artifacts/frames/ 2>/dev/null | grep -iE "^${N}-${SLUG}|^${SLUG}" | h
 [ -n "$FRAME" ] && echo "frame=$FRAME" || echo "frame=false"
 
 # recheck (session-only state — no on-disk artifact, /dev tracks via Σ_s)
-echo "recheck=session"
+# Value is always `null` (sentinel); /dev never parses it for truthiness — recheck always
+# runs via Σ_s (see Step 1 — Scan State in dev/SKILL.md). Line exists for parser uniformity.
+echo "recheck=null"
 
 # analyze
 ANALYZE=$(ls artifacts/analyses/ 2>/dev/null | grep -E "^${N}-|${SLUG}" | head -1)

--- a/plugins/dev-core/skills/dev/scan-state.sh
+++ b/plugins/dev-core/skills/dev/scan-state.sh
@@ -14,6 +14,9 @@ gh issue view "$N" --json state 2>/dev/null \
 FRAME=$(ls artifacts/frames/ 2>/dev/null | grep -iE "^${N}-${SLUG}|^${SLUG}" | head -1)
 [ -n "$FRAME" ] && echo "frame=$FRAME" || echo "frame=false"
 
+# recheck (session-only state — no on-disk artifact, /dev tracks via Σ_s)
+echo "recheck=session"
+
 # analyze
 ANALYZE=$(ls artifacts/analyses/ 2>/dev/null | grep -E "^${N}-|${SLUG}" | head -1)
 [ -n "$ANALYZE" ] && echo "analyze=$ANALYZE" || echo "analyze=false"

--- a/plugins/dev-core/skills/recheck/README.md
+++ b/plugins/dev-core/skills/recheck/README.md
@@ -48,3 +48,12 @@ The **Update issue first** option is not available in standalone mode because th
 ## State
 
 No on-disk artifact (per frame Out-of-Scope). Session-only tracking inside `/dev` (`Σ_s`), the same pattern used by `validate` and `ci-watch`. Starting a new `/dev` session on the same issue re-runs the check fresh — this is intentional, as deterministic checks are cheap and fresh state is more reliable than stale cached results.
+
+## Effectiveness tracking
+
+`/recheck` only earns its place in the pipeline if it actually catches stale issues. The original frame defines two checkpoints:
+
+- **Success in 6 months:** at least one stale issue caught per month before `/implement` runs; zero S-tier issues silently re-implementing already-fixed bugs.
+- **Revisit trigger (3-month window):** if `/recheck` fires zero signals across three months of usage, **or** users skip past the prompt more than 80% of the time when signals fire, the cost-benefit no longer holds — re-open the design.
+
+Tracking is **manual**: no metric is written to disk by design (no recheck-log artifact). Operators should periodically grep recent `/dev` runs for "Drift Signals" appearances and note skip-rate informally. If the revisit trigger fires, open an issue to re-evaluate.

--- a/plugins/dev-core/skills/recheck/README.md
+++ b/plugins/dev-core/skills/recheck/README.md
@@ -1,0 +1,50 @@
+# recheck
+
+Drift-check a GitHub issue before any work begins. Catches stale issues (code evolved, symbols renamed, blockers resolved) before `/dev` spends time on a premise that no longer holds.
+
+## Why
+
+Issues age. By the time `/dev` fires, the fix may already exist, symbols may have been renamed or removed, or blocking dependencies may have closed — making the original premise invalid or redundant.
+
+The riskiest path is S-tier: `/dev` jumps straight from triage to implementation with no intermediate gates (frame, analyze, spec, and plan are all skipped). Without `/recheck`, a stale S-tier issue produces committed work on a dead premise with no checkpoint to catch it.
+
+`/recheck` is the fail-fast guard between `/issue-triage` and `/frame`, and it runs for every tier (S, F-lite, F-full) with no skip path.
+
+## Usage
+
+```
+/recheck #N
+```
+
+Called standalone, `/recheck` runs all three drift checks, then presents a 3-option decision prompt (Proceed | Close | Abort) if any signal fires.
+
+When invoked by `/dev` as part of the pipeline, the same checks run but the decision prompt includes a fourth option — **Update issue first** — which re-runs `/issue-triage` and then re-runs `/recheck` exactly once. If signals still fire on the second run, the Update option is removed and the user must choose a terminal outcome.
+
+Triggers: `"recheck"` | `"is this issue still valid"` | `"check drift"` | `"check issue staleness"`
+
+## How it works
+
+Three deterministic checks run in parallel (no LLM calls):
+
+| Signal | What it checks | Means |
+|---|---|---|
+| git-drift | `git log --since=<issue.created_at>` on file paths cited in the issue body | Code has moved in the area the issue describes |
+| symbol-missing | `grep` for symbols or error strings cited in the issue body | An identifier the issue references no longer exists in the tree |
+| dep-resolved | `gh issue view <blocker> --json state` for each `blocked-by` link | A dependency the issue was waiting on is now closed |
+
+When **all checks are clean**: prints `Issue still relevant.` (one line in pipeline mode; a richer summary with signal counts in standalone mode) and returns silently with no artifact written.
+
+When **any signal fires**: prints a `## Drift Signals` summary listing each signal kind and its evidence (commit SHAs, missing symbol names, closed blocker numbers), then presents a decision prompt:
+
+| Option | Pipeline | Standalone | Effect |
+|---|---|---|---|
+| Proceed anyway | ✓ | ✓ | Continue with the current premise; `/dev` moves to the next step |
+| Update issue first | ✓ | — | Re-run `/issue-triage`, then re-run `/recheck` exactly once |
+| Close as resolved/obsolete | ✓ | ✓ | `gh issue close N --reason completed` and abort `/dev` |
+| Abort | ✓ | ✓ | Exit `/dev` cleanly; no issue mutation |
+
+The **Update issue first** option is not available in standalone mode because there is no `/dev` context to loop back into — run `/issue-triage` manually and then call `/recheck #N` again.
+
+## State
+
+No on-disk artifact (per frame Out-of-Scope). Session-only tracking inside `/dev` (`Σ_s`), the same pattern used by `validate` and `ci-watch`. Starting a new `/dev` session on the same issue re-runs the check fresh — this is intentional, as deterministic checks are cheap and fresh state is more reliable than stale cached results.

--- a/plugins/dev-core/skills/recheck/SKILL.md
+++ b/plugins/dev-core/skills/recheck/SKILL.md
@@ -64,17 +64,24 @@ Note: `gh issue view` does not expose `parent` or `blocked-by` as structured JSO
 
 ## Step 2 — Extract Refs from Body
 
-From `body`, regex-extract:
+From `body`, regex-extract THEN validate. Extraction is loose; **validation is strict** — drop anything that fails.
 
-| Kind          | Pattern                                                  | Example match         |
-|---------------|----------------------------------------------------------|-----------------------|
-| cited paths   | `` `path/to/file.ext` `` or bare `path/to/file.ext`      | `src/core/runner.ts`  |
-| symbols       | CamelCase identifiers, `function_names`, error strings   | `WorktreeSetup`, `run_phase` |
-| blocked-by Ns | `blocked by #(\d+)`, `blocks #(\d+)`, `parent: #(\d+)`, `closes #(\d+)` | `#179` |
+| Kind          | Extraction pattern                                       | Validation (required)                                | Example match         |
+|---------------|----------------------------------------------------------|------------------------------------------------------|-----------------------|
+| cited paths   | `` `path/to/file.ext` `` or bare `path/to/file.ext`      | match `^[A-Za-z0-9_./-]+$` ∧ ¬contains `..` segment ∧ ¬absolute (`^/`) — reject otherwise | `src/core/runner.ts`  |
+| symbols       | CamelCase identifiers, `function_names`                  | match `^[A-Za-z_][A-Za-z0-9_]{0,63}$` — reject anything else (incl. flags, paths, error strings with quotes/spaces) | `WorktreeSetup`, `run_phase` |
+| blocked-by Ns | `blocked by #(\d+)`, `blocks #(\d+)`, `parent: #(\d+)`, `closes #(\d+)` | digits only (regex already enforces); dedup; **cap at 20** (warn `dep-drift: capped at 20 blockers (body contained N)` if exceeded) | `#179` |
 
-∅ cited paths → git-drift falls back to entire repo (all commits since createdAt).
-∅ symbols → symbol-drift is a no-op.
-∅ blocked-by → dep-drift is a no-op.
+**Validation rationale:**
+- Symbols flow into `grep` arguments — without the allowlist, a body-symbol like `-e '/etc/passwd'` or `$(id)` would inject as a grep flag or command substitution.
+- Paths flow into `git log -- <paths>` — without the `..` ban + absolute-path ban, traversal patterns leak outside the repo.
+- Blocker numbers flow into `gh issue view <N>` — the `\d+` regex enforces numeric, but the **dedup + cap** prevents an issue body with 200 `closes #N` references from triggering 200 sequential `gh` API calls.
+
+Loose extraction (e.g. picking up an "error string" candidate) then strict validation = silently drop the candidate, do not abort.
+
+∅ validated cited paths → git-drift falls back to entire repo (all commits since createdAt).
+∅ validated symbols → symbol-drift is a no-op.
+∅ validated blocked-by → dep-drift is a no-op.
 
 ## Step 3 — Drift Checks (parallel, deterministic)
 
@@ -96,8 +103,10 @@ Signal fires if count > 0.
 ### symbol-drift
 
 ```bash
-for sym in <extracted_symbols>; do
-  grep -rq "$sym" --include='*.ts' --include='*.tsx' --include='*.js' \
+# $sym already validated in Step 2 to match ^[A-Za-z_][A-Za-z0-9_]{0,63}$
+# Use grep -F (fixed-string) + -- end-of-options marker for defense-in-depth.
+for sym in <validated_symbols>; do
+  grep -rqF -- "$sym" --include='*.ts' --include='*.tsx' --include='*.js' \
        --include='*.py' --include='*.sh' --include='*.md' . \
     || echo "missing: $sym"
 done
@@ -109,13 +118,20 @@ Signal fires per missing symbol.
 ### dep-drift
 
 ```bash
-for blocker in <extracted_blocker_numbers>; do
-  state=$(gh issue view "$blocker" --json state --jq '.state' 2>/dev/null)
-  [ "$state" = "CLOSED" ] && echo "closed: #$blocker"
+# $blocker already validated in Step 2 to be numeric, deduped, and capped at 20.
+# Capture stderr explicitly to distinguish "issue is open" from "API error" —
+# silently treating API errors as "not closed" would mask the dep-drift signal.
+for blocker in <validated_blockers>; do
+  if ! out=$(gh issue view "$blocker" --json state --jq '.state' 2>&1); then
+    echo "dep-drift: error fetching #$blocker — skipped ($out)" >&2
+    continue
+  fi
+  [ "$out" = "CLOSED" ] && echo "closed: #$blocker"
 done
 ```
 
 Signal fires per closed blocker. Semantics: closed blocker = signal regardless of meaning (could be "ready to proceed, re-verify scope" OR "this issue is now moot") — DP(A) surfaces the ambiguity; user decides.
+API failures (auth, network, rate-limit, repo-not-found) are surfaced as warnings on stderr rather than silently swallowed — operators see "skipped" entries and can re-run if needed.
 `kind: "dep-resolved"` | `description: "blocker #$blocker is now closed"` | `evidence: ["#$blocker"]`
 
 ## Step 4 — Decide
@@ -189,7 +205,7 @@ Recommended: Option 1 or 3 — depends on signal severity
 | Option               | Effect                                                                                    |
 |----------------------|-------------------------------------------------------------------------------------------|
 | **Proceed anyway**   | Return exit 0. In pipeline, `/dev` re-scans and continues to next step.                  |
-| **Update issue first** | `Skill: "issue-triage", args: "N"` → then re-run self with `--from-dev --update-iter=2 #N`. On 2nd run, omit Update from DP (loop bound = 1 iteration). |
+| **Update issue first** | `Skill: "issue-triage", args: "N"` → then re-run self with `--from-dev --update-iter=2 #N`. On 2nd run, omit Update from DP (loop bound = 1 iteration). **Note on task state:** `/dev` has already marked its `triage` task `completed` in the prior Step 8 cycle and does not re-mark it during this in-skill re-invocation. The triage task remains `completed` in `/dev`'s task list — by design, since recheck owns the side-channel refinement, not `/dev`. The actual triage work is re-executed and its effects (label changes, re-classification) take hold immediately; only the task-list flag is stale, and that has no downstream consumer. |
 | **Close as resolved/obsolete** | `gh issue close N --reason completed --comment "Closed by /recheck — drift signals indicated issue is no longer applicable."` → exit with abort signal so `/dev` marks task cancelled. |
 | **Abort**            | Exit cleanly. No mutation. `/dev` halts cleanly.                                         |
 
@@ -213,7 +229,7 @@ No on-disk artifact. `/dev` tracks recheck as Σ_s (session-only) like `validate
 - **Phase:** Frame
 - **Predecessor:** `/issue-triage`
 - **Successor:** `/frame` (F-lite, F-full) ∨ `/implement` (S, frame skipped)
-- **Class:** `adv` (when clean — passes through) / `gate` (when signals fire — DP blocks progress)
+- **Class:** `adv` — `/dev`'s type system is single-valued per step (`gate ∈ {frame, spec, plan}`, all others `adv`). The DP rendered on signal-fire is **skill-internal**: `/recheck` self-manages the blocking decision the same way `/validate` and `/ci-watch` do when they surface failures. From `/dev`'s perspective, `/recheck` is always `adv`.
 
 ## Exit
 

--- a/plugins/dev-core/skills/recheck/SKILL.md
+++ b/plugins/dev-core/skills/recheck/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: recheck
+argument-hint: '[#N | --issue N]'
+description: Drift-check an issue before work begins — fails fast when code has evolved (git-drift, symbol-missing, dep-resolved). Triggers: "recheck" | "is this issue still valid" | "check drift" | "check issue staleness".
+version: 0.1.0
+allowed-tools: Bash, Read, Grep, Glob, Skill, ToolSearch
+---
+
+# Recheck
+
+## Success
+
+I := signals computed ∧ (¬signals → silent return) ∨ (signals → DP A presented)
+
+Let:
+  N  := issue number
+  S  := signal set { git-drift, symbol-missing, dep-resolved }
+  M  := mode ∈ { pipeline, standalone }
+  DP := decision protocol (see `${CLAUDE_PLUGIN_ROOT}/../shared/references/decision-presentation.md`)
+
+Drift-check N against 3 deterministic signals (no LLM); block pipeline via DP(A) when S ≠ ∅.
+Standalone-safe: callable without `/dev`. Invoked by `/dev` between `triage` and `frame`.
+
+## Entry
+
+```
+/recheck #N            standalone — signal-fire DP has 3 options (Proceed | Close | Abort)
+(invoked by /dev)      pipeline  — signal-fire DP has 4 options (adds Update issue first)
+```
+
+## Pipeline
+
+| Step | ID      | Required | Notes                                          |
+|------|---------|----------|------------------------------------------------|
+| 0    | parse   | ✓        | resolve N, detect M, check `--update-iter` flag |
+| 1    | fetch   | ✓        | `gh issue view N --json number,title,body,labels,createdAt` |
+| 2    | extract | ✓        | cited paths, symbols, blocked-by numbers from body |
+| 3    | check   | ✓        | run 3 drift checks (parallel, deterministic)   |
+| 4    | decide  | ✓        | S == ∅ → silent return ; S ≠ ∅ → DP(A)        |
+
+## Step 0 — Parse + Detect Mode
+
+Resolve N from:
+- `#N` positional arg → strip `#`
+- `--issue N` flag
+- `$ARGUMENTS` (bare number)
+
+Detect M:
+- `--from-dev` flag present → `pipeline`
+- else → `standalone`
+
+Check `--update-iter=2` flag: ∃ → this is the 2nd run after Update; omit **Update issue first** from DP even if signals fire.
+
+Issue N ¬∃ (gh returns 404) → print `Error: issue #N not found.` + exit 1.
+
+## Step 1 — Fetch Issue
+
+```bash
+gh issue view N --json number,title,body,labels,createdAt \
+  --jq '{number:.number, title:.title, body:.body, labels:[.labels[].name], createdAt:.createdAt}'
+```
+
+Note: `gh issue view` does not expose `parent` or `blocked-by` as structured JSON fields. Primary approach: grep body for `blocked by #N`, `blocks #N`, `parent: #N`, `closes #N` patterns (Step 2). Secondary: `gh api repos/{owner}/{repo}/issues/N/sub_issues` if sub-issue API is available.
+
+## Step 2 — Extract Refs from Body
+
+From `body`, regex-extract:
+
+| Kind          | Pattern                                                  | Example match         |
+|---------------|----------------------------------------------------------|-----------------------|
+| cited paths   | `` `path/to/file.ext` `` or bare `path/to/file.ext`      | `src/core/runner.ts`  |
+| symbols       | CamelCase identifiers, `function_names`, error strings   | `WorktreeSetup`, `run_phase` |
+| blocked-by Ns | `blocked by #(\d+)`, `blocks #(\d+)`, `parent: #(\d+)`, `closes #(\d+)` | `#179` |
+
+∅ cited paths → git-drift falls back to entire repo (all commits since createdAt).
+∅ symbols → symbol-drift is a no-op.
+∅ blocked-by → dep-drift is a no-op.
+
+## Step 3 — Drift Checks (parallel, deterministic)
+
+Run all 3 checks concurrently. Each emits 0 or more signal entries.
+
+### git-drift
+
+```bash
+created_at=$(gh issue view N --json createdAt --jq '.createdAt')
+# If cited paths extracted:
+git log --since="$created_at" --oneline -- path/to/cited/file.ext ... | wc -l
+# If ∅ cited paths (fallback: whole repo):
+git log --since="$created_at" --oneline | wc -l
+```
+
+Signal fires if count > 0.
+`kind: "git-drift"` | `description: "N commits on cited paths since issue created"` | `evidence: [sha list]`
+
+### symbol-drift
+
+```bash
+for sym in <extracted_symbols>; do
+  grep -rq "$sym" --include='*.ts' --include='*.tsx' --include='*.js' \
+       --include='*.py' --include='*.sh' --include='*.md' . \
+    || echo "missing: $sym"
+done
+```
+
+Signal fires per missing symbol.
+`kind: "symbol-missing"` | `description: "symbol '$sym' not found in tree"` | `evidence: ["$sym"]`
+
+### dep-drift
+
+```bash
+for blocker in <extracted_blocker_numbers>; do
+  state=$(gh issue view "$blocker" --json state --jq '.state' 2>/dev/null)
+  [ "$state" = "CLOSED" ] && echo "closed: #$blocker"
+done
+```
+
+Signal fires per closed blocker. Semantics: closed blocker = signal regardless of meaning (could be "ready to proceed, re-verify scope" OR "this issue is now moot") — DP(A) surfaces the ambiguity; user decides.
+`kind: "dep-resolved"` | `description: "blocker #$blocker is now closed"` | `evidence: ["#$blocker"]`
+
+## Step 4 — Decide
+
+### S == ∅ (no signals)
+
+- **Pipeline mode (M == pipeline):**
+  Print exactly: `Issue still relevant.`
+  Return silently. `/dev` proceeds to next step.
+
+- **Standalone mode (M == standalone):**
+  Print richer summary:
+  ```
+  Issue #N still relevant.
+  Checks: git-drift (0 commits) | symbol-drift (all found) | dep-drift (no closed blockers)
+  ```
+  Exit 0.
+
+### S ≠ ∅ (signals fired)
+
+Render `## Drift Signals` block:
+
+```
+## Drift Signals — Issue #N
+
+| Kind           | Description                          | Evidence             |
+|----------------|--------------------------------------|----------------------|
+| git-drift      | 12 commits on cited paths since...   | abc1234, def5678 ... |
+| symbol-missing | symbol 'WorktreeSetup' not found     | WorktreeSetup        |
+| dep-resolved   | blocker #179 is now closed           | #179                 |
+```
+
+Then present DP(A):
+
+**Pipeline DP (4 options — M == pipeline ∧ ¬--update-iter=2):**
+
+```
+── Decision: Issue #N drift detected ──
+Context:     <signal count> signal(s) fired (see ## Drift Signals above)
+Target:      decide whether to continue, update, close, or abort
+Path:        executed immediately after choice
+
+Options:
+  1. Proceed anyway        — continue, current premise accepted as-is
+  2. Update issue first    — re-invoke /issue-triage, then re-run /recheck once
+  3. Close as resolved/obsolete — gh issue close N --reason completed ; abort /dev
+  4. Abort                 — exit /dev cleanly, no mutation
+Recommended: Option 1 or 2 — depends on signal severity
+```
+
+**Pipeline DP on 2nd run (M == pipeline ∧ --update-iter=2):**
+Same block, but Option 2 (Update issue first) is OMITTED. Forces terminal decision. No infinite loop.
+
+**Standalone DP (3 options — M == standalone):**
+
+```
+── Decision: Issue #N drift detected ──
+Context:     <signal count> signal(s) fired (see ## Drift Signals above)
+Target:      decide whether to continue, close, or abort
+Path:        executed immediately after choice
+
+Options:
+  1. Proceed    — continue with current premise
+  2. Close as resolved/obsolete — gh issue close N --reason completed
+  3. Abort      — exit cleanly, no mutation
+Recommended: Option 1 or 3 — depends on signal severity
+```
+
+## DP Outcomes — Implementation
+
+| Option               | Effect                                                                                    |
+|----------------------|-------------------------------------------------------------------------------------------|
+| **Proceed anyway**   | Return exit 0. In pipeline, `/dev` re-scans and continues to next step.                  |
+| **Update issue first** | `Skill: "issue-triage", args: "N"` → then re-run self with `--from-dev --update-iter=2 #N`. On 2nd run, omit Update from DP (loop bound = 1 iteration). |
+| **Close as resolved/obsolete** | `gh issue close N --reason completed --comment "Closed by /recheck — drift signals indicated issue is no longer applicable."` → exit with abort signal so `/dev` marks task cancelled. |
+| **Abort**            | Exit cleanly. No mutation. `/dev` halts cleanly.                                         |
+
+## State
+
+No on-disk artifact. `/dev` tracks recheck as Σ_s (session-only) like `validate`, `ci-watch`. Re-running `/dev #N` in a new session re-runs `/recheck` — acceptable: deterministic checks are cheap and fresh state is more valuable than skip-on-resume.
+
+`RecheckResult` is ephemeral — built during execution, consumed by DP(A) prompt, then discarded:
+- `issue_number: int`
+- `signals: Signal[]` — empty on clean path; `Signal` = { `kind`, `description`, `evidence[]` }
+- `blocking: bool` — `true` iff `signals` non-empty
+
+## Task Integration
+
+- `/dev` owns the dev-pipeline task lifecycle externally
+- This skill does NOT update its own dev-pipeline task
+- Sub-tasks created: none
+
+## Chain Position
+
+- **Phase:** Frame
+- **Predecessor:** `/issue-triage`
+- **Successor:** `/frame` (F-lite, F-full) ∨ `/implement` (S, frame skipped)
+- **Class:** `adv` (when clean — passes through) / `gate` (when signals fire — DP blocks progress)
+
+## Exit
+
+| Path                              | Effect                                                                 |
+|-----------------------------------|------------------------------------------------------------------------|
+| Via `/dev` — clean                | Print `Issue still relevant.` → return silently → `/dev` continues     |
+| Via `/dev` — Proceed on signals   | Return exit 0 → `/dev` re-scans → next step                           |
+| Via `/dev` — Update issue first   | Invoke `issue-triage` → re-run self once (`--update-iter=2`)          |
+| Via `/dev` — Close                | `gh issue close N` → exit with abort signal → `/dev` marks cancelled  |
+| Via `/dev` — Abort                | Exit cleanly, no mutation → `/dev` halts                              |
+| Standalone — clean                | Print richer summary (counts per check) → exit 0                      |
+| Standalone — signal               | Render `## Drift Signals` + 3-option DP → apply outcome               |
+
+## Edge Cases
+
+- ∅ cited paths ∧ ∅ symbols ∧ ∅ blockers in body → git-drift uses entire repo since `createdAt` (commit count); symbol-drift + dep-drift are no-ops.
+- Issue ¬∃ (gh 404) → print `Error: issue #N not found.` + exit 1.
+- `--update-iter=2` on a clean 2nd run → print `Issue still relevant (re-verified after triage update).` + return.
+- `createdAt` parse failure → fallback to `--since="1 year ago"` + warn: `Warning: could not parse issue creation date; using 1-year fallback.`
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

- New `/recheck` skill: drift-checks an issue before any work begins via 3 deterministic parallel checks — `git-drift` (commits on cited paths since issue.created_at), `symbol-missing` (cited symbols no longer in tree), `dep-resolved` (blocked-by issues now closed).
- Integrated into `/dev` pipeline between `/issue-triage` and `/frame` — runs for **every tier** (S, F-lite, F-full) with **no skip path**. S-tier path (which previously raced `triage → implement`) now has explicit staleness validation.
- Signal-clean → one-line `Issue still relevant.` + silent continue. Signal-fire → DP(A) `Proceed | Update issue first | Close as resolved/obsolete | Abort`. Standalone mode (`/recheck #N` outside `/dev`) omits `Update`.
- Update issue first re-runs `/issue-triage` then re-checks exactly once; persistent signals re-present DP without Update (forces terminal decision, no infinite loop).
- State is session-only (Σ_s) — no on-disk artifact, `scan-state.sh` emits `recheck=session`.

## Lifecycle

| Phase | Artifact | Status |
|---|---|---|
| Intent | #181: feat(dev-core): add /recheck phase to dev pipeline | Open |
| Frame | [181-add-recheck-phase-frame.mdx](artifacts/frames/181-add-recheck-phase-frame.mdx) | Approved |
| Spec | [181-add-recheck-phase-spec.mdx](artifacts/specs/181-add-recheck-phase-spec.mdx) | Approved (13 binary criteria, post-3-agent review) |
| Plan | [181-add-recheck-phase-plan.mdx](artifacts/plans/181-add-recheck-phase-plan.mdx) | Approved (F-lite, 6 micro-tasks, 2 waves) |
| Implementation | 4 commits on `worktree-181-add-recheck-phase` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (558 pass / 4 skipped) | Passed |

## Files changed (9)

- **New:** `plugins/dev-core/skills/recheck/SKILL.md` (237 lines), `plugins/dev-core/skills/recheck/README.md` (50 lines)
- **Edited:** `plugins/dev-core/skills/dev/SKILL.md` (6 sections wired: Σ map, STEPS, skip logic, invocation map, Tier Skip Matrix, Phases summary), `scan-state.sh` (emit `recheck=session`), `dev/README.md`
- **Metadata:** `plugin.json`, `marketplace.json`, root `README.md`, `plugins/dev-core/README.md` (skill count 32→33 + skill index row)

## Test Plan

- [ ] Run `/dev #<any aged issue>` and verify `/recheck` fires immediately after `/issue-triage` and before `/frame`.
- [ ] Force a drift signal by editing a path cited in an issue body, then `/recheck #N` — confirm DP(A) appears with the 4 pipeline options.
- [ ] Standalone `/recheck #N` outside `/dev` — confirm DP shows only 3 options (no Update).
- [ ] Choose **Update issue first** with persistent signals — confirm DP re-presents on 2nd run without the Update option.
- [ ] Choose **Close as resolved/obsolete** — confirm `gh issue close` runs and `/dev` task is marked cancelled.
- [ ] Smoke (already verified): `bash plugins/dev-core/skills/dev/scan-state.sh <N> <slug>` emits a `recheck=session` line between `frame=…` and `analyze=…`.

## Premise tracking (per frame)

- Success in 6 mo: ≥1 stale catch/month; 0 silent S-tier re-implementations.
- Failure in 6 mo (revisit triggers): 0 signals fired across 3 months **OR** >80% user skip-past rate when signals fire.

Closes #181

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`