### PR TITLE
fix(dev-core,dev-init): tighten REPO_SLUG_RE owner segment to GitHub charset (#217)

### DIFF
--- a/plugins/dev-core/skills/shared/__tests__/config.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/config.test.ts
@@ -421,6 +421,33 @@ describe('detectGitHubRepo', () => {
     expect(spawnSyncSpy).not.toHaveBeenCalled()
   })
 
+  it('throws when the owner segment contains a dot', () => {
+    // GitHub owners (users/orgs) are [A-Za-z0-9-] only — no dots, unlike repo names.
+    process.env.GITHUB_REPO = 'my.org/repo'
+    expect(() => detectGitHubRepo()).toThrow('Invalid GitHub repo "my.org/repo"')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws when the owner segment contains an underscore', () => {
+    process.env.GITHUB_REPO = 'my_org/repo'
+    expect(() => detectGitHubRepo()).toThrow('Invalid GitHub repo "my_org/repo"')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts a numeric-only owner/repo slug', () => {
+    // Digits are valid in both segments — 123/456 must pass.
+    process.env.GITHUB_REPO = '123/456'
+    expect(detectGitHubRepo()).toBe('123/456')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts dots and underscores in the repo-name segment', () => {
+    // Repo names may contain . and _ — owner tightening must not regress this.
+    process.env.GITHUB_REPO = 'owner/my.repo_name'
+    expect(detectGitHubRepo()).toBe('owner/my.repo_name')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
   it('parses SSH remote URL', () => {
     spawnSyncSpy.mockImplementation((cmd: string[]) => {
       if (cmd[0] === 'gh') return { stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 1, success: false }

--- a/plugins/dev-core/skills/shared/adapters/config-helpers.ts
+++ b/plugins/dev-core/skills/shared/adapters/config-helpers.ts
@@ -95,7 +95,7 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
  * GitHub owner: [A-Za-z0-9-], repo name: [A-Za-z0-9._-].
  * Callers do `detectGitHubRepo().split('/')` and expect exactly two non-empty segments.
  */
-const REPO_SLUG_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/
+const REPO_SLUG_RE = /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/
 
 /**
  * Validate a candidate GitHub repo slug and throw a clear error if it doesn't match.

--- a/plugins/dev-init/skills/shared/__tests__/config.test.ts
+++ b/plugins/dev-init/skills/shared/__tests__/config.test.ts
@@ -421,6 +421,33 @@ describe('detectGitHubRepo', () => {
     expect(spawnSyncSpy).not.toHaveBeenCalled()
   })
 
+  it('throws when the owner segment contains a dot', () => {
+    // GitHub owners (users/orgs) are [A-Za-z0-9-] only — no dots, unlike repo names.
+    process.env.GITHUB_REPO = 'my.org/repo'
+    expect(() => detectGitHubRepo()).toThrow('Invalid GitHub repo "my.org/repo"')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws when the owner segment contains an underscore', () => {
+    process.env.GITHUB_REPO = 'my_org/repo'
+    expect(() => detectGitHubRepo()).toThrow('Invalid GitHub repo "my_org/repo"')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts a numeric-only owner/repo slug', () => {
+    // Digits are valid in both segments — 123/456 must pass.
+    process.env.GITHUB_REPO = '123/456'
+    expect(detectGitHubRepo()).toBe('123/456')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts dots and underscores in the repo-name segment', () => {
+    // Repo names may contain . and _ — owner tightening must not regress this.
+    process.env.GITHUB_REPO = 'owner/my.repo_name'
+    expect(detectGitHubRepo()).toBe('owner/my.repo_name')
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+
   it('parses SSH remote URL', () => {
     spawnSyncSpy.mockImplementation((cmd: string[]) => {
       if (cmd[0] === 'gh') return { stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 1, success: false }

--- a/plugins/dev-init/skills/shared/adapters/config-helpers.ts
+++ b/plugins/dev-init/skills/shared/adapters/config-helpers.ts
@@ -91,7 +91,7 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
  * GitHub owner: [A-Za-z0-9-], repo name: [A-Za-z0-9._-].
  * Callers do `detectGitHubRepo().split('/')` and expect exactly two non-empty segments.
  */
-const REPO_SLUG_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/
+const REPO_SLUG_RE = /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/
 
 /**
  * Validate a candidate GitHub repo slug and throw a clear error if it doesn't match.


### PR DESCRIPTION
## Summary
- GitHub owners (users/orgs) allow only `[A-Za-z0-9-]` — no dots or underscores. The previous owner pattern `[A-Za-z0-9._-]` over-permitted; narrowed to `[A-Za-z0-9-]` in **both** `config-helpers.ts` copies (parallel-path parity).
- Repo-name segment keeps `.` and `_` as GitHub allows.
- Deferred from #213 (PR #216 review). Impact: low — not a security issue (owner/name flow as typed `-f` GraphQL variables since #213/#216, so a dotted owner just yields a benign 404). This tightens diagnostics, not injection surface.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #217: tighten REPO_SLUG_RE owner segment to GitHub's actual charset | OPEN |
| Implementation | 1 commit on `feat/217-tighten-repo-slug-re-owner-segment` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4 new) | Passed |

## Test Plan
- [ ] `GITHUB_REPO=my.org/repo` → rejected (`Invalid GitHub repo`)
- [ ] `GITHUB_REPO=my_org/repo` → rejected
- [ ] `GITHUB_REPO=123/456` → accepted (numeric-only)
- [ ] `GITHUB_REPO=owner/my.repo_name` → accepted (repo-name dots/underscores preserved)

Closes #217

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`