### PR TITLE
fix(dev-init): harden gh_project_id GraphQL slug interpolation (#213)

### DIFF
--- a/plugins/dev-core/skills/shared/__tests__/config.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/config.test.ts
@@ -252,6 +252,114 @@ describe('buildBranchProtectionPayload', () => {
   })
 })
 
+describe('gh_project_id auto-detect', () => {
+  let spawnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // GH_PROJECT_ID must not be set — forces the gh CLI auto-detect path
+    delete process.env.GH_PROJECT_ID
+    // GITHUB_REPO must be valid so detectGitHubRepo() resolves without spawning
+    process.env.GITHUB_REPO = 'Test/test-repo'
+  })
+
+  afterEach(() => {
+    spawnSpy?.mockRestore()
+    delete process.env.GH_PROJECT_ID
+    process.env.GITHUB_REPO = 'Test/test-repo'
+    vi.resetModules()
+  })
+
+  it('uses typed -f variables for owner and name (no interpolation in query)', async () => {
+    let capturedCmd: string[] = []
+
+    spawnSpy = vi.spyOn(Bun, 'spawnSync').mockImplementation((cmd: string[]) => {
+      if (cmd[0] === 'gh' && cmd[1] === 'repo') {
+        return {
+          stdout: new TextEncoder().encode('Owner/repo\n'),
+          stderr: new Uint8Array(),
+          exitCode: 0,
+          success: true,
+        } as unknown as ReturnType<typeof Bun.spawnSync>
+      }
+      if (cmd[0] === 'gh' && cmd[1] === 'api') {
+        capturedCmd = [...cmd]
+        return {
+          stdout: new TextEncoder().encode('PVT_test123\n'),
+          stderr: new Uint8Array(),
+          exitCode: 0,
+          success: true,
+        } as unknown as ReturnType<typeof Bun.spawnSync>
+      }
+      return {
+        stdout: new Uint8Array(),
+        stderr: new Uint8Array(),
+        exitCode: 1,
+        success: false,
+      } as unknown as ReturnType<typeof Bun.spawnSync>
+    })
+
+    vi.resetModules()
+    const mod = await import('../adapters/config-helpers')
+
+    expect(mod.GH_PROJECT_ID).toBe('PVT_test123')
+
+    // owner and name passed as typed -f variables — not interpolated into query string
+    const ownerFlagIdx = capturedCmd.indexOf('owner=Owner')
+    const nameFlagIdx = capturedCmd.indexOf('name=repo')
+    expect(ownerFlagIdx).toBeGreaterThan(-1)
+    expect(nameFlagIdx).toBeGreaterThan(-1)
+    // each typed variable must be preceded by '-f'
+    expect(capturedCmd[ownerFlagIdx - 1]).toBe('-f')
+    expect(capturedCmd[nameFlagIdx - 1]).toBe('-f')
+
+    // query= arg must use $owner / $name placeholders — NOT the literal owner value
+    const queryArg = capturedCmd.find((a) => a.startsWith('query=')) ?? ''
+    expect(queryArg).toContain('$owner')
+    expect(queryArg).toContain('$name')
+    expect(queryArg).not.toContain('"Owner"')
+    expect(queryArg).not.toContain('"repo"')
+  })
+
+  it('does not call gh api graphql when gh repo view returns a hostile slug', async () => {
+    let graphqlSpawned = false
+
+    spawnSpy = vi.spyOn(Bun, 'spawnSync').mockImplementation((cmd: string[]) => {
+      if (cmd[0] === 'gh' && cmd[1] === 'repo') {
+        return {
+          // Hostile slug — assertValidRepoSlug must reject this before graphql is called
+          stdout: new TextEncoder().encode('a") { x } #/b\n'),
+          stderr: new Uint8Array(),
+          exitCode: 0,
+          success: true,
+        } as unknown as ReturnType<typeof Bun.spawnSync>
+      }
+      if (cmd[0] === 'gh' && cmd[1] === 'api') {
+        graphqlSpawned = true
+        return {
+          stdout: new TextEncoder().encode('PVT_should_not_reach\n'),
+          stderr: new Uint8Array(),
+          exitCode: 0,
+          success: true,
+        } as unknown as ReturnType<typeof Bun.spawnSync>
+      }
+      return {
+        stdout: new Uint8Array(),
+        stderr: new Uint8Array(),
+        exitCode: 1,
+        success: false,
+      } as unknown as ReturnType<typeof Bun.spawnSync>
+    })
+
+    vi.resetModules()
+    const mod = await import('../adapters/config-helpers')
+
+    // assertValidRepoSlug throws → catch swallows → GH_PROJECT_ID falls back to ''
+    expect(mod.GH_PROJECT_ID).toBe('')
+    // graphql spawn must never have fired
+    expect(graphqlSpawned).toBe(false)
+  })
+})
+
 describe('detectGitHubRepo', () => {
   const originalEnv = process.env.GITHUB_REPO
   let spawnSyncSpy: ReturnType<typeof vi.spyOn>

--- a/plugins/dev-init/skills/shared/__tests__/config.test.ts
+++ b/plugins/dev-init/skills/shared/__tests__/config.test.ts
@@ -252,6 +252,114 @@ describe('buildBranchProtectionPayload', () => {
   })
 })
 
+describe('gh_project_id auto-detect', () => {
+  let spawnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // GH_PROJECT_ID must not be set — forces the gh CLI auto-detect path
+    delete process.env.GH_PROJECT_ID
+    // GITHUB_REPO must be valid so detectGitHubRepo() resolves without spawning
+    process.env.GITHUB_REPO = 'Test/test-repo'
+  })
+
+  afterEach(() => {
+    spawnSpy?.mockRestore()
+    delete process.env.GH_PROJECT_ID
+    process.env.GITHUB_REPO = 'Test/test-repo'
+    vi.resetModules()
+  })
+
+  it('uses typed -f variables for owner and name (no interpolation in query)', async () => {
+    let capturedCmd: string[] = []
+
+    spawnSpy = vi.spyOn(Bun, 'spawnSync').mockImplementation((cmd: string[]) => {
+      if (cmd[0] === 'gh' && cmd[1] === 'repo') {
+        return {
+          stdout: new TextEncoder().encode('Owner/repo\n'),
+          stderr: new Uint8Array(),
+          exitCode: 0,
+          success: true,
+        } as unknown as ReturnType<typeof Bun.spawnSync>
+      }
+      if (cmd[0] === 'gh' && cmd[1] === 'api') {
+        capturedCmd = [...cmd]
+        return {
+          stdout: new TextEncoder().encode('PVT_test123\n'),
+          stderr: new Uint8Array(),
+          exitCode: 0,
+          success: true,
+        } as unknown as ReturnType<typeof Bun.spawnSync>
+      }
+      return {
+        stdout: new Uint8Array(),
+        stderr: new Uint8Array(),
+        exitCode: 1,
+        success: false,
+      } as unknown as ReturnType<typeof Bun.spawnSync>
+    })
+
+    vi.resetModules()
+    const mod = await import('../adapters/config-helpers')
+
+    expect(mod.GH_PROJECT_ID).toBe('PVT_test123')
+
+    // owner and name passed as typed -f variables — not interpolated into query string
+    const ownerFlagIdx = capturedCmd.indexOf('owner=Owner')
+    const nameFlagIdx = capturedCmd.indexOf('name=repo')
+    expect(ownerFlagIdx).toBeGreaterThan(-1)
+    expect(nameFlagIdx).toBeGreaterThan(-1)
+    // each typed variable must be preceded by '-f'
+    expect(capturedCmd[ownerFlagIdx - 1]).toBe('-f')
+    expect(capturedCmd[nameFlagIdx - 1]).toBe('-f')
+
+    // query= arg must use $owner / $name placeholders — NOT the literal owner value
+    const queryArg = capturedCmd.find((a) => a.startsWith('query=')) ?? ''
+    expect(queryArg).toContain('$owner')
+    expect(queryArg).toContain('$name')
+    expect(queryArg).not.toContain('"Owner"')
+    expect(queryArg).not.toContain('"repo"')
+  })
+
+  it('does not call gh api graphql when gh repo view returns a hostile slug', async () => {
+    let graphqlSpawned = false
+
+    spawnSpy = vi.spyOn(Bun, 'spawnSync').mockImplementation((cmd: string[]) => {
+      if (cmd[0] === 'gh' && cmd[1] === 'repo') {
+        return {
+          // Hostile slug — assertValidRepoSlug must reject this before graphql is called
+          stdout: new TextEncoder().encode('a") { x } #/b\n'),
+          stderr: new Uint8Array(),
+          exitCode: 0,
+          success: true,
+        } as unknown as ReturnType<typeof Bun.spawnSync>
+      }
+      if (cmd[0] === 'gh' && cmd[1] === 'api') {
+        graphqlSpawned = true
+        return {
+          stdout: new TextEncoder().encode('PVT_should_not_reach\n'),
+          stderr: new Uint8Array(),
+          exitCode: 0,
+          success: true,
+        } as unknown as ReturnType<typeof Bun.spawnSync>
+      }
+      return {
+        stdout: new Uint8Array(),
+        stderr: new Uint8Array(),
+        exitCode: 1,
+        success: false,
+      } as unknown as ReturnType<typeof Bun.spawnSync>
+    })
+
+    vi.resetModules()
+    const mod = await import('../adapters/config-helpers')
+
+    // assertValidRepoSlug throws → catch swallows → GH_PROJECT_ID falls back to ''
+    expect(mod.GH_PROJECT_ID).toBe('')
+    // graphql spawn must never have fired
+    expect(graphqlSpawned).toBe(false)
+  })
+})
+
 describe('detectGitHubRepo', () => {
   const originalEnv = process.env.GITHUB_REPO
   let spawnSyncSpy: ReturnType<typeof vi.spyOn>

--- a/plugins/dev-init/skills/shared/adapters/config-helpers.ts
+++ b/plugins/dev-init/skills/shared/adapters/config-helpers.ts
@@ -50,10 +50,26 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
       if (repoProc.exitCode === 0) {
         const repo = new TextDecoder().decode(repoProc.stdout).trim()
         if (repo) {
-          const [owner, name] = repo.split('/')
-          const query = `{ repository(owner: "${owner}", name: "${name}") { projectsV2(first: 1) { nodes { id } } } }`
+          // Validate before split — a malformed slug must not flow into the GraphQL
+          // call. owner/name are passed as typed -f variables (never string-interpolated)
+          // so a hostile value cannot break out of the query.
+          const [owner, name] = assertValidRepoSlug(repo).split('/')
+          const query =
+            'query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { projectsV2(first: 1) { nodes { id } } } }'
           const idProc = Bun.spawnSync(
-            ['gh', 'api', 'graphql', '-f', `query=${query}`, '--jq', '.data.repository.projectsV2.nodes[0].id'],
+            [
+              'gh',
+              'api',
+              'graphql',
+              '-f',
+              `query=${query}`,
+              '-f',
+              `owner=${owner}`,
+              '-f',
+              `name=${name}`,
+              '--jq',
+              '.data.repository.projectsV2.nodes[0].id',
+            ],
             { stdout: 'pipe', stderr: 'pipe' },
           )
           if (idProc.exitCode === 0) {
@@ -63,7 +79,7 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
         }
       }
     } catch {
-      /* gh not available or no project linked */
+      /* gh not available, no project linked, or invalid slug from gh output */
     }
   }
 


### PR DESCRIPTION
## Summary
- `dev-init` `config-helpers.ts` `gh_project_id` auto-detect split `gh repo view` output on `/` and **interpolated owner/name directly into the GraphQL query string** (GraphQL-injection class, security-auditor C75).
- Now validates the slug via `assertValidRepoSlug()` **before** the split and passes `owner`/`name` as **typed `-f` GraphQL variables** instead of string interpolation — the query string is constant, gh handles escaping.
- Mirrors the already-hardened `dev-core` copy (closes the parallel-path drift flagged in #213). Tests added to **both** `config.test.ts` files for parity.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #213: robustness: harden dev-init config-helpers gh slug interpolation | Open |
| Implementation | 1 commit on `feat/213-harden-dev-init-config-helpers-gh-slug-interpolation` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2 new specs) | Passed |

## Notes
- Two of the three asks in #213 (port `REPO_SLUG_RE`/`assertValidRepoSlug`, validate both `detectGitHubRepo()` paths, drop `execSync` shell-string) had **already landed** via #210/#212 + the dev-init extraction. Only the `gh_project_id` GraphQL path remained — this PR closes it.

## Test Plan
- [ ] `gh_project_id auto-detect` passes `owner=`/`name=` as typed `-f` vars; `query=` contains `$owner`/`$name` placeholders, not interpolated values
- [ ] A hostile slug from `gh repo view` (e.g. `a") { x } #/b`) is rejected by `assertValidRepoSlug` before any GraphQL spawn → `GH_PROJECT_ID` falls back to `''`

Closes #213

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`