### PR TITLE
fix(dev-init): harden detectGitHubRepo() slug validation + safe spawn

### DIFF
--- a/plugins/dev-init/skills/shared/__tests__/config.test.ts
+++ b/plugins/dev-init/skills/shared/__tests__/config.test.ts
@@ -283,37 +283,75 @@ describe('detectGitHubRepo', () => {
     expect(spawnSyncSpy).not.toHaveBeenCalled()
   })
 
+  it('throws when GITHUB_REPO lacks a slash (no owner/repo)', () => {
+    process.env.GITHUB_REPO = 'myrepo'
+    expect(() => detectGitHubRepo()).toThrow('Invalid GitHub repo "myrepo"')
+    // Must reject before falling through to git remote detection.
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws when GITHUB_REPO has an empty segment', () => {
+    process.env.GITHUB_REPO = 'owner/'
+    expect(() => detectGitHubRepo()).toThrow('Expected "owner/repo" format')
+  })
+
+  it('throws when GITHUB_REPO has extra path segments', () => {
+    process.env.GITHUB_REPO = 'owner/repo/extra'
+    expect(() => detectGitHubRepo()).toThrow('Invalid GitHub repo')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws when GITHUB_REPO has a leading slash (empty owner)', () => {
+    process.env.GITHUB_REPO = '/repo'
+    expect(() => detectGitHubRepo()).toThrow('Invalid GitHub repo')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws when GITHUB_REPO is whitespace-padded', () => {
+    process.env.GITHUB_REPO = ' owner/repo '
+    expect(() => detectGitHubRepo()).toThrow('Invalid GitHub repo')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
   it('parses SSH remote URL', () => {
-    spawnSyncSpy.mockReturnValue({
-      stdout: new TextEncoder().encode('git@github.com:Roxabi/roxabi-plugins.git\n'),
-      stderr: new Uint8Array(),
-      exitCode: 0,
-      success: true,
-    } as unknown as ReturnType<typeof Bun.spawnSync>)
+    spawnSyncSpy.mockImplementation((cmd: string[]) => {
+      if (cmd[0] === 'gh') return { stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 1, success: false }
+      return {
+        stdout: new TextEncoder().encode('git@github.com:Roxabi/roxabi-plugins.git\n'),
+        stderr: new Uint8Array(),
+        exitCode: 0,
+        success: true,
+      }
+    })
 
     expect(detectGitHubRepo()).toBe('Roxabi/roxabi-plugins')
   })
 
   it('parses HTTPS remote URL', () => {
-    const stdout = new TextEncoder().encode('https://github.com/Roxabi/roxabi-plugins.git\n')
-    spawnSyncSpy.mockReturnValue({
-      stdout,
-      stderr: new Uint8Array(),
-      exitCode: 0,
-      success: true,
-    } as unknown as ReturnType<typeof Bun.spawnSync>)
+    spawnSyncSpy.mockImplementation((cmd: string[]) => {
+      if (cmd[0] === 'gh') return { stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 1, success: false }
+      return {
+        stdout: new TextEncoder().encode('https://github.com/Roxabi/roxabi-plugins.git\n'),
+        stderr: new Uint8Array(),
+        exitCode: 0,
+        success: true,
+      }
+    })
 
     const result = detectGitHubRepo()
     expect(result).toBe('Roxabi/roxabi-plugins')
   })
 
   it('parses HTTPS remote URL without .git suffix', () => {
-    spawnSyncSpy.mockReturnValue({
-      stdout: new TextEncoder().encode('https://github.com/Roxabi/roxabi-plugins\n'),
-      stderr: new Uint8Array(),
-      exitCode: 0,
-      success: true,
-    } as unknown as ReturnType<typeof Bun.spawnSync>)
+    spawnSyncSpy.mockImplementation((cmd: string[]) => {
+      if (cmd[0] === 'gh') return { stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 1, success: false }
+      return {
+        stdout: new TextEncoder().encode('https://github.com/Roxabi/roxabi-plugins\n'),
+        stderr: new Uint8Array(),
+        exitCode: 0,
+        success: true,
+      }
+    })
 
     expect(detectGitHubRepo()).toBe('Roxabi/roxabi-plugins')
   })

--- a/plugins/dev-init/skills/shared/adapters/config-helpers.ts
+++ b/plugins/dev-init/skills/shared/adapters/config-helpers.ts
@@ -3,7 +3,6 @@
  * These are used by EnvConfigAdapter and re-exported from config.ts for backward compat.
  */
 
-import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import type { ProjectFieldIds } from '../domain/types'
 import type { WorkspaceProject } from '../ports/workspace'
@@ -32,7 +31,11 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
   // 3rd: Auto-detect via gh CLI for supported keys
   if (key === 'github_repo') {
     try {
-      return execSync('gh repo view --json nameWithOwner --jq .nameWithOwner', { encoding: 'utf-8' }).trim()
+      const proc = Bun.spawnSync(['gh', 'repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      if (proc.exitCode === 0) return new TextDecoder().decode(proc.stdout).trim()
     } catch {
       /* gh not available */
     }
@@ -40,18 +43,24 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
 
   if (key === 'gh_project_id') {
     try {
-      const repo = execSync('gh repo view --json nameWithOwner --jq .nameWithOwner', {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim()
-      if (repo) {
-        const [owner, name] = repo.split('/')
-        const query = `{ repository(owner: \\"${owner}\\", name: \\"${name}\\") { projectsV2(first: 1) { nodes { id } } } }`
-        const id = execSync(`gh api graphql -f query="${query}" --jq '.data.repository.projectsV2.nodes[0].id'`, {
-          encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
-        }).trim()
-        if (id && id !== 'null') return id
+      const repoProc = Bun.spawnSync(['gh', 'repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      if (repoProc.exitCode === 0) {
+        const repo = new TextDecoder().decode(repoProc.stdout).trim()
+        if (repo) {
+          const [owner, name] = repo.split('/')
+          const query = `{ repository(owner: "${owner}", name: "${name}") { projectsV2(first: 1) { nodes { id } } } }`
+          const idProc = Bun.spawnSync(
+            ['gh', 'api', 'graphql', '-f', `query=${query}`, '--jq', '.data.repository.projectsV2.nodes[0].id'],
+            { stdout: 'pipe', stderr: 'pipe' },
+          )
+          if (idProc.exitCode === 0) {
+            const id = new TextDecoder().decode(idProc.stdout).trim()
+            if (id && id !== 'null') return id
+          }
+        }
       }
     } catch {
       /* gh not available or no project linked */
@@ -61,15 +70,43 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
   return undefined
 }
 
+/**
+ * A GitHub repo slug: exactly `owner/repo`.
+ * GitHub owner: [A-Za-z0-9-], repo name: [A-Za-z0-9._-].
+ * Callers do `detectGitHubRepo().split('/')` and expect exactly two non-empty segments.
+ */
+const REPO_SLUG_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/
+
+/**
+ * Validate a candidate GitHub repo slug and throw a clear error if it doesn't match.
+ * Used by both the yaml/env path and the git-remote fallback in detectGitHubRepo().
+ */
+function assertValidRepoSlug(value: string): string {
+  if (!REPO_SLUG_RE.test(value)) {
+    throw new Error(
+      `Invalid GitHub repo "${value}". Expected "owner/repo" format ` +
+        '(set github_repo in dev-core config or the GITHUB_REPO env var).',
+    )
+  }
+  return value
+}
+
 export function detectGitHubRepo(): string {
   const fromYamlOrEnv = loadDevCoreConfig('github_repo', 'GITHUB_REPO')
-  if (fromYamlOrEnv) return fromYamlOrEnv
+  if (fromYamlOrEnv) {
+    // Guard the yaml/env path: callers do `detectGitHubRepo().split('/')` and
+    // expect `owner/repo`. A bare value (e.g. `GITHUB_REPO=myrepo`) would slip
+    // through as a silent `undefined` repo → malformed GraphQL. Fail loud here.
+    return assertValidRepoSlug(fromYamlOrEnv)
+  }
   try {
     const proc = Bun.spawnSync(['git', 'remote', 'get-url', 'origin'], { stdout: 'pipe', stderr: 'pipe' })
     const url = new TextDecoder().decode(proc.stdout).trim()
     // SSH: git@github.com:owner/repo.git  |  HTTPS: https://github.com/owner/repo.git
     const match = url.match(/[:/]([^/:]+\/[^/]+?)(?:\.git)?$/)
-    if (match?.[1]) return match[1]
+    // Validate the extracted candidate — a malformed remote must not silently
+    // return a bad slug that callers would split('/') into garbage GraphQL args.
+    if (match?.[1]) return assertValidRepoSlug(match[1])
   } catch {}
   throw new Error('Cannot detect GitHub repo. Set GITHUB_REPO env var or ensure git remote "origin" is configured.')
 }


### PR DESCRIPTION
## Summary
- Ports the #202/#206 hardening into the drifted **dev-init** copy of `config-helpers.ts`, which lagged ~69 lines behind dev-core on the old `execSync` string-interpolation form.
- `detectGitHubRepo()` now validates both return paths (yaml/env + git-remote fallback) via `REPO_SLUG_RE` + `assertValidRepoSlug()` — closes the unvalidated-return hole where a bare value (e.g. `GITHUB_REPO=myrepo`) would slip through and break callers' `split('/')`.
- Both `gh` calls in `loadDevCoreConfig()` migrated from `execSync` shell-string interpolation to `Bun.spawnSync` **array-form**, eliminating the injection vector on the `gh_project_id` GraphQL query (`owner`/`name` previously interpolated into a shell command string).
- Dropped the now-unused `node:child_process` import.

Surfaced by security-auditor (C92), deferred from PR #208 review iteration 2.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #210: harden detectGitHubRepo() in dev-init copy | OPEN |
| Implementation | 1 commit on `feat/210-harden-detectgithubrepo` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (5 new slug-validation cases) | Passed |

## Test Plan
- [ ] `GITHUB_REPO=myrepo` (no slash) → throws `Invalid GitHub repo`
- [ ] `GITHUB_REPO=owner/repo/extra` / `/repo` / `owner/` / ` owner/repo ` → throws
- [ ] Valid `owner/repo` + SSH/HTTPS git remote detection still resolve correctly
- [ ] `gh_project_id` GraphQL query runs via array-form spawn (no shell string)

Closes #210

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`