### PR TITLE
fix(dev-core): migrate gh CLI calls to array-form spawn (#203)

### DIFF
--- a/plugins/dev-core/skills/issues/digest.ts
+++ b/plugins/dev-core/skills/issues/digest.ts
@@ -6,7 +6,6 @@
  * Usage: bun digest.ts
  */
 
-import { execSync } from 'node:child_process'
 import { detectGitHubRepo } from '../shared/adapters/config-helpers'
 import {
   buildCols,
@@ -33,10 +32,28 @@ import { ghGraphQLExec } from './lib/gh-exec'
 
 const [owner, repo] = detectGitHubRepo().split('/')
 
-const epicsRaw = execSync(
-  `gh issue list --repo ${owner}/${repo} --label epic --state open --json number,title --limit 50`,
-  { encoding: 'utf-8' },
+const epicsProc = Bun.spawnSync(
+  [
+    'gh',
+    'issue',
+    'list',
+    '--repo',
+    `${owner}/${repo}`,
+    '--label',
+    'epic',
+    '--state',
+    'open',
+    '--json',
+    'number,title',
+    '--limit',
+    '50',
+  ],
+  { stdout: 'pipe', stderr: 'pipe' },
 )
+if (epicsProc.exitCode !== 0) {
+  throw new Error(`gh issue list failed: ${new TextDecoder().decode(epicsProc.stderr).trim()}`)
+}
+const epicsRaw = new TextDecoder().decode(epicsProc.stdout).trim()
 const topEpics: Array<{ number: number; title: string }> = JSON.parse(epicsRaw)
 
 if (topEpics.length === 0) {

--- a/plugins/dev-core/skills/issues/show.ts
+++ b/plugins/dev-core/skills/issues/show.ts
@@ -5,7 +5,6 @@
  * Usage: bun show.ts <issue-number>
  */
 
-import { execSync } from 'node:child_process'
 import { detectGitHubRepo } from '../shared/adapters/config-helpers'
 import { ghGraphQLExec } from './lib/gh-exec'
 
@@ -78,10 +77,21 @@ interface GhIssue {
   comments: GhComment[]
 }
 
-const raw = execSync(
-  `gh issue view ${issueNum} --json number,title,body,state,labels,assignees,milestone,createdAt,updatedAt,closedAt,comments`,
-  { encoding: 'utf-8' },
+const ghProc = Bun.spawnSync(
+  [
+    'gh',
+    'issue',
+    'view',
+    String(issueNum),
+    '--json',
+    'number,title,body,state,labels,assignees,milestone,createdAt,updatedAt,closedAt,comments',
+  ],
+  { stdout: 'pipe', stderr: 'pipe' },
 )
+if (ghProc.exitCode !== 0) {
+  throw new Error(`gh issue view failed: ${new TextDecoder().decode(ghProc.stderr).trim()}`)
+}
+const raw = new TextDecoder().decode(ghProc.stdout).trim()
 const issue: GhIssue = JSON.parse(raw)
 
 // ── 2. Sub-issues via GraphQL ────────────────────────────────────────────────

--- a/plugins/dev-core/skills/shared/__tests__/config.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/config.test.ts
@@ -284,36 +284,44 @@ describe('detectGitHubRepo', () => {
   })
 
   it('parses SSH remote URL', () => {
-    spawnSyncSpy.mockReturnValue({
-      stdout: new TextEncoder().encode('git@github.com:Roxabi/roxabi-plugins.git\n'),
-      stderr: new Uint8Array(),
-      exitCode: 0,
-      success: true,
-    } as unknown as ReturnType<typeof Bun.spawnSync>)
+    spawnSyncSpy.mockImplementation((cmd: string[]) => {
+      if (cmd[0] === 'gh') return { stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 1, success: false }
+      return {
+        stdout: new TextEncoder().encode('git@github.com:Roxabi/roxabi-plugins.git\n'),
+        stderr: new Uint8Array(),
+        exitCode: 0,
+        success: true,
+      }
+    })
 
     expect(detectGitHubRepo()).toBe('Roxabi/roxabi-plugins')
   })
 
   it('parses HTTPS remote URL', () => {
-    const stdout = new TextEncoder().encode('https://github.com/Roxabi/roxabi-plugins.git\n')
-    spawnSyncSpy.mockReturnValue({
-      stdout,
-      stderr: new Uint8Array(),
-      exitCode: 0,
-      success: true,
-    } as unknown as ReturnType<typeof Bun.spawnSync>)
+    spawnSyncSpy.mockImplementation((cmd: string[]) => {
+      if (cmd[0] === 'gh') return { stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 1, success: false }
+      return {
+        stdout: new TextEncoder().encode('https://github.com/Roxabi/roxabi-plugins.git\n'),
+        stderr: new Uint8Array(),
+        exitCode: 0,
+        success: true,
+      }
+    })
 
     const result = detectGitHubRepo()
     expect(result).toBe('Roxabi/roxabi-plugins')
   })
 
   it('parses HTTPS remote URL without .git suffix', () => {
-    spawnSyncSpy.mockReturnValue({
-      stdout: new TextEncoder().encode('https://github.com/Roxabi/roxabi-plugins\n'),
-      stderr: new Uint8Array(),
-      exitCode: 0,
-      success: true,
-    } as unknown as ReturnType<typeof Bun.spawnSync>)
+    spawnSyncSpy.mockImplementation((cmd: string[]) => {
+      if (cmd[0] === 'gh') return { stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 1, success: false }
+      return {
+        stdout: new TextEncoder().encode('https://github.com/Roxabi/roxabi-plugins\n'),
+        stderr: new Uint8Array(),
+        exitCode: 0,
+        success: true,
+      }
+    })
 
     expect(detectGitHubRepo()).toBe('Roxabi/roxabi-plugins')
   })

--- a/plugins/dev-core/skills/shared/adapters/config-helpers.ts
+++ b/plugins/dev-core/skills/shared/adapters/config-helpers.ts
@@ -3,7 +3,6 @@
  * These are used by EnvConfigAdapter and re-exported from config.ts for backward compat.
  */
 
-import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import type { ProjectFieldIds } from '../domain/types'
 import type { WorkspaceProject } from '../ports/workspace'
@@ -32,7 +31,11 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
   // 3rd: Auto-detect via gh CLI for supported keys
   if (key === 'github_repo') {
     try {
-      return execSync('gh repo view --json nameWithOwner --jq .nameWithOwner', { encoding: 'utf-8' }).trim()
+      const proc = Bun.spawnSync(['gh', 'repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      if (proc.exitCode === 0) return new TextDecoder().decode(proc.stdout).trim()
     } catch {
       /* gh not available */
     }
@@ -40,18 +43,24 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
 
   if (key === 'gh_project_id') {
     try {
-      const repo = execSync('gh repo view --json nameWithOwner --jq .nameWithOwner', {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim()
-      if (repo) {
-        const [owner, name] = repo.split('/')
-        const query = `{ repository(owner: \\"${owner}\\", name: \\"${name}\\") { projectsV2(first: 1) { nodes { id } } } }`
-        const id = execSync(`gh api graphql -f query="${query}" --jq '.data.repository.projectsV2.nodes[0].id'`, {
-          encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
-        }).trim()
-        if (id && id !== 'null') return id
+      const repoProc = Bun.spawnSync(['gh', 'repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      if (repoProc.exitCode === 0) {
+        const repo = new TextDecoder().decode(repoProc.stdout).trim()
+        if (repo) {
+          const [owner, name] = repo.split('/')
+          const query = `{ repository(owner: "${owner}", name: "${name}") { projectsV2(first: 1) { nodes { id } } } }`
+          const idProc = Bun.spawnSync(
+            ['gh', 'api', 'graphql', '-f', `query=${query}`, '--jq', '.data.repository.projectsV2.nodes[0].id'],
+            { stdout: 'pipe', stderr: 'pipe' },
+          )
+          if (idProc.exitCode === 0) {
+            const id = new TextDecoder().decode(idProc.stdout).trim()
+            if (id && id !== 'null') return id
+          }
+        }
       }
     } catch {
       /* gh not available or no project linked */


### PR DESCRIPTION
## Summary

Migrates `gh` CLI invocations that interpolated `detectGitHubRepo()` output (owner/repo), issue numbers, and a GraphQL query into shell command strings via `execSync` over to array-form `Bun.spawnSync(['gh', ...])` — **no shell**, so shell metacharacters in any interpolated value can no longer be interpreted.

Class: shell-injection hardening. Pre-existing; surfaced during review of #192 (PR #201), not introduced by it.

## Changes

- `plugins/dev-core/skills/issues/show.ts` — `gh issue view` → array-form spawn; dropped `execSync` import.
- `plugins/dev-core/skills/issues/digest.ts` — `gh issue list --repo owner/repo` → array-form spawn; dropped `execSync` import.
- `plugins/dev-core/skills/shared/adapters/config-helpers.ts` — `gh repo view` (×2, static) and `gh api graphql -f query=...` (interpolated) → array-form spawn; dropped `execSync` import.
- `plugins/dev-core/skills/shared/__tests__/config.test.ts` — updated `detectGitHubRepo` tests for the new `Bun.spawnSync` code path.

Mirrors the existing safe `run()` / `Bun.spawnSync` pattern in `github-adapter.ts`.

## Verification

- lint ✓ · typecheck ✓ · test ✓ (681 passed, 4 skipped, 0 failed)

## Notes

- `lib/gh-exec.ts` still uses `execSync` for `gh api graphql --input <tmpfile>` — static command, query passed via temp file, no interpolation → not a shell-injection vector. Out of scope.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)