### PR TITLE
fix(dev-core): validate gh_project_id slug before GraphQL interpolation

### DIFF
--- a/plugins/dev-core/skills/shared/adapters/config-helpers.ts
+++ b/plugins/dev-core/skills/shared/adapters/config-helpers.ts
@@ -50,10 +50,29 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
       if (repoProc.exitCode === 0) {
         const repo = new TextDecoder().decode(repoProc.stdout).trim()
         if (repo) {
-          const [owner, name] = repo.split('/')
-          const query = `{ repository(owner: "${owner}", name: "${name}") { projectsV2(first: 1) { nodes { id } } } }`
+          // Validate before splitting + interpolating. assertValidRepoSlug throws on a
+          // malformed slug; the surrounding catch turns that into a silent "no project
+          // detected" (undefined), matching the gh-not-available path. Belt-and-suspenders:
+          // owner/name are passed as typed GraphQL variables (-f) instead of interpolated,
+          // so the query string is constant and the gh CLI handles escaping.
+          const [owner, name] = assertValidRepoSlug(repo).split('/')
+          const query =
+            'query($owner: String!, $name: String!) ' +
+            '{ repository(owner: $owner, name: $name) { projectsV2(first: 1) { nodes { id } } } }'
           const idProc = Bun.spawnSync(
-            ['gh', 'api', 'graphql', '-f', `query=${query}`, '--jq', '.data.repository.projectsV2.nodes[0].id'],
+            [
+              'gh',
+              'api',
+              'graphql',
+              '-f',
+              `query=${query}`,
+              '-f',
+              `owner=${owner}`,
+              '-f',
+              `name=${name}`,
+              '--jq',
+              '.data.repository.projectsV2.nodes[0].id',
+            ],
             { stdout: 'pipe', stderr: 'pipe' },
           )
           if (idProc.exitCode === 0) {

--- a/plugins/dev-core/skills/shared/adapters/config-helpers.ts
+++ b/plugins/dev-core/skills/shared/adapters/config-helpers.ts
@@ -82,7 +82,7 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
         }
       }
     } catch {
-      /* gh not available or no project linked */
+      /* gh not available, no project linked, or invalid slug from gh output */
     }
   }
 


### PR DESCRIPTION
## Summary
- The `gh_project_id` auto-detect path in `loadDevCoreConfig()` split `gh repo view` output on `/` and interpolated `owner`/`name` directly into a GraphQL query template literal without validation — the same pattern #202 hardened for `detectGitHubRepo()`. Pre-existing; surfaced by security-auditor (C75), deferred from PR #208.
- Fix reuses the existing `assertValidRepoSlug()` helper to validate the slug before split (a malformed slug throws → caught → silent "no project detected", matching the gh-unavailable path), **and** passes `owner`/`name` as typed GraphQL variables (`-f`) instead of string interpolation, so the query string is now constant and the gh CLI handles escaping.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #209: validate gh_project_id auto-detect slug before GraphQL interpolation | Open |
| Implementation | 1 commit on `feat/209-validate-gh-project-id-slug` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (692 pass) | Passed |

## Test Plan
- [ ] `bun run typecheck` — declaration ordering (GH_PROJECT_ID evaluates after REPO_SLUG_RE; no TDZ)
- [ ] `bun run test` — `detectGitHubRepo` slug-validation tests still green (same helper)
- [ ] Manual: in a repo with a linked Project, `GH_PROJECT_ID` still auto-detects via the parameterized query

Closes #209

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`