### PR TITLE
docs(dev-core): document intentional axial-adr dispatch asymmetry (#185)

### DIFF
--- a/plugins/dev-core/skills/code-review/SKILL.md
+++ b/plugins/dev-core/skills/code-review/SKILL.md
@@ -116,6 +116,8 @@ digests = emit_all_digests(chunks)            # list[BoundaryDigest]
 | **devops** | Δ ∩ {configs, CI} ≠ ∅ | config, deploy, infra |
 | **axial-adr-review** | ∃ axial ADR (`axial: true` ∈ `docs/architecture/adr/`) ∧ Δ ∩ {`infrastructure/`, `adapters/`, `domains/`, `stages/`} ≠ ∅ | Drift along non-primary axis (target × concern duplication) — read-only review agent (no Write/Edit/Bash tools) |
 
+> **Note on axial-adr-review asymmetry (intentional):** The `/code-review` condition is **structural** — it triggers when the diff touches `infrastructure/`, `adapters/`, `domains/`, or `stages/`. The spec phase (`/spec`) uses a **semantic/intent-based** condition (spec adds adapter/integration/target ∨ touches `infrastructure/`). The two are complementary: `/spec` catches intent-level N×M violations, `/code-review` catches implementation-level ones. See `plugins/shared/references/axial-decomposition.md`.
+
 Skip rules: architect → |Δ| ≤ 5 ∧ ¬arch keywords | product-lead → spec ∄ | tester → Δ ⊂ {config, docs, infra}
 
 **Subdomain split (multi-chunk):** For each chunk `c_i`, apply the dispatch table against `c_i.files` only (not full Δ). Default: 1 agent per domain per chunk.

--- a/plugins/dev-core/skills/spec/SKILL.md
+++ b/plugins/dev-core/skills/spec/SKILL.md
@@ -160,6 +160,8 @@ Auto-select ρ (¬ask user). Architect always included:
 | devops | ∃ CI/CD / deploy / infra criteria | Operational feasibility |
 | axial-adr-review | ∃ axial ADR (`axial: true` ∈ `docs/architecture/adr/`) ∧ (spec adds adapter/integration/target ∨ touches `infrastructure/`) | Drift along non-primary axis (N×M trap) — read-only review |
 
+> **Note on axial-adr-review asymmetry (intentional):** The `/spec` condition is **semantic/intent-based** — it triggers when the spec proposes adding a new adapter/integration/target or touches `infrastructure/`. The code-review phase (`/code-review`) uses a **structural** condition (diff touches `infrastructure/`, `adapters/`, `domains/`, or `stages/`). The two are complementary: `/spec` catches intent-level N×M violations, `/code-review` catches implementation-level ones. A spec that adds infrastructure/ changes without proposing a new adapter is not a spec-level axial concern but may still be caught at code-review. See `plugins/shared/references/axial-decomposition.md`.
+
 ∀ r ∈ ρ → spawn ∥:
 ```
 Task(

--- a/plugins/shared/references/axial-decomposition.md
+++ b/plugins/shared/references/axial-decomposition.md
@@ -62,6 +62,17 @@ Reject vague answers. Push the user toward one of:
 
 If a concern X appears in 3+ sibling dirs, it's no longer a coincidence — it's a duplication. Promote it to a shared primitive along the **primary axis**.
 
+## Dispatch asymmetry (intentional)
+
+`/spec` and `/code-review` both dispatch `axial-adr-review`, but with different conditions:
+
+| Skill | Trigger | Nature |
+|-------|---------|--------|
+| `/spec` | spec adds adapter/integration/target ∨ touches `infrastructure/` | **Semantic/intent** — reviews design proposals |
+| `/code-review` | Δ ∩ {`infrastructure/`, `adapters/`, `domains/`, `stages/`} ≠ ∅ | **Structural** — reviews actual file changes |
+
+This asymmetry is intentional. A spec may add `infrastructure/` changes without proposing a new adapter (e.g., refactoring existing stage wiring). In that case, the axial-adr concern is not relevant at the spec level because no new axis-crossing is being proposed — but it becomes relevant at code-review if the diff shows structural drift. The two gates are complementary: `/spec` catches intent-level N×M violations, `/code-review` catches implementation-level ones.
+
 ## Boundaries
 
 This reference describes the **decision** + the **interview**. It does NOT prescribe a specific axis — every system has its own answer. Surface trade-offs; the project owner picks.


### PR DESCRIPTION
## Summary
- Document the intentional asymmetry between `/spec` and `/code-review` axial-adr dispatch conditions.
- Add reference note to `axial-decomposition.md` explaining the semantic-vs-structural split.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #185: follow-up(#184): clarify /spec vs /code-review axial-adr dispatch asymmetry (S4) | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/185-follow-up-184-clarify-spec-vs-code-review-axial-adr-dispatch-asymmetry-s4` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new) | Passed |

## Test Plan
- [ ] Review `/spec` dispatch table note for clarity
- [ ] Review `/code-review` dispatch table note for clarity
- [ ] Review `axial-decomposition.md` new section

Closes #185

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`