### PR TITLE
fix(dev-core): correct 5 latent bugs in CLI tooling (#191)

### DIFF
--- a/artifacts/frames/191-fix-latent-correctness-bugs-in-dev-core-scripts-frame.mdx
+++ b/artifacts/frames/191-fix-latent-correctness-bugs-in-dev-core-scripts-frame.mdx
@@ -1,0 +1,84 @@
+---
+title: Fix latent correctness bugs in dev-core scripts
+issue: 191
+status: approved
+tier: F-lite
+date: 2026-05-30
+---
+
+## Problem
+
+A 2026-05-30 audit of the `dev-core` plugin's TypeScript tooling surfaced 5 latent
+correctness bugs. None are user-reported yet, but each is a real defect that will
+misbehave under the right input:
+
+1. **`skills/issues/lib/components.ts:154-167` — `ciIcon` dead branch.** The guard
+   `if (status === 'COMPLETED' || status === 'SUCCESS')` at L154 already captures
+   `status === 'SUCCESS'`, so the later `if (status === 'SUCCESS')` at L164 is
+   unreachable. A `StatusContext` with `status: 'SUCCESS'` and a *non*-success
+   conclusion falls through to the wrong icon. Same pattern repeats for the CSS-class
+   variant (L171-178). StatusContext-vs-CheckRun semantics must be checked before fixing.
+2. **`skills/issues/dashboard.ts:296-303` vs `:243` — `localPath` dropped in
+   single-project path.** The single-project `wsProjects` map omits `localPath`, so
+   branches/worktrees are never fetched on that path. Likely a regression vs the
+   multi-project path.
+3. **`skills/issue-triage/lib/list.ts:93` — `renderTree()` has no cycle guard.** A
+   GitHub-returned sub-issue cycle recurses until stack overflow. Needs a
+   `visited: Set<number>` guard.
+4. **`skills/issue-triage/lib/migrate.ts:733` — unverified `issueType=null` revert.** A
+   FIXME flags that the revert path is unverified in prod; it can mass-mutate issue
+   types with no warning. Needs a CLI warning + confirmation before executing.
+5. **`tools/licenseChecker.ts:308-320` — `parseSpdxExpression` mis-parses nesting.**
+   Breaks on nested SPDX such as `(MIT OR Apache-2.0) AND BSD-2-Clause`, producing a
+   wrong component list and potentially a false license verdict.
+
+Observable impact: wrong CI icons in the issues dashboard, missing worktree/branch data
+in single-project mode, a crash on cyclic sub-issues, a risky un-gated migration revert,
+and incorrect license-compliance results.
+
+## Who
+
+- **Primary:** Roxabi maintainers using `dev-core` skills (`/issues`, `/issue-triage`,
+  license checks) day-to-day.
+- **Secondary:** Any downstream consumer of the `dev-core` marketplace plugin who runs
+  these scripts.
+
+## Constraints
+
+- All fixes live under `plugins/dev-core/` — single plugin, single domain (TS tooling).
+- Runtime = `bun`; tests = `vitest`; formatter = `biome` (single quotes, no semicolons).
+- Each bug is independently fixable — no cross-bug coupling.
+- Bug 1 requires verifying StatusContext vs CheckRun semantics before changing branch order.
+- Bugs 4 needs a behavior change (add confirmation) — must not break non-interactive callers.
+
+## Out of Scope
+
+- No refactor of the surrounding modules beyond what each fix needs.
+- No new features in `/issues`, `/issue-triage`, or the license checker.
+- No change to plugin packaging/versioning policy.
+
+## Premise Validity
+
+**Success in 6 months:** All 5 cited code locations are corrected, each covered by a
+regression test (vitest) that fails on the old code and passes on the new; the
+`dev-core` test suite is green and no new related bug reports land.
+
+**Failure in 6 months:** Any of the 5 bugs still reproduces (e.g. cyclic sub-issue still
+overflows the stack, or `parseSpdxExpression` still mis-parses a nested expression), OR
+a fix shipped without a test that pins the corrected behavior — observable by running the
+listed inputs against the merged code.
+
+**Simplest alternative:** Patch each line in place with no added tests.
+**Why not simplest:** These are *latent* bugs with no failing test guarding them — without
+regression tests the fixes can silently regress on the next refactor, which is exactly how
+they were introduced. Tests are the deliverable, not a nice-to-have.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (TS tooling under `plugins/dev-core/`),
+5 files, no new architecture, no unknowns beyond the one semantics check in Bug 1.
+
+Signals observed:
+- 5 files, all under one plugin → not S (>3 files), not F-full (single domain, no new arch).
+- Each bug pre-diagnosed with file:line + fix direction → clear scope.
+- One small verification needed (StatusContext vs CheckRun) → handled in spec/implement, not an arch unknown.

--- a/artifacts/plans/191-fix-latent-correctness-bugs-in-dev-core-scripts-plan.mdx
+++ b/artifacts/plans/191-fix-latent-correctness-bugs-in-dev-core-scripts-plan.mdx
@@ -1,0 +1,155 @@
+---
+title: "Plan: Fix latent correctness bugs in dev-core scripts"
+issue: 191
+spec: artifacts/specs/191-fix-latent-correctness-bugs-in-dev-core-scripts-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: 2026-05-30
+---
+
+## Summary
+
+Fix 5 independent latent-correctness bugs in `plugins/dev-core/`, each via TDD (failing
+regression test → minimal fix → green). No inter-bug dependencies → one wave, 3 parallel
+agent instances split by directory + subject.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  subgraph issues["skills/issues (backend-dev-A)"]
+    CMP[components.ts<br/>ciIcon/ciClass] --- CMPT[components.test.ts NEW]
+    DASH[dashboard.ts<br/>toWorkspaceProject NEW] --- DASHT[dashboard test NEW]
+  end
+  subgraph triage["skills/issue-triage (backend-dev-B)"]
+    LIST[list.ts<br/>renderTree+visited] --- LISTT[list.test.ts]
+    MIG[migrate.ts revert + yes gate<br/>triage.ts parseMigrateRevertArgs] --- MIGT[migrate.test.ts]
+  end
+  subgraph tools["tools (backend-dev-C)"]
+    LIC[licenseChecker.ts<br/>isLicenseAllowed] --- LICT[licenseChecker.test.ts]
+  end
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|----------------|-------|-------|
+| backend-dev-A | T1, T2 | `skills/issues/lib/components.ts`, `skills/issues/dashboard.ts` (+ new tests) |
+| backend-dev-B | T3, T4 | `skills/issue-triage/lib/list.ts`, `skills/issue-triage/lib/migrate.ts`, `skills/issue-triage/triage.ts` (+ tests) |
+| backend-dev-C | T5 | `tools/licenseChecker.ts`, `tools/__tests__/licenseChecker.test.ts` |
+
+Tester role is embedded: each instance writes its own regression tests (tightly coupled
+characterization/unit tests for the function it changes — TDD, no handoff).
+
+## Wave Structure
+
+1 wave, max 3 parallel agents. Elapsed ~1 unit vs ~5 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 3 ∥ | backend-dev-A: T1, T2 · backend-dev-B: T3, T4 · backend-dev-C: T5 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 Bug 1 ciIcon/ciClass | 1 | judgmental | 6 | — |
+| T2 Bug 2 toWorkspaceProject | 1 | judgmental | 6 | — |
+| T3 Bug 3 renderTree visited | 1 | bounded | 5 | — |
+| T4 Bug 4 revert yes-gate | 1 | judgmental | 12 | — |
+| T5 Bug 5 SPDX eval | 1 | judgmental | 10 | — |
+
+**Total estimated ops: 39**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2 | 12 | ci-render, workspace-map | — |
+| backend-dev-B | T3, T4 | 17 | tree-recursion, migrate-revert | — |
+| backend-dev-C | T5 | 10 | spdx | — |
+
+All instances within caps (≤50 ops, ≤4 tasks, ≤2 subjects).
+
+## Consistency Report
+
+- Covered: 5/5 success-criteria bugs (SC Bug1→T1, Bug2→T2, Bug3→T3, Bug4→T4, Bug5→T5).
+- Final SC ("suite green") = verified by `/validate` after all tasks.
+- Uncovered: none. Untraced tasks: none. Exemptions: none.
+
+## Micro-Tasks
+
+### T1 — Bug 1: remove StatusContext/CheckRun conflation in ciIcon/ciClass `[P]`
+- **File:** `plugins/dev-core/skills/issues/lib/components.ts` (+ NEW `skills/issues/__tests__/components.test.ts`)
+- **Change:** drop `|| status === 'SUCCESS'` from the COMPLETED guards (L154, L171) so StatusContext rows route to the dedicated block (L164/L178).
+- **RED:** new test asserts `ciIcon('SUCCESS','')==='✅'`, `ciIcon('FAILURE','')==='❌'`, `ciIcon('COMPLETED','SUCCESS')==='✅'`, and same-shape `ciClass` cases — written to pass on intended routing (characterization; output identical pre/post since fix is behavior-preserving).
+- **GREEN:** apply the guard edits; output unchanged.
+- **Verify:** `bun run test -- components` → pass. `grep -n "status === 'SUCCESS'" components.ts` shows only the StatusContext block (L164/L178) + ciSummary L189, not the COMPLETED guards.
+- **Spec trace:** SC Bug 1 · **Subject:** ci-render · **Difficulty:** 2
+
+### T2 — Bug 2: extract shared `toWorkspaceProject`, use in both wsProjects paths `[P]`
+- **File:** `plugins/dev-core/skills/issues/dashboard.ts` (+ test)
+- **Change:** add `toWorkspaceProject(p)` returning `{label, repo, projectId, type, fieldIds, vercelProjects, localPath}`; replace both inline maps (L243-251 multi, L296-303 single) with `ws.projects.map(toWorkspaceProject)`. Export the helper for testing.
+- **RED:** test asserts `toWorkspaceProject({...localPath:'/x'})` includes `localPath:'/x'` (fails today for the single-path shape because it omitted the field).
+- **GREEN:** extraction makes both paths include `localPath`.
+- **Verify:** `bun run test -- dashboard` → pass. `bun run typecheck` green.
+- **Spec trace:** SC Bug 2 · **Subject:** workspace-map · **Difficulty:** 2
+
+### T3 — Bug 3: add `visited` cycle guard to renderTree `[P]`
+- **File:** `plugins/dev-core/skills/issue-triage/lib/list.ts` (+ extend `__tests__/list.test.ts`)
+- **Change:** thread `visited: Set<number>` through `renderTree`; skip a node already in `visited` (no re-expansion); add each rendered node to `visited`. Export `renderTree` for test.
+- **RED:** test builds rows with a cycle (#1.subIssueNumbers=[2], #2.subIssueNumbers=[1]) and asserts `renderTree` returns without throwing and emits each node ≤ once. Fails today (stack overflow).
+- **GREEN:** guard added.
+- **Verify:** `bun run test -- list` → pass.
+- **Spec trace:** SC Bug 3 · **Subject:** tree-recursion · **Difficulty:** 2
+
+### T4 — Bug 4: warning + confirmation gate on issueType null-revert `[P]`
+- **Files:** `plugins/dev-core/skills/issue-triage/lib/migrate.ts`, `plugins/dev-core/skills/issue-triage/triage.ts` (+ update/extend `__tests__/migrate.test.ts`)
+- **Change:**
+  - `revert(opts: { snapshotPath: string; yes?: boolean })`. Before the backfill loop, detect `issueType` rows that would revert (`field==='issueType' && !flagged && new_value!==null`). If any:
+    - print a prominent warning naming the unverified `updateIssueIssueType(node,null)` op + affected issue numbers;
+    - if `opts.yes` → proceed; else if `process.stdin.isTTY` → readline `Proceed? [y/N]`, non-`y` → skip issueType rows; else (non-interactive) → skip issueType rows, log skip, mark partial.
+  - On any skipped issueType row in non-interactive/declined mode → set non-zero exit (e.g. `process.exitCode = 1`) after the summary so automation detects partial revert.
+  - `parseMigrateRevertArgs` (triage.ts:67): parse `--yes`/`-y` → `{ snapshotPath, yes }`; pass to `revert`.
+- **RED/updated tests:**
+  - UPDATE existing `calls updateIssueIssueType(...)` test → pass `{ snapshotPath, yes: true }`.
+  - NEW: non-interactive (`stdin.isTTY=false`), no yes → `updateIssueIssueType` NOT called, warning + skip logged, `process.exitCode` non-zero.
+  - NEW: non-`issueType` rows unaffected by the gate.
+- **GREEN:** implement gate.
+- **Verify:** `bun run test -- migrate` → pass. `bun run typecheck` green.
+- **Spec trace:** SC Bug 4 · **Subject:** migrate-revert · **Difficulty:** 4
+
+### T5 — Bug 5: correct SPDX precedence/grouping in isLicenseAllowed `[P]`
+- **File:** `plugins/dev-core/tools/licenseChecker.ts` (+ extend `tools/__tests__/licenseChecker.test.ts`)
+- **Change:** replace the flatten-and-`.every()`/`.some()` logic in `isLicenseAllowed` (L309-319) with an evaluator that respects parentheses and AND-binds-tighter-than-OR. `A WITH B` = one opaque atom; strip a trailing `+` before atom match. Leave `parseSpdxExpression` unchanged (existing tests lock it).
+- **RED:** tests —
+  - `isLicenseAllowed('(MIT OR Apache-2.0) AND BSD-2-Clause', ['MIT','BSD-2-Clause'])` → `true` (fails today).
+  - unsatisfiable nested group → `false`.
+  - `A WITH B` opaque-atom + `GPL-2.0+`→`GPL-2.0` cases.
+  - existing `parseSpdxExpression` + simple AND/OR `isLicenseAllowed` tests still pass.
+- **GREEN:** implement evaluator.
+- **Verify:** `bun run test -- licenseChecker` → pass.
+- **Spec trace:** SC Bug 5 · **Subject:** spdx · **Difficulty:** 3
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T-numbers ref this list. -->
+
+### Wave 1 — no deps, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | ci-render |
+| T2 | backend-dev-A | — | workspace-map |
+| T3 | backend-dev-B | — | tree-recursion |
+| T4 | backend-dev-B | — | migrate-revert |
+| T5 | backend-dev-C | — | spdx |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 13 — ci-render
+- T2: 14 — workspace-map
+- T3: 15 — tree-recursion
+- T4: 16 — migrate-revert
+- T5: 17 — spdx

--- a/artifacts/specs/191-fix-latent-correctness-bugs-in-dev-core-scripts-spec.mdx
+++ b/artifacts/specs/191-fix-latent-correctness-bugs-in-dev-core-scripts-spec.mdx
@@ -1,0 +1,111 @@
+---
+title: Fix latent correctness bugs in dev-core scripts
+issue: 191
+status: approved
+tier: F-lite
+date: 2026-05-30
+promoted_from: artifacts/frames/191-fix-latent-correctness-bugs-in-dev-core-scripts-frame.mdx
+---
+
+## Context
+
+Source: [frame](../frames/191-fix-latent-correctness-bugs-in-dev-core-scripts-frame.mdx).
+A 2026-05-30 audit surfaced 5 latent correctness defects in `plugins/dev-core/`. Each
+was verified against the current code on branch `feat/191-…` before this spec was written
+(file:line evidence inline below). Two findings were re-characterised after verification:
+
+- **Bug 1 is dead code, not a live divergence.** The data normalization
+  (`fetch-github.ts:208-209`, `:264-265`) guarantees StatusContext rows always carry
+  `conclusion = ''` and a CheckRun `status` is never `'SUCCESS'`. So `ciIcon`/`ciClass`
+  produce identical output today whether the StatusContext branch is reachable or not. The
+  fix removes the misleading conflation and pins the intended routing with tests; it does
+  **not** change current output.
+- **Bug 5's fix belongs in `isLicenseAllowed`, not `parseSpdxExpression`.** Existing tests
+  (`licenseChecker.test.ts:93-105`) lock `parseSpdxExpression` to flatten-and-list
+  semantics. The precedence/grouping bug lives in how `isLicenseAllowed` evaluates that
+  flat list. `parseSpdxExpression` is left as-is.
+
+## Goal
+
+All 5 cited locations are corrected and each is pinned by a regression test that fails on
+the pre-fix code (or, for behavior-preserving Bug 1, a characterization test that locks the
+intended routing), with the `dev-core` suite green.
+
+> Note (Bug 1 follow-up, out of scope): `ciSummary` (components.ts:189) carries the same
+> `c.status === 'SUCCESS'` StatusContext pattern. It is correct today and untouched here;
+> flag in the PR description as a candidate follow-up.
+
+## Users
+
+- **Primary:** Roxabi maintainers running `/issues`, `/issue-triage`, and the license check.
+- **Secondary:** downstream consumers of the `dev-core` marketplace plugin.
+
+## Expected Behavior
+
+| # | Site | Symptom today | Behavior after fix |
+|---|------|---------------|--------------------|
+| 1 | `skills/issues/lib/components.ts:154,171` | `\|\| status === 'SUCCESS'` in the COMPLETED guard makes the StatusContext branch (L164/L178) unreachable; harmless now but masks intent and is a regression trap | StatusContext `SUCCESS` routes through the dedicated StatusContext block; CheckRun `COMPLETED`+`SUCCESS` still ✅. Output unchanged; dead branch gone |
+| 2 | `skills/issues/dashboard.ts:296-303` | Single-project `wsProjects` map omits `localPath` (cast `as WorkspaceProject[]` hides it) → branches/worktrees not resolved in that path | Both paths build the project shape via one shared mapper → `localPath` always present |
+| 3 | `skills/issue-triage/lib/list.ts:93` | `renderTree` recurses with no cycle guard → stack overflow on a cyclic sub-issue graph | `visited: Set<number>` short-circuits already-rendered nodes; cycle renders finitely |
+| 4 | `skills/issue-triage/lib/migrate.ts:733` | `updateIssueIssueType(node, null)` (unverified per FIXME #121) runs with no warning/confirmation | A prominent warning + confirmation gate runs before any `issueType` null-revert; safe-by-default when non-interactive |
+| 5 | `tools/licenseChecker.ts:309-319` | `isLicenseAllowed` flattens nested SPDX and `.every()`-checks all atoms → false "violation" for compliant pkgs like `(MIT OR Apache-2.0) AND BSD-2-Clause` | `isLicenseAllowed` evaluates SPDX with correct AND/OR precedence + parentheses |
+
+## Data Model & Consumers
+
+```mermaid
+flowchart TD
+  subgraph issues["skills/issues"]
+    FG[fetch-github.ts<br/>status = c.status \|\| c.state<br/>conclusion = c.conclusion \|\| ''] --> CMP[components.ts<br/>ciIcon / ciClass]
+    DASH[dashboard.ts<br/>wsProjects map x2] -->|localPath| BH[buildHtml → branch/worktree fetch]
+  end
+  subgraph triage["skills/issue-triage"]
+    LIST[list.ts renderTree<br/>recursion] --> TREE[tree output]
+    MIG[migrate.ts revert<br/>issueType=null] --> API[updateIssueIssueType]
+  end
+  subgraph tools["tools"]
+    LIC[licenseChecker.ts<br/>isLicenseAllowed → parseSpdxExpression] --> VERD[allowed / violation verdict]
+  end
+```
+
+Each bug is independent — no shared state, no ordering between fixes.
+
+| Consumer | Reads | When | Status |
+|----------|-------|------|--------|
+| `ciIcon`/`ciClass` | `check.status`, `check.conclusion` | rendering PR CI rows | this issue (Bug 1) |
+| `buildHtml` branch/worktree resolution | `wsProjects[].localPath` | single-project dashboard render | this issue (Bug 2) |
+| `renderTree` | `IssueRow.subIssueNumbers` | `/issue-triage list` tree | this issue (Bug 3) |
+| `revert` CLI | snapshot `issueType` rows | `triage.ts migrate revert` | this issue (Bug 4) |
+| `checkCompliance` | SPDX license expression | license gate | this issue (Bug 5) |
+
+## Breadboard
+
+Affordances are the corrected functions and their call sites; wiring is the test that pins each.
+
+| ID | Affordance | Handler / change | Pinned by |
+|----|-----------|------------------|-----------|
+| S1 | `ciIcon`, `ciClass` | drop `\|\| status === 'SUCCESS'` from the COMPLETED guards (L154, L171) | new `components.test.ts` |
+| S2 | `toWorkspaceProject(p)` (new helper) | single mapper used by both `wsProjects` maps (dashboard.ts:243, :296) — includes `localPath` | new test on the helper |
+| S3 | `renderTree(..., visited)` | add `visited: Set<number>`; skip + mark; export for test | extend `list.test.ts` |
+| S4 | `revert(opts)` + `parseMigrateRevertArgs` (CLI wiring for `--yes`) | add `yes?: boolean` / `--yes`; warn + gate `issueType` null-reverts; non-interactive (`!process.stdin.isTTY`) without `--yes` → skip with warning + non-zero exit | update + extend `migrate.test.ts` |
+| S5 | `isLicenseAllowed` | SPDX eval respecting parens + AND-binds-tighter-than-OR; `A WITH B` treated as one opaque atom; trailing `+` stripped before atom match | extend `licenseChecker.test.ts` |
+
+## Slices
+
+Each slice = one bug, independently demo-able and shippable. No inter-slice dependency.
+
+| Slice | Scope | Demo |
+|-------|-------|------|
+| 1 | Bug 1 — components.ts guard + characterization tests | tests assert StatusContext + CheckRun routing; output identical pre/post |
+| 2 | Bug 2 — extract `toWorkspaceProject`, use in both paths | test: single-project mapping includes `localPath` |
+| 3 | Bug 3 — `visited` cycle guard in `renderTree` | test: cyclic sub-issue graph renders without overflow |
+| 4 | Bug 4 — warning + confirmation gate on `issueType` revert | tests: `yes:true` → reverts; non-interactive no-yes → skipped + warned |
+| 5 | Bug 5 — correct SPDX evaluation in `isLicenseAllowed` | test: `(MIT OR Apache-2.0) AND BSD-2-Clause` allowed when MIT+BSD allowed |
+
+## Success Criteria
+
+- [ ] Bug 1: `\|\| status === 'SUCCESS'` removed from both guards (components.ts L154, L171); `ciIcon`/`ciClass` output is unchanged for StatusContext (`status='SUCCESS'`/`'FAILURE'`/`'PENDING'`, `conclusion=''`) and CheckRun (`status='COMPLETED'`, `conclusion ∈ {SUCCESS,FAILURE,…}`) inputs, asserted by tests.
+- [ ] Bug 2: a single `toWorkspaceProject` mapper is used by both `wsProjects` constructions; the single-project path output includes a non-undefined `localPath`, asserted by a test.
+- [ ] Bug 3: `renderTree` carries a `visited: Set<number>`; a constructed cyclic sub-issue graph (e.g. #1→#2→#1) returns without throwing (no `RangeError`/overflow), emits finite output, and expands each node at most once, asserted by a test.
+- [ ] Bug 4: running `revert` over a snapshot containing an `issueType` row prints a warning naming the unverified operation; with `--yes`/`yes:true` it proceeds (calls `updateIssueIssueType(node, null)`); when `yes` is false/absent and the session is non-interactive (`!process.stdin.isTTY`) it skips the issueType revert, logs the skip, and the command exits non-zero so automated callers can detect the partial revert — all asserted by tests; non-`issueType` reverts are unaffected.
+- [ ] Bug 5: `isLicenseAllowed('(MIT OR Apache-2.0) AND BSD-2-Clause', ['MIT','BSD-2-Clause'])` returns `true`; a nested expression whose required group is unsatisfiable returns `false`; `A WITH B` is matched as a single opaque atom and a trailing `+` is stripped before matching; existing `parseSpdxExpression` tests still pass — asserted by tests.
+- [ ] `bun run test`, `bun run typecheck`, `bun run lint` all green.

--- a/plugins/dev-core/skills/issue-triage/__tests__/list.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/list.test.ts
@@ -233,6 +233,76 @@ describe('issue-triage/list (default tree view)', () => {
   })
 })
 
+describe('issue-triage/list > renderTree cycle guard', () => {
+  it('does not throw or overflow when sub-issue graph has a 2-node cycle', async () => {
+    const { renderTree } = await import('../lib/list')
+
+    const row1: Parameters<typeof renderTree>[0][number] = {
+      item_id: 'item-1',
+      number: 1,
+      title: 'Issue one',
+      size: 'M',
+      priority: 'P1 - High',
+      status: 'Backlog',
+      mismatch: false,
+      subIssueNumbers: [2],
+      hasDoneChild: false,
+    }
+    const row2: Parameters<typeof renderTree>[0][number] = {
+      item_id: 'item-2',
+      number: 2,
+      title: 'Issue two',
+      size: 'S',
+      priority: 'P2 - Medium',
+      status: 'In Progress',
+      mismatch: false,
+      subIssueNumbers: [1],
+      hasDoneChild: false,
+    }
+
+    const byNumber = new Map([
+      [1, row1],
+      [2, row2],
+    ])
+
+    const lines: string[] = []
+    expect(() => renderTree([row1], byNumber, 0, lines, new Set())).not.toThrow()
+    // Each node should appear at most once
+    const numbersInOutput = lines
+      .map((l) => {
+        const m = l.match(/#(\d+)/)
+        return m ? Number(m[1]) : null
+      })
+      .filter((n): n is number => n !== null)
+    expect(numbersInOutput.filter((n) => n === 1).length).toBeLessThanOrEqual(1)
+    expect(numbersInOutput.filter((n) => n === 2).length).toBeLessThanOrEqual(1)
+  })
+
+  it('does not throw or overflow when sub-issue graph has a self-referential cycle', async () => {
+    const { renderTree } = await import('../lib/list')
+
+    const row1: Parameters<typeof renderTree>[0][number] = {
+      item_id: 'item-1',
+      number: 1,
+      title: 'Self-referential',
+      size: 'M',
+      priority: 'P1 - High',
+      status: 'Backlog',
+      mismatch: false,
+      subIssueNumbers: [1],
+      hasDoneChild: false,
+    }
+
+    const byNumber = new Map([[1, row1]])
+
+    const lines: string[] = []
+    expect(() => renderTree([row1], byNumber, 0, lines, new Set())).not.toThrow()
+    // Node 1 appears exactly once
+    const n1Count = lines.filter((l) => l.includes('#1')).length
+    expect(n1Count).toBe(1)
+  })
+})
+
 describe('issue-triage/list > priority mismatch detection', () => {
   it('no mismatch when field and label agree', async () => {
     const { detectPriorityMismatch } = await import('../lib/list')

--- a/plugins/dev-core/skills/issue-triage/__tests__/list.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/list.test.ts
@@ -267,14 +267,15 @@ describe('issue-triage/list > renderTree cycle guard', () => {
 
     const lines: string[] = []
     expect(() => renderTree([row1], byNumber, 0, lines, new Set())).not.toThrow()
-    // Each node should appear at most once
+    // Root node (#1, the one passed into renderTree) must appear exactly once (not 0 — that would mean empty output)
+    // Non-root cycle node (#2) may or may not render depending on visited-set order
     const numbersInOutput = lines
       .map((l) => {
         const m = l.match(/#(\d+)/)
         return m ? Number(m[1]) : null
       })
       .filter((n): n is number => n !== null)
-    expect(numbersInOutput.filter((n) => n === 1).length).toBeLessThanOrEqual(1)
+    expect(numbersInOutput.filter((n) => n === 1).length).toBe(1)
     expect(numbersInOutput.filter((n) => n === 2).length).toBeLessThanOrEqual(1)
   })
 

--- a/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
@@ -1057,7 +1057,7 @@ describe('migrate > revert', () => {
       expect(mockClearField).toHaveBeenCalledTimes(3)
     })
 
-    it('calls updateIssueIssueType(issueNodeId, null) for issueType rows', async () => {
+    it('calls updateIssueIssueType(issueNodeId, null) for issueType rows when yes:true', async () => {
       // Arrange
       const rows: BackfillRow[] = [
         { repo: 'Roxabi/test', number: 11, field: 'issueType', old_value: null, new_value: 'feat', flagged: false },
@@ -1073,11 +1073,59 @@ describe('migrate > revert', () => {
         }),
       )
 
-      // Act
-      await revert({ snapshotPath })
+      // Act — pass yes:true to bypass the confirmation gate
+      await revert({ snapshotPath, yes: true })
 
       // Assert
       expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-11', null)
+    })
+
+    it('skips issueType reverts and sets process.exitCode=1 in non-interactive mode without --yes', async () => {
+      // Arrange
+      const rows: BackfillRow[] = [
+        { repo: 'Roxabi/test', number: 11, field: 'issueType', old_value: null, new_value: 'feat', flagged: false },
+      ]
+      await writeFile(snapshotPath, JSON.stringify(rows), 'utf-8')
+
+      // process.stdin.isTTY is undefined (falsy) in vitest/node — non-interactive path
+
+      // Act — no yes flag
+      await revert({ snapshotPath })
+
+      // Assert
+      expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+      const logCalls = (console.log as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+      expect(logCalls.some((msg) => /skip.*issueType/i.test(msg) || /issueType revert/i.test(msg))).toBe(true)
+      expect(process.exitCode).toBe(1)
+
+      // Cleanup
+      process.exitCode = 0
+    })
+
+    it('non-issueType backfill rows (Lane/Size/Priority) proceed regardless of issueType gate', async () => {
+      // Arrange — snapshot with only non-issueType rows
+      const rows: BackfillRow[] = [
+        { repo: 'Roxabi/test', number: 70, field: 'Lane', old_value: null, new_value: 'a1', flagged: false },
+        { repo: 'Roxabi/test', number: 70, field: 'Size', old_value: null, new_value: 'M', flagged: false },
+        { repo: 'Roxabi/test', number: 70, field: 'Priority', old_value: null, new_value: 'P1 - High', flagged: false },
+      ]
+      await writeFile(snapshotPath, JSON.stringify(rows), 'utf-8')
+
+      mockGhGraphQL.mockResolvedValue(
+        makeItemFieldsResponse({
+          issueId: 'node-70',
+          itemId: 'item-70',
+          fields: { Lane: 'a1', Size: 'M', Priority: 'P1 - High' },
+        }),
+      )
+
+      // Act — no yes flag, non-interactive
+      await revert({ snapshotPath })
+
+      // Assert — clearField called for all 3 rows, no exitCode penalty
+      expect(mockClearField).toHaveBeenCalledTimes(3)
+      expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+      expect(process.exitCode).not.toBe(1)
     })
   })
 

--- a/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/migrate.test.ts
@@ -1030,7 +1030,11 @@ describe('migrate > revert', () => {
     mockRun.mockResolvedValue('')
   })
 
-  afterEach(() => vi.restoreAllMocks())
+  // FIX 2: reset process.exitCode after each test so exitCode=1 does not leak into later tests
+  afterEach(() => {
+    vi.restoreAllMocks()
+    process.exitCode = 0
+  })
 
   describe('backfill snapshot kind', () => {
     it('detects backfill snapshot and calls clearField for non-flagged rows with non-null new_value', async () => {
@@ -1087,19 +1091,25 @@ describe('migrate > revert', () => {
       ]
       await writeFile(snapshotPath, JSON.stringify(rows), 'utf-8')
 
+      // FIX 1: spy on process.stderr.write to assert the WARNING is emitted
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
       // process.stdin.isTTY is undefined (falsy) in vitest/node — non-interactive path
 
       // Act — no yes flag
       await revert({ snapshotPath })
 
-      // Assert
+      // Assert — FIX 1: stderr WARNING must mention unverified/WARNING/issueType
+      const stderrCalls = stderrSpy.mock.calls.map((c) => String(c[0]))
+      expect(stderrCalls.some((msg) => /unverified|WARNING|issueType/i.test(msg))).toBe(true)
+      stderrSpy.mockRestore()
+
+      // Assert — FIX 3: pin skip-log to the exact production string (migrate.ts ~L889)
       expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
       const logCalls = (console.log as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
-      expect(logCalls.some((msg) => /skip.*issueType/i.test(msg) || /issueType revert/i.test(msg))).toBe(true)
+      expect(logCalls.some((msg) => msg.includes('Skipped') && msg.includes('issueType revert'))).toBe(true)
       expect(process.exitCode).toBe(1)
-
-      // Cleanup
-      process.exitCode = 0
+      // FIX 2: inline reset removed — handled by afterEach
     })
 
     it('non-issueType backfill rows (Lane/Size/Priority) proceed regardless of issueType gate', async () => {

--- a/plugins/dev-core/skills/issue-triage/lib/list.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/list.ts
@@ -90,9 +90,18 @@ function buildRows(items: RawItem[]): IssueRow[] {
   })
 }
 
-function renderTree(roots: IssueRow[], byNumber: Map<number, IssueRow>, depth: number, lines: string[]): void {
+export function renderTree(
+  roots: IssueRow[],
+  byNumber: Map<number, IssueRow>,
+  depth: number,
+  lines: string[],
+  visited: Set<number> = new Set(),
+): void {
   const indent = '  '.repeat(depth)
   for (const row of roots) {
+    if (visited.has(row.number)) continue
+    visited.add(row.number)
+
     const maxLen = Math.max(20, 50 - depth * 2)
     const title = row.title.length > maxLen ? `${row.title.slice(0, maxLen - 3)}...` : row.title
     const size = row.size ?? '-'
@@ -104,7 +113,7 @@ function renderTree(roots: IssueRow[], byNumber: Map<number, IssueRow>, depth: n
 
     const children = row.subIssueNumbers.map((n) => byNumber.get(n)).filter((c): c is IssueRow => c !== undefined)
     if (children.length > 0) {
-      renderTree(children, byNumber, depth + 1, lines)
+      renderTree(children, byNumber, depth + 1, lines, visited)
     }
   }
 }
@@ -154,7 +163,7 @@ export async function listIssues(args: string[]): Promise<void> {
   const roots = rows.filter((r) => !allChildNumbers.has(r.number))
 
   const lines: string[] = []
-  renderTree(roots, byNumber, 0, lines)
+  renderTree(roots, byNumber, 0, lines, new Set())
   for (const line of lines) console.log(line)
   console.log('')
   console.log(`*${openItems.length} open issue${openItems.length === 1 ? '' : 's'}*`)

--- a/plugins/dev-core/skills/issue-triage/lib/migrate.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/migrate.ts
@@ -718,8 +718,12 @@ async function fetchIssueFieldState(
   }
 }
 
-async function revertBackfillRow(row: BackfillRow): Promise<'reverted' | 'skipped'> {
+async function revertBackfillRow(row: BackfillRow, allowIssueType = true): Promise<'reverted' | 'skipped'> {
   if (row.flagged || row.new_value === null) return 'skipped'
+
+  if (row.field === 'issueType' && !allowIssueType) {
+    return 'skipped'
+  }
 
   const { itemId, issueNodeId, currentFields, currentIssueType } = await fetchIssueFieldState(row.repo, row.number)
 
@@ -771,7 +775,7 @@ async function revertRewriteRow(row: RewriteRow): Promise<'reverted' | 'skipped'
   return 'reverted'
 }
 
-export async function revert(opts: { snapshotPath: string }): Promise<void> {
+export async function revert(opts: { snapshotPath: string; yes?: boolean }): Promise<void> {
   const { readFile } = await import('node:fs/promises')
   const raw = await readFile(opts.snapshotPath, 'utf-8')
   const parsed = JSON.parse(raw) as unknown
@@ -819,7 +823,39 @@ export async function revert(opts: { snapshotPath: string }): Promise<void> {
   let skipped = 0
   const errors: RevertError[] = []
 
+  // Confirmation gate for issueType null-reverts (FIXME #121: unverified API operation)
+  let allowIssueType = true
   if (isBackfill) {
+    const issueTypeRows = rawRows
+      .filter(isValidBackfillRow)
+      .filter((r) => r.field === 'issueType' && !r.flagged && r.new_value !== null)
+    if (issueTypeRows.length > 0) {
+      const affected = issueTypeRows.map((r) => `#${r.number}`).join(', ')
+      process.stderr.write(
+        `\nWARNING: ${issueTypeRows.length} row(s) would call updateIssueIssueType(node, null) — ` +
+          `this operation is unverified (FIXME #121). Affected: ${affected}\n\n`,
+      )
+      if (opts.yes) {
+        allowIssueType = true
+      } else if (process.stdin.isTTY) {
+        const { createInterface } = await import('node:readline')
+        const rl = createInterface({ input: process.stdin, output: process.stderr })
+        const answer = await new Promise<string>((resolve) => {
+          rl.question('Proceed with issueType reverts? [y/N] ', (ans) => {
+            rl.close()
+            resolve(ans)
+          })
+        })
+        allowIssueType = answer === 'y' || answer === 'Y'
+      } else {
+        // Non-interactive: skip issueType reverts
+        allowIssueType = false
+      }
+    }
+  }
+
+  if (isBackfill) {
+    let issueTypeSkipped = 0
     for (const row of rawRows) {
       // fix #12: per-row validation
       if (!isValidBackfillRow(row)) {
@@ -827,15 +863,33 @@ export async function revert(opts: { snapshotPath: string }): Promise<void> {
         continue
       }
       try {
-        const outcome = await revertBackfillRow(row)
+        const outcome = await revertBackfillRow(row, allowIssueType)
         if (outcome === 'reverted') reverted++
-        else skipped++
+        else {
+          skipped++
+          if (row.field === 'issueType' && !allowIssueType && !row.flagged && row.new_value !== null) {
+            issueTypeSkipped++
+          }
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         errors.push({ repo: row.repo, number: row.number, field: row.field, error: message })
         console.error(`error #${row.number}.${row.field}: ${message}`)
       }
     }
+
+    console.log(`Reverted ${reverted} rows, skipped ${skipped} already-reverted, errors ${errors.length}`)
+    if (errors.length > 0) {
+      for (const e of errors) {
+        const loc = e.field ? `${e.repo}#${e.number} [${e.field}]` : `${e.repo}#${e.number}`
+        console.error(`  ${loc}: ${e.error}`)
+      }
+    }
+    if (issueTypeSkipped > 0) {
+      console.log(`Skipped ${issueTypeSkipped} issueType revert(s) — confirmation not given`)
+      process.exitCode = 1
+    }
+    return
   } else {
     for (const row of rawRows) {
       // fix #12: per-row validation

--- a/plugins/dev-core/skills/issue-triage/triage.ts
+++ b/plugins/dev-core/skills/issue-triage/triage.ts
@@ -64,8 +64,9 @@ function parseMigrateBackfillArgs(argv: string[]): { repo: string; dryRun: boole
   return { repo, dryRun, snapshotPath }
 }
 
-function parseMigrateRevertArgs(argv: string[]): { snapshotPath: string } {
+function parseMigrateRevertArgs(argv: string[]): { snapshotPath: string; yes?: boolean } {
   let snapshotPath: string | undefined
+  let yes: boolean | undefined
   let i = 0
 
   while (i < argv.length) {
@@ -74,24 +75,27 @@ function parseMigrateRevertArgs(argv: string[]): { snapshotPath: string } {
       snapshotPath = argv[i + 1]
       if (!snapshotPath) {
         console.error('Error: --snapshot requires a path value')
-        console.error('Usage: triage.ts migrate revert --snapshot <path>')
+        console.error('Usage: triage.ts migrate revert --snapshot <path> [--yes]')
         process.exit(1)
       }
       i += 2
+    } else if (flag === '--yes' || flag === '-y') {
+      yes = true
+      i += 1
     } else {
       console.error(`Error: unknown flag "${flag}"`)
-      console.error('Usage: triage.ts migrate revert --snapshot <path>')
+      console.error('Usage: triage.ts migrate revert --snapshot <path> [--yes]')
       process.exit(1)
     }
   }
 
   if (!snapshotPath) {
     console.error('Error: --snapshot <path> is required')
-    console.error('Usage: triage.ts migrate revert --snapshot <path>')
+    console.error('Usage: triage.ts migrate revert --snapshot <path> [--yes]')
     process.exit(1)
   }
 
-  return { snapshotPath }
+  return { snapshotPath, yes }
 }
 
 switch (command) {
@@ -140,7 +144,7 @@ switch (command) {
         const opts = parseMigrateRevertArgs(subArgs)
         // fix #2: validate user-supplied snapshot path at CLI layer
         opts.snapshotPath = validateSnapshotPath(opts.snapshotPath)
-        await revert(opts)
+        await revert({ snapshotPath: opts.snapshotPath, yes: opts.yes })
         break
       }
       default:

--- a/plugins/dev-core/skills/issues/__tests__/components.test.ts
+++ b/plugins/dev-core/skills/issues/__tests__/components.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { ciClass, ciIcon } from '../lib/components'
+
+const CI_SPINNER_HTML = '<span class="ci-spinner"></span>'
+
+describe('ciIcon — StatusContext rows (conclusion="")', () => {
+  it('SUCCESS,"" → ✅', () => {
+    expect(ciIcon('SUCCESS', '')).toBe('✅')
+  })
+
+  it('FAILURE,"" → ❌', () => {
+    expect(ciIcon('FAILURE', '')).toBe('❌')
+  })
+
+  it('PENDING,"" → spinner', () => {
+    expect(ciIcon('PENDING', '')).toBe(CI_SPINNER_HTML)
+  })
+})
+
+describe('ciIcon — CheckRun rows (status=COMPLETED)', () => {
+  it('COMPLETED,SUCCESS → ✅', () => {
+    expect(ciIcon('COMPLETED', 'SUCCESS')).toBe('✅')
+  })
+
+  it('COMPLETED,FAILURE → ❌', () => {
+    expect(ciIcon('COMPLETED', 'FAILURE')).toBe('❌')
+  })
+})
+
+describe('ciClass — StatusContext rows (conclusion="")', () => {
+  it('SUCCESS,"" → ci-success', () => {
+    expect(ciClass('SUCCESS', '')).toBe('ci-success')
+  })
+
+  it('FAILURE,"" → ci-failure', () => {
+    expect(ciClass('FAILURE', '')).toBe('ci-failure')
+  })
+})
+
+describe('ciClass — CheckRun rows (status=COMPLETED)', () => {
+  it('COMPLETED,SUCCESS → ci-success', () => {
+    expect(ciClass('COMPLETED', 'SUCCESS')).toBe('ci-success')
+  })
+})

--- a/plugins/dev-core/skills/issues/__tests__/components.test.ts
+++ b/plugins/dev-core/skills/issues/__tests__/components.test.ts
@@ -42,3 +42,17 @@ describe('ciClass — CheckRun rows (status=COMPLETED)', () => {
     expect(ciClass('COMPLETED', 'SUCCESS')).toBe('ci-success')
   })
 })
+
+describe('ciIcon/ciClass — StatusContext-vs-CheckRun routing regression (Bug-1)', () => {
+  // Pins the fix: StatusContext row with status=SUCCESS and non-empty conclusion must NOT
+  // be misrouted to the CheckRun/COMPLETED branch.
+  // Pre-fix code returned ⛔ (CANCELLED conclusion) for ciIcon and 'ci-cancelled' for ciClass.
+  // Post-fix code correctly routes to the StatusContext SUCCESS branch.
+  it('ciIcon: SUCCESS with CANCELLED conclusion → ✅ (StatusContext SUCCESS branch, not CheckRun)', () => {
+    expect(ciIcon('SUCCESS', 'CANCELLED')).toBe('✅')
+  })
+
+  it('ciClass: SUCCESS with CANCELLED conclusion → ci-success (StatusContext SUCCESS branch, not CheckRun)', () => {
+    expect(ciClass('SUCCESS', 'CANCELLED')).toBe('ci-success')
+  })
+})

--- a/plugins/dev-core/skills/issues/__tests__/dashboard.test.ts
+++ b/plugins/dev-core/skills/issues/__tests__/dashboard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { toWorkspaceProject } from '../lib/workspace-helpers'
+
+describe('toWorkspaceProject', () => {
+  it('preserves localPath (regression: single-project path dropped it)', () => {
+    const input = {
+      label: 'my-project',
+      repo: 'owner/repo',
+      projectId: 'PVT_123',
+      type: 'technical' as const,
+      fieldIds: undefined,
+      vercelProjects: [],
+      localPath: '/some/path',
+    }
+    const result = toWorkspaceProject(input)
+    expect(result.localPath).toBe('/some/path')
+  })
+
+  it('maps all WorkspaceProject fields', () => {
+    const input = {
+      label: 'proj',
+      repo: 'owner/repo',
+      projectId: 'PVT_456',
+      type: 'company' as const,
+      fieldIds: { status: 'f1', size: 'f2', priority: 'f3' } as never,
+      vercelProjects: [{ projectId: 'vp1', teamId: 'team1' }],
+      localPath: '/home/user/projects/repo',
+    }
+    const result = toWorkspaceProject(input)
+    expect(result.label).toBe('proj')
+    expect(result.repo).toBe('owner/repo')
+    expect(result.projectId).toBe('PVT_456')
+    expect(result.type).toBe('company')
+    expect(result.vercelProjects).toEqual([{ projectId: 'vp1', teamId: 'team1' }])
+    expect(result.localPath).toBe('/home/user/projects/repo')
+  })
+
+  it('handles missing optional fields gracefully', () => {
+    const input = {
+      label: 'minimal',
+      repo: 'owner/repo',
+      projectId: 'PVT_789',
+    }
+    const result = toWorkspaceProject(input as never)
+    expect(result.label).toBe('minimal')
+    expect(result.localPath).toBeUndefined()
+    expect(result.vercelProjects).toBeUndefined()
+  })
+})

--- a/plugins/dev-core/skills/issues/dashboard.ts
+++ b/plugins/dev-core/skills/issues/dashboard.ts
@@ -32,6 +32,7 @@ import {
 import { buildHtml } from './lib/page'
 import type { Branch, BranchCI, Issue, PR, VercelDeployment, WorkflowRun, Worktree } from './lib/types'
 import { handleUpdate } from './lib/update'
+import { toWorkspaceProject } from './lib/workspace-helpers'
 
 type ProjectMeta = {
   prs: PR[]
@@ -240,15 +241,7 @@ async function refreshCache(): Promise<void> {
       const workspaceChanged = !cache || cache.workspaceHash !== newWorkspaceHash
       const changed = workspaceChanged || !cache || cache.hash !== hash
       const updatedAt = Date.now()
-      const wsProjects = ws.projects.map((p) => ({
-        label: p.label,
-        repo: p.repo,
-        projectId: p.projectId,
-        type: p.type,
-        fieldIds: p.fieldIds,
-        vercelProjects: p.vercelProjects,
-        localPath: p.localPath,
-      })) as WorkspaceProject[]
+      const wsProjects = ws.projects.map(toWorkspaceProject)
       const roadmapProject =
         ws.roadmapProjectId && roadmapLabel ? { label: roadmapLabel, projectId: ws.roadmapProjectId } : undefined
       const html = buildHtml(
@@ -293,14 +286,7 @@ async function refreshCache(): Promise<void> {
     const changed = dataChanged || workspaceChanged
 
     const updatedAt = Date.now()
-    const wsProjects = ws.projects.map((p) => ({
-      label: p.label,
-      repo: p.repo,
-      projectId: p.projectId,
-      type: p.type,
-      fieldIds: p.fieldIds,
-      vercelProjects: p.vercelProjects,
-    })) as WorkspaceProject[]
+    const wsProjects = ws.projects.map(toWorkspaceProject)
     const html = buildHtml(
       issues,
       prs,

--- a/plugins/dev-core/skills/issues/lib/components.ts
+++ b/plugins/dev-core/skills/issues/lib/components.ts
@@ -150,8 +150,8 @@ function getPRDisplay(pr: PR): { label: string; cssClass: string } {
 
 const CI_SPINNER = '<span class="ci-spinner"></span>'
 
-function ciIcon(status: string, conclusion: string): string {
-  if (status === 'COMPLETED' || status === 'SUCCESS') {
+export function ciIcon(status: string, conclusion: string): string {
+  if (status === 'COMPLETED') {
     if (conclusion === 'SUCCESS' || conclusion === '') return '\u2705'
     if (conclusion === 'FAILURE' || conclusion === 'ERROR') return '\u274c'
     if (conclusion === 'CANCELLED' || conclusion === 'TIMED_OUT') return '\u26d4'
@@ -167,8 +167,8 @@ function ciIcon(status: string, conclusion: string): string {
   return '\u2753'
 }
 
-function ciClass(status: string, conclusion: string): string {
-  if (status === 'COMPLETED' || status === 'SUCCESS') {
+export function ciClass(status: string, conclusion: string): string {
+  if (status === 'COMPLETED') {
     if (conclusion === 'SUCCESS' || conclusion === '') return 'ci-success'
     if (conclusion === 'FAILURE' || conclusion === 'ERROR') return 'ci-failure'
     if (conclusion === 'CANCELLED' || conclusion === 'TIMED_OUT') return 'ci-cancelled'

--- a/plugins/dev-core/skills/issues/lib/workspace-helpers.ts
+++ b/plugins/dev-core/skills/issues/lib/workspace-helpers.ts
@@ -1,0 +1,28 @@
+import type { WorkspaceProject } from '../../shared/ports/workspace'
+
+/**
+ * Maps a raw workspace project entry (as stored in workspace.json) to a typed
+ * WorkspaceProject, ensuring every field — including the optional `localPath` —
+ * is forwarded.  This helper is used in both the workspace (multi-project) and
+ * single-project code paths in dashboard.ts so that neither path accidentally
+ * drops fields.
+ */
+export function toWorkspaceProject(p: {
+  label: string
+  repo: string
+  projectId: string
+  type?: WorkspaceProject['type']
+  fieldIds?: WorkspaceProject['fieldIds']
+  vercelProjects?: WorkspaceProject['vercelProjects']
+  localPath?: string
+}): WorkspaceProject {
+  return {
+    label: p.label,
+    repo: p.repo,
+    projectId: p.projectId,
+    type: p.type,
+    fieldIds: p.fieldIds,
+    vercelProjects: p.vercelProjects,
+    localPath: p.localPath,
+  }
+}

--- a/plugins/dev-core/skills/issues/lib/workspace-helpers.ts
+++ b/plugins/dev-core/skills/issues/lib/workspace-helpers.ts
@@ -7,15 +7,7 @@ import type { WorkspaceProject } from '../../shared/ports/workspace'
  * single-project code paths in dashboard.ts so that neither path accidentally
  * drops fields.
  */
-export function toWorkspaceProject(p: {
-  label: string
-  repo: string
-  projectId: string
-  type?: WorkspaceProject['type']
-  fieldIds?: WorkspaceProject['fieldIds']
-  vercelProjects?: WorkspaceProject['vercelProjects']
-  localPath?: string
-}): WorkspaceProject {
+export function toWorkspaceProject(p: WorkspaceProject): WorkspaceProject {
   return {
     label: p.label,
     repo: p.repo,

--- a/plugins/dev-core/tools/__tests__/licenseChecker.test.ts
+++ b/plugins/dev-core/tools/__tests__/licenseChecker.test.ts
@@ -178,6 +178,26 @@ describe('isLicenseAllowed', () => {
   it('trailing +: GPL-2.0+ → strip + and match bare id — allowed=[GPL-2.0] → true', () => {
     expect(isLicenseAllowed('GPL-2.0+', ['GPL-2.0'])).toBe(true)
   })
+
+  // ─── Recursion / complexity guard ───────────────────────────────────────────
+
+  it('50 000 nested parens: does not throw and returns false', () => {
+    const bomb = `${'('.repeat(50000)}MIT${')'.repeat(50000)}`
+    expect(() => isLicenseAllowed(bomb, ['MIT'])).not.toThrow()
+    expect(isLicenseAllowed(bomb, ['MIT'])).toBe(false)
+  })
+
+  it('>20 open-parens (moderately nested, not 50k): returns false without throwing', () => {
+    // 21 levels of nesting — exceeds the paren cap
+    const expr = `${'('.repeat(21)}MIT${')'.repeat(21)}`
+    expect(() => isLicenseAllowed(expr, ['MIT'])).not.toThrow()
+    expect(isLicenseAllowed(expr, ['MIT'])).toBe(false)
+  })
+
+  it('regression: normal nested expression within cap still evaluates correctly', () => {
+    // (MIT OR Apache-2.0) AND BSD-2-Clause — 1 open-paren, well under cap
+    expect(isLicenseAllowed('(MIT OR Apache-2.0) AND BSD-2-Clause', ['MIT', 'BSD-2-Clause'])).toBe(true)
+  })
 })
 
 // ─── detectLicense ───────────────────────────────────────────────────────────

--- a/plugins/dev-core/tools/__tests__/licenseChecker.test.ts
+++ b/plugins/dev-core/tools/__tests__/licenseChecker.test.ts
@@ -156,6 +156,28 @@ describe('isLicenseAllowed', () => {
   it('returns false for empty allowed list', () => {
     expect(isLicenseAllowed('MIT', [])).toBe(false)
   })
+
+  // Precedence and grouping tests
+  it('grouped AND+OR: (MIT OR Apache-2.0) AND BSD-2-Clause — allowed=[MIT,BSD-2-Clause] → true', () => {
+    expect(isLicenseAllowed('(MIT OR Apache-2.0) AND BSD-2-Clause', ['MIT', 'BSD-2-Clause'])).toBe(true)
+  })
+
+  it('grouped AND+OR: (MIT OR Apache-2.0) AND BSD-2-Clause — allowed=[MIT] → false (BSD group unsatisfiable)', () => {
+    expect(isLicenseAllowed('(MIT OR Apache-2.0) AND BSD-2-Clause', ['MIT'])).toBe(false)
+  })
+
+  it('AND binds tighter than OR: MIT OR GPL-3.0 AND Proprietary — allowed=[MIT] → true', () => {
+    // Parsed as: MIT OR (GPL-3.0 AND Proprietary) — MIT satisfies the top-level OR
+    expect(isLicenseAllowed('MIT OR GPL-3.0 AND Proprietary', ['MIT'])).toBe(true)
+  })
+
+  it('WITH exception: Apache-2.0 WITH LLVM-exception treated as opaque atom — allowed=[Apache-2.0 WITH LLVM-exception] → true', () => {
+    expect(isLicenseAllowed('Apache-2.0 WITH LLVM-exception', ['Apache-2.0 WITH LLVM-exception'])).toBe(true)
+  })
+
+  it('trailing +: GPL-2.0+ → strip + and match bare id — allowed=[GPL-2.0] → true', () => {
+    expect(isLicenseAllowed('GPL-2.0+', ['GPL-2.0'])).toBe(true)
+  })
 })
 
 // ─── detectLicense ───────────────────────────────────────────────────────────

--- a/plugins/dev-core/tools/licenseChecker.ts
+++ b/plugins/dev-core/tools/licenseChecker.ts
@@ -300,25 +300,91 @@ export function parseSpdxExpression(expression: string): string[] {
     .filter(Boolean)
 }
 
+// ─── SPDX Expression Evaluator ───────────────────────────────────────────────
+// Tokenizes the expression into: atoms (including "A WITH B" as one unit),
+// parentheses, and AND/OR operators. Then evaluates with correct precedence:
+// AND binds tighter than OR (SPDX spec §4.1).
+
+type SpdxToken = '(' | ')' | 'AND' | 'OR' | string
+
+function tokenizeSpdx(expr: string): SpdxToken[] {
+  // Split on whitespace first, then reassemble WITH pairs as single atoms
+  const raw = expr.replace(/\(/g, ' ( ').replace(/\)/g, ' ) ').trim().split(/\s+/).filter(Boolean)
+
+  const tokens: SpdxToken[] = []
+  let i = 0
+  while (i < raw.length) {
+    const t = raw[i]
+    if (t === '(' || t === ')' || t === 'AND' || t === 'OR') {
+      tokens.push(t as SpdxToken)
+      i++
+    } else if (raw[i + 1] === 'WITH' && i + 2 < raw.length) {
+      // "A WITH B" → single opaque atom
+      tokens.push(`${t} WITH ${raw[i + 2]}`)
+      i += 3
+    } else {
+      tokens.push(t)
+      i++
+    }
+  }
+  return tokens
+}
+
+function isAtomAllowed(atom: string, allowedLicenses: string[]): boolean {
+  // Strip trailing '+' (e.g. GPL-2.0+ → GPL-2.0)
+  const normalized = atom.endsWith('+') ? atom.slice(0, -1) : atom
+  return allowedLicenses.includes(normalized)
+}
+
+// Recursive-descent: OR → AND → primary
+function evaluateSpdxExpression(expr: string, allowedLicenses: string[]): boolean {
+  const tokens = tokenizeSpdx(expr)
+  let pos = 0
+
+  function parseOr(): boolean {
+    let result = parseAnd()
+    while (pos < tokens.length && tokens[pos] === 'OR') {
+      pos++
+      const right = parseAnd()
+      result = result || right
+    }
+    return result
+  }
+
+  function parseAnd(): boolean {
+    let result = parsePrimary()
+    while (pos < tokens.length && tokens[pos] === 'AND') {
+      pos++
+      const right = parsePrimary()
+      result = result && right
+    }
+    return result
+  }
+
+  function parsePrimary(): boolean {
+    if (pos >= tokens.length) return false
+    const t = tokens[pos]
+    if (t === '(') {
+      pos++ // consume '('
+      const result = parseOr()
+      if (pos < tokens.length && tokens[pos] === ')') pos++ // consume ')'
+      return result
+    }
+    pos++
+    return isAtomAllowed(t, allowedLicenses)
+  }
+
+  return parseOr()
+}
+
 export function isLicenseAllowed(license: string | null, allowedLicenses: string[]): boolean {
   if (!license) return false
 
-  // Direct match
+  // Direct match (fast path — also handles simple atoms with no operators)
   if (allowedLicenses.includes(license)) return true
 
-  // SPDX AND expression — all components must be allowed (check before OR/parens)
-  if (license.includes(' AND ')) {
-    const components = parseSpdxExpression(license)
-    return components.every((c) => allowedLicenses.includes(c))
-  }
-
-  // SPDX OR expression — at least one component must be allowed
-  if (license.includes(' OR ') || license.startsWith('(')) {
-    const components = parseSpdxExpression(license)
-    return components.some((c) => allowedLicenses.includes(c))
-  }
-
-  return false
+  // Evaluate as SPDX expression with correct precedence and grouping
+  return evaluateSpdxExpression(license, allowedLicenses)
 }
 
 // ─── Compliance Check ────────────────────────────────────────────────────────

--- a/plugins/dev-core/tools/licenseChecker.ts
+++ b/plugins/dev-core/tools/licenseChecker.ts
@@ -291,6 +291,7 @@ export function detectLicense(
 
 // ─── SPDX Expression Handling ────────────────────────────────────────────────
 
+/** @deprecated Superseded by the evaluator in isLicenseAllowed; retained for backward compatibility. Does not strip '+' suffixes or respect grouping. */
 export function parseSpdxExpression(expression: string): string[] {
   // Strip all parens and split on OR/AND
   const cleaned = expression.replace(/[()]/g, '')
@@ -308,7 +309,10 @@ export function parseSpdxExpression(expression: string): string[] {
 type SpdxToken = '(' | ')' | 'AND' | 'OR' | string
 
 function tokenizeSpdx(expr: string): SpdxToken[] {
-  // Split on whitespace first, then reassemble WITH pairs as single atoms
+  // Split on whitespace first, then reassemble WITH pairs as single atoms.
+  // Note: WITH must appear between two atoms (e.g. "Apache-2.0 WITH LLVM-exception").
+  // Grouped forms like "(A) WITH B" are NOT valid SPDX — the paren/length cap in
+  // isLicenseAllowed() acts as the safety net for such malformed expressions.
   const raw = expr.replace(/\(/g, ' ( ').replace(/\)/g, ' ) ').trim().split(/\s+/).filter(Boolean)
 
   const tokens: SpdxToken[] = []
@@ -382,6 +386,18 @@ export function isLicenseAllowed(license: string | null, allowedLicenses: string
 
   // Direct match (fast path — also handles simple atoms with no operators)
   if (allowedLicenses.includes(license)) return true
+
+  // Guard against pathologically large or deeply nested expressions from untrusted
+  // package.json data (e.g. 50 000 nested parens → stack overflow in the evaluator).
+  // Real SPDX expressions are short; 512 chars and 20 open-parens are well above any
+  // legitimate expression seen in the wild.
+  const openParenCount = (license.match(/\(/g) ?? []).length
+  if (license.length > 512 || openParenCount > 20) {
+    process.stderr.write(
+      `license-check: expression too complex to evaluate safely, treating as disallowed: ${license.slice(0, 60)}...\n`,
+    )
+    return false
+  }
 
   // Evaluate as SPDX expression with correct precedence and grouping
   return evaluateSpdxExpression(license, allowedLicenses)


### PR DESCRIPTION
## Summary

Fixes 5 independent latent correctness bugs in `plugins/dev-core/` surfaced by a 2026-05-30 audit. Each is fixed via TDD (regression test + minimal fix) and shipped as its own commit.

| # | Site | Defect → Fix |
|---|------|--------------|
| 1 | `skills/issues/lib/components.ts` | `\|\| status === 'SUCCESS'` in the COMPLETED guard shadowed the dedicated StatusContext branch (dead code). Removed it so StatusContext rows route correctly. **Behavior-preserving** — verified no current divergence (StatusContext always normalizes to `conclusion=''`, CheckRun `status` is never `'SUCCESS'`); fix + characterization tests prevent future regression. |
| 2 | `skills/issues/dashboard.ts` | Single-project `wsProjects` map dropped `localPath` (masked by `as` cast) → branches/worktrees unresolved. Extracted shared `toWorkspaceProject` mapper used by both paths. |
| 3 | `skills/issue-triage/lib/list.ts` | `renderTree` recursed with no cycle guard → stack overflow on cyclic sub-issues. Added `visited: Set<number>`. |
| 4 | `skills/issue-triage/lib/migrate.ts` | Unverified `issueType=null` revert (FIXME #121) ran with no warning. Added warning + confirmation gate (`--yes` / interactive prompt); non-interactive without `--yes` skips the revert and exits non-zero. |
| 5 | `tools/licenseChecker.ts` | `isLicenseAllowed` flattened nested SPDX → false violations for e.g. `(MIT OR Apache-2.0) AND BSD-2-Clause`. Replaced with a proper evaluator (parens + AND-binds-tighter-than-OR, `WITH` opaque atom, `+` suffix). `parseSpdxExpression` left unchanged. |

> Follow-up (out of scope): `ciSummary` (components.ts:189) carries the same StatusContext pattern — correct today, candidate for a later cleanup.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #191: Fix latent correctness bugs in dev-core scripts | Open |
| Analysis | — (skipped, F-lite) | Absent |
| Spec | [191-…-spec.mdx](artifacts/specs/191-fix-latent-correctness-bugs-in-dev-core-scripts-spec.mdx) | Present |
| Implementation | 5 fix commits on `feat/191-…` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (680 pass, 5 test files added/extended) | Passed |

## Test Plan

- [ ] `cd plugins/dev-core && bun run test` — 680 pass
- [ ] Bug 1: `ciIcon('SUCCESS','')` → ✅, `ciIcon('FAILURE','')` → ❌ (StatusContext routing)
- [ ] Bug 2: `toWorkspaceProject({…localPath})` preserves `localPath`
- [ ] Bug 3: cyclic sub-issue graph renders without overflow
- [ ] Bug 4: non-interactive `migrate revert` of an issueType row skips + exits non-zero; `--yes` proceeds
- [ ] Bug 5: `isLicenseAllowed('(MIT OR Apache-2.0) AND BSD-2-Clause', ['MIT','BSD-2-Clause'])` → true

Closes #191

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
