### PR TITLE
refactor(issue-triage): set.ts writes Size board field

### DIFF
--- a/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
@@ -87,6 +87,20 @@ vi.mock('../../shared/adapters/config-helpers', () => ({
     if (u === 'L' || u === 'XL') return 'F-full'
     return undefined
   },
+  getSizeOptionId: (input: string) => {
+    const map: Record<string, string> = { S: 'size-s', 'F-lite': 'size-f-lite', 'F-full': 'size-f-full' }
+    const valid = new Set(['S', 'F-lite', 'F-full'])
+    let canonical: string | undefined
+    if (valid.has(input)) canonical = input
+    else {
+      const u = input.toUpperCase().replace(/[-\s]/g, '-')
+      if (valid.has(u)) canonical = u
+      else if (u === 'XS') canonical = 'S'
+      else if (u === 'M') canonical = 'F-lite'
+      else if (u === 'L' || u === 'XL') canonical = 'F-full'
+    }
+    return canonical ? { optionId: map[canonical], canonical } : undefined
+  },
   resolvePriority: (input: string) => {
     const canonical = new Set(['P0 - Urgent', 'P1 - High', 'P2 - Medium', 'P3 - Low'])
     if (canonical.has(input)) return input
@@ -166,6 +180,7 @@ describe('issue-triage/set > field updates', () => {
   it('updates size via label', async () => {
     await setIssue(['42', '--size', 'F-lite'])
     expect(mockSyncSizeLabel).toHaveBeenCalledWith(42, 'F-lite')
+    expect(mockUpdateField).toHaveBeenCalledWith('item-123', 'SZF_test', 'size-f-lite')
   })
 
   it('updates priority field with alias', async () => {
@@ -276,9 +291,9 @@ describe('issue-triage/set > combined flags', () => {
 
   it('handles multiple flags at once', async () => {
     await setIssue(['42', '--size', 'F-full', '--priority', 'Urgent', '--blocked-by', '99'])
-    // size via label, priority via field + label
+    // size via label + board field, priority via field + label
     expect(mockSyncSizeLabel).toHaveBeenCalledWith(42, 'F-full')
-    expect(mockUpdateField).toHaveBeenCalledTimes(1) // priority only
+    expect(mockUpdateField).toHaveBeenCalledTimes(2) // size board + priority
     expect(mockAddBlockedBy).toHaveBeenCalledTimes(1)
   })
 
@@ -390,6 +405,7 @@ describe('issue-triage/set > cross-repo subject', () => {
   it('skips label sync for cross-repo subject with --size', async () => {
     await setIssue(['Roxabi/voiceCLI#144', '--size', 'S'])
     expect(mockSyncSizeLabel).not.toHaveBeenCalled()
+    expect(mockUpdateField).not.toHaveBeenCalled()
     const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
     expect(errCalls.some((m) => m.includes('label sync') && m.includes('cross-repo'))).toBe(true)
   })
@@ -438,8 +454,9 @@ describe('issue-triage/set > additive regression', () => {
 
   it('--size alone does not call lane or type mutations', async () => {
     await setIssue(['123', '--size', 'S'])
-    // size via label sync
+    // size via label sync + board field
     expect(mockSyncSizeLabel).toHaveBeenCalledWith(123, 'S')
+    expect(mockUpdateField).toHaveBeenCalledWith('item-123', 'SZF_test', 'size-s')
     expect(mockSyncLaneLabel).not.toHaveBeenCalled()
     expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
   })

--- a/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
@@ -89,12 +89,13 @@ vi.mock('../../shared/adapters/config-helpers', () => ({
   },
   getSizeOptionId: (input: string) => {
     const map: Record<string, string> = { S: 'size-s', 'F-lite': 'size-f-lite', 'F-full': 'size-f-full' }
+    // Derive canonical via the same resolution logic as the resolveSize mock above
     const valid = new Set(['S', 'F-lite', 'F-full'])
     let canonical: string | undefined
     if (valid.has(input)) canonical = input
     else {
       const u = input.toUpperCase().replace(/[-\s]/g, '-')
-      if (valid.has(u)) canonical = u
+      if (valid.has(u as 'S' | 'F-lite' | 'F-full')) canonical = u
       else if (u === 'XS') canonical = 'S'
       else if (u === 'M') canonical = 'F-lite'
       else if (u === 'L' || u === 'XL') canonical = 'F-full'
@@ -191,6 +192,29 @@ describe('issue-triage/set > field updates', () => {
   it('updates status with case normalization', async () => {
     await setIssue(['42', '--status', 'In Progress'])
     expect(mockUpdateField).toHaveBeenCalledWith('item-123', expect.any(String), 'status-inprog')
+  })
+
+  it('exits with error for invalid --size value', async () => {
+    // Arrange — throw on exit so execution stops after the guard, matching real process.exit semantics
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
+      throw new Error(`process.exit:${code}`)
+    }) as never)
+    // Act
+    await setIssue(['42', '--size', 'bogus']).catch(() => {})
+    // Assert
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(errCalls.some((m) => m.includes('Invalid size'))).toBe(true)
+  })
+
+  it('logs Size= exactly once for --size (no duplicate)', async () => {
+    // Arrange
+    const logs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args) => logs.push(String(args[0])))
+    // Act
+    await setIssue(['42', '--size', 'F-lite'])
+    // Assert
+    expect(logs.filter((l) => l.startsWith('Size=')).length).toBe(1)
   })
 })
 

--- a/plugins/dev-core/skills/issue-triage/lib/set.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/set.ts
@@ -5,6 +5,7 @@
 
 import {
   GITHUB_REPO,
+  getSizeOptionId,
   isProjectConfigured,
   NOT_CONFIGURED_MSG,
   PRIORITY_FIELD_ID,
@@ -13,6 +14,7 @@ import {
   resolvePriority,
   resolveSize,
   resolveStatus,
+  SIZE_FIELD_ID,
   STATUS_FIELD_ID,
   STATUS_OPTIONS,
 } from '../../shared/adapters/config-helpers'
@@ -128,6 +130,16 @@ function resolveItemId(issueNumber: number): Promise<string | undefined> {
   })
 }
 
+async function applySize(itemId: string, issueNumber: number, size: string): Promise<void> {
+  const resolved = getSizeOptionId(size)
+  if (!resolved) {
+    console.error('Error: Invalid size')
+    process.exit(1)
+  }
+  await updateField(itemId, SIZE_FIELD_ID, resolved.optionId)
+  console.log(`Size=${resolved.canonical} #${issueNumber}`)
+}
+
 async function applyStatus(itemId: string, issueNumber: number, status: string): Promise<void> {
   const canonical = resolveStatus(status)
   if (!(canonical && STATUS_OPTIONS[canonical])) {
@@ -164,11 +176,11 @@ async function applyType(issueNumber: number, type: string): Promise<void> {
 }
 
 async function applyProjectFields(issueNumber: number, opts: SetOptions): Promise<void> {
-  if (!(opts.priority || opts.status || opts.type)) return
+  if (!(opts.size || opts.priority || opts.status || opts.type)) return
 
   if (opts.subjectRepo) {
     console.error(
-      `Warning: --status/--priority/--type are not supported for cross-repo subjects (${opts.subjectRepo}#${issueNumber}) — skipped`,
+      `Warning: --size/--status/--priority/--type are not supported for cross-repo subjects (${opts.subjectRepo}#${issueNumber}) — skipped`,
     )
     return
   }
@@ -182,6 +194,7 @@ async function applyProjectFields(issueNumber: number, opts: SetOptions): Promis
   if (!itemId) return
 
   if (opts.status) await applyStatus(itemId, issueNumber, opts.status)
+  if (opts.size) await applySize(itemId, issueNumber, opts.size)
   if (opts.priority) await applyPriority(itemId, issueNumber, opts.priority)
   if (opts.type) await applyType(issueNumber, opts.type)
 }
@@ -325,10 +338,7 @@ export async function setIssue(args: string[]): Promise<void> {
     }
     if (opts.size) {
       const canonical = resolveSize(opts.size)
-      if (canonical) {
-        await syncSizeLabel(opts.issueNumber, canonical)
-        console.log(`Size=${canonical} #${opts.issueNumber}`)
-      }
+      if (canonical) await syncSizeLabel(opts.issueNumber, canonical)
     }
     if (opts.lane) {
       const canonical = resolveLane(opts.lane)


### PR DESCRIPTION
## Summary
- `set.ts` `applyProjectFields` now writes the **Size board field** (via `getSizeOptionId` + `updateField`), matching `create.ts`. Previously `set --size` synced only the size *label*, leaving the board field stale.
- Adds `applySize()`, `opts.size` to the guard + cross-repo warning, imports `getSizeOptionId` + `SIZE_FIELD_ID`. Keeps `syncSizeLabel` (label still synced); drops the now-duplicate `Size=` log (owned by `applySize`).

**Behavior note:** `set --size` on a repo without a configured project board now hits the existing `isProjectConfigured()` exit — same as `--status/--priority/--type` already do.

Origin: PR #199 review (parallel-path-drift, C88), deferred from #177.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #200: set.ts writes Size board field (parity with create.ts) | OPEN |
| Implementation | 1 commit on `feat/200-set-ts-writes-size-board-field` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (681 passed) | Passed |

## Test Plan
- [ ] `set --size F-lite` writes the Size board field AND syncs the size label (no duplicate `Size=` log)
- [ ] combined `set --size X --priority Y` writes both board fields
- [ ] cross-repo subject `--size` skips board write + label sync with warning
- [ ] `set --size` with unconfigured project exits cleanly (parity with status/priority/type)

Closes #200

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`