### PR TITLE
test(shared): harden detectGitHubRepo suite + typecheck/CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         run: bun run test
       - name: Shared detectGitHubRepo suite — caller parity (#218 SC3)
         run: |
+          set -euo pipefail
           DEV_CORE="plugins/dev-core/skills/shared/__tests__/config.test.ts"
           DEV_INIT="plugins/dev-init/skills/shared/__tests__/config.test.ts"
           if ! diff "$DEV_CORE" "$DEV_INIT"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,17 @@ jobs:
         run: bun typecheck
       - name: Test (vitest)
         run: bun run test
+      - name: Shared detectGitHubRepo suite — caller parity (#218 SC3)
+        run: |
+          DEV_CORE="plugins/dev-core/skills/shared/__tests__/config.test.ts"
+          DEV_INIT="plugins/dev-init/skills/shared/__tests__/config.test.ts"
+          if ! diff "$DEV_CORE" "$DEV_INIT"; then
+            echo "ERROR: dev-core and dev-init config.test.ts have diverged."
+            echo "  The registerGitHubRepoDetectionSuite caller boilerplate must stay byte-identical."
+            echo "  See #218 spec SC3 / #225 — update both files in lockstep."
+            exit 1
+          fi
+          echo "Caller parity OK — both config.test.ts are byte-identical"
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'

--- a/plugins/dev-init/skills/init/__tests__/project.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/project.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../shared/queries', () => ({
   UPDATE_FIELD_OPTIONS_MUTATION: 'UPDATE_FIELD_OPTIONS_MUTATION',
 }))
 
-vi.mock('../../../cli/lib/workspace-store', () => ({
+vi.mock('../../shared/adapters/workspace-store', () => ({
   readWorkspace: vi.fn(() => ({ projects: [] })),
   writeWorkspace: vi.fn(),
   getWorkspacePath: () => '/tmp/test-workspace.json',

--- a/plugins/dev-init/skills/init/lib/project.test.ts
+++ b/plugins/dev-init/skills/init/lib/project.test.ts
@@ -69,7 +69,7 @@ vi.mock('../../shared/adapters/github-adapter', () => ({
 const mockWriteWorkspace = vi.fn(() => {})
 const mockReadWorkspace = vi.fn(() => ({ projects: [] }))
 
-vi.mock('../../../cli/lib/workspace-store', () => ({
+vi.mock('../../shared/adapters/workspace-store', () => ({
   readWorkspace: mockReadWorkspace,
   writeWorkspace: mockWriteWorkspace,
   getWorkspacePath: () => '/tmp/test-workspace.json',

--- a/plugins/dev-init/skills/init/lib/project.ts
+++ b/plugins/dev-init/skills/init/lib/project.ts
@@ -3,7 +3,6 @@
  * Supports --type technical|company to configure per-project field slots.
  */
 
-import { readWorkspace, writeWorkspace } from '../../../cli/lib/workspace-store'
 import {
   DEFAULT_PRIORITY_OPTIONS,
   DEFAULT_SIZE_OPTIONS,
@@ -11,6 +10,7 @@ import {
 } from '../../shared/adapters/config-helpers'
 import type { ParsedField } from '../../shared/adapters/github-adapter'
 import { ghGraphQL, linkProjectToRepo, parseProjectFields, run } from '../../shared/adapters/github-adapter'
+import { readWorkspace, writeWorkspace } from '../../shared/adapters/workspace-store'
 import type { ProjectFieldIds } from '../../shared/domain/types'
 import type { ProjectType, WorkspaceProject } from '../../shared/ports/workspace'
 import { PROJECT_WORKFLOWS_QUERY, UPDATE_FIELD_OPTIONS_MUTATION } from '../../shared/queries'

--- a/plugins/dev-init/skills/shared/adapters/workspace-store.ts
+++ b/plugins/dev-init/skills/shared/adapters/workspace-store.ts
@@ -1,0 +1,63 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { WorkspaceError } from '../domain/errors'
+import type { Workspace, WorkspaceProject } from '../ports/workspace'
+
+export function getWorkspacePath(): string {
+  const home = process.env.HOME ?? ''
+  const vault = `${home}/.roxabi-vault`
+  if (existsSync(vault)) return `${vault}/workspace.json`
+  return `${home}/.config/roxabi/workspace.json`
+}
+
+export function readWorkspace(): Workspace {
+  const p = getWorkspacePath()
+  if (!existsSync(p)) return { projects: [] }
+  const raw = JSON.parse(readFileSync(p, 'utf8')) as unknown
+  return parseWorkspace(raw)
+}
+
+/**
+ * Validate an unknown value as a Workspace. Throws with a specific field path
+ * on shape failures so the user can fix their workspace.json. Unlike the `.roxabi`
+ * marker (which fails silently and falls back to git remote), workspace.json has
+ * no fallback — fail-loud is the right default at this boundary.
+ */
+export function parseWorkspace(raw: unknown): Workspace {
+  if (!raw || typeof raw !== 'object' || !('projects' in raw)) {
+    throw new WorkspaceError('workspace.json: expected object with `projects` array')
+  }
+  const obj = raw as Record<string, unknown>
+  const projects = obj.projects
+  if (!Array.isArray(projects)) {
+    throw new WorkspaceError('workspace.json: `projects` must be an array')
+  }
+  const roadmapProjectId =
+    obj.roadmapProjectId !== undefined && typeof obj.roadmapProjectId === 'string' ? obj.roadmapProjectId : undefined
+  return { projects: projects.map(validateProject), roadmapProjectId }
+}
+
+function validateProject(p: unknown, i: number): WorkspaceProject {
+  if (!p || typeof p !== 'object') {
+    throw new WorkspaceError(`workspace.json: projects[${i}] must be an object`)
+  }
+  const obj = p as Record<string, unknown>
+  for (const field of ['repo', 'projectId', 'label'] as const) {
+    const v = obj[field]
+    if (typeof v !== 'string' || v.length === 0) {
+      throw new WorkspaceError(`workspace.json: projects[${i}].${field} must be a non-empty string`)
+    }
+  }
+  if (obj.localPath !== undefined && typeof obj.localPath !== 'string') {
+    throw new WorkspaceError(`workspace.json: projects[${i}].localPath must be a string if present`)
+  }
+  return obj as unknown as WorkspaceProject
+}
+
+export function writeWorkspace(ws: Workspace): void {
+  const p = getWorkspacePath()
+  const dir = p.substring(0, p.lastIndexOf('/'))
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+  }
+  writeFileSync(p, `${JSON.stringify(ws, null, 2)}\n`, { mode: 0o600 })
+}

--- a/plugins/shared/__tests__/detect-github-repo.suite.ts
+++ b/plugins/shared/__tests__/detect-github-repo.suite.ts
@@ -5,11 +5,30 @@ interface ConfigHelpersModule {
   detectGitHubRepo: () => string
 }
 
+/**
+ * Shared test suite for `detectGitHubRepo` + `gh_project_id` auto-detection.
+ *
+ * **Caller contract — required hoisted mocks.** This suite spies on the
+ * `node:child_process` mock and relies on the `node:fs` mock that each calling
+ * test file must hoist at module scope (vitest hoists `vi.mock(...)` above
+ * imports). The suite does NOT install these mocks itself:
+ *
+ * ```ts
+ * vi.mock('node:fs', ...)            // block .claude/dev-core.yml reads
+ * vi.mock('node:child_process', ...) // block gh CLI fallback in detectGitHubRepo
+ * ```
+ *
+ * Without both mocks the suite's `execSync` spy and config-helper loads behave
+ * non-deterministically (real fs/child_process reach the host environment).
+ */
 export function registerGitHubRepoDetectionSuite(opts: {
   detectGitHubRepo: () => string
   loadConfigHelpers: () => Promise<ConfigHelpersModule>
 }) {
   const { detectGitHubRepo, loadConfigHelpers } = opts
+  // Capture the live pre-test value once so both blocks restore the caller's
+  // real GITHUB_REPO (not a hardcoded sentinel) in their afterEach.
+  const originalGitHubRepo = process.env.GITHUB_REPO
 
   describe('gh_project_id auto-detect', () => {
     let spawnSpy: ReturnType<typeof vi.spyOn>
@@ -24,7 +43,11 @@ export function registerGitHubRepoDetectionSuite(opts: {
     afterEach(() => {
       spawnSpy?.mockRestore()
       delete process.env.GH_PROJECT_ID
-      process.env.GITHUB_REPO = 'Test/test-repo'
+      if (originalGitHubRepo !== undefined) {
+        process.env.GITHUB_REPO = originalGitHubRepo
+      } else {
+        delete process.env.GITHUB_REPO
+      }
       vi.resetModules()
     })
 
@@ -120,7 +143,6 @@ export function registerGitHubRepoDetectionSuite(opts: {
   })
 
   describe('detectGitHubRepo', () => {
-    const originalEnv = process.env.GITHUB_REPO
     let spawnSyncSpy: ReturnType<typeof vi.spyOn>
     let execSyncSpy: ReturnType<typeof vi.spyOn>
 
@@ -135,8 +157,8 @@ export function registerGitHubRepoDetectionSuite(opts: {
     })
 
     afterEach(() => {
-      if (originalEnv !== undefined) {
-        process.env.GITHUB_REPO = originalEnv
+      if (originalGitHubRepo !== undefined) {
+        process.env.GITHUB_REPO = originalGitHubRepo
       } else {
         delete process.env.GITHUB_REPO
       }

--- a/plugins/shared/__tests__/detect-github-repo.suite.ts
+++ b/plugins/shared/__tests__/detect-github-repo.suite.ts
@@ -272,10 +272,9 @@ export function registerGitHubRepoDetectionSuite(opts: {
       expect(detectGitHubRepo()).toBe('Roxabi/roxabi-plugins')
     })
 
-    it('throws when no env var, no git remote, and no gh CLI', async () => {
-      // Temporarily remove GITHUB_REPO env var to force git detection
-      const originalEnv = process.env.GITHUB_REPO
-      delete process.env.GITHUB_REPO
+    it('throws when no env var, no git remote, and no gh CLI', () => {
+      // beforeEach already deleted GITHUB_REPO; afterEach restores originalGitHubRepo.
+      // No in-test save/restore needed — that path forces git detection.
 
       // Mock git to fail
       spawnSyncSpy.mockReturnValue({
@@ -287,9 +286,6 @@ export function registerGitHubRepoDetectionSuite(opts: {
 
       // The function should throw when detection fails
       expect(() => detectGitHubRepo()).toThrow('Cannot detect GitHub repo')
-
-      // Restore env
-      process.env.GITHUB_REPO = originalEnv
     })
   })
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "vitest.config.ts",
     "vitest.setup.ts",
     "plugins/dev-core/**/*.ts",
+    "plugins/dev-init/**/*.ts",
     "plugins/shared/**/*.ts"
   ],
   "exclude": [
@@ -22,6 +23,7 @@
     "plugins/dev-core/cli/__tests__",
     "plugins/dev-core/cli/index.ts",
     "plugins/dev-core/skills/init/init.ts",
-    "plugins/dev-core/skills/issue-triage/triage.ts"
+    "plugins/dev-core/skills/issue-triage/triage.ts",
+    "plugins/dev-init/skills/init/init.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- Follow-up hardening pass on the shared `detectGitHubRepo` / `gh_project_id` test factory consolidated in #218 / PR #221. Addresses the 4 non-blocking review items.
- Test-infra only, with one runtime fix: a latent broken import in dev-init surfaced once dev-init was brought under typecheck.

**The 4 items:**
1. **Bring dev-init under typecheck** (parallel-path-drift) — added `plugins/dev-init/**/*.ts` to `tsconfig.json` `include`; excluded `dev-init/skills/init/init.ts` (mirrors the dev-core top-level-await exclude). This surfaced a broken import (`dev-init/init/lib/project.ts → ../../../cli/lib/workspace-store`, resolving to a non-existent `dev-init/cli/`) that passed only because tests `vi.mock` the specifier. Fixed by adding a dev-init-native `skills/shared/adapters/workspace-store.ts` (its deps `WorkspaceError` + `ports/workspace` already exist) and repointing the import + both test mocks.
2. **CI byte-identity guardrail** — new ci.yml step asserts the two `config.test.ts` callers stay byte-identical (encodes #218 spec SC3).
3. **Restore live `GITHUB_REPO`** — capture `originalGitHubRepo` once at factory top; both `afterEach` blocks restore it via the `!== undefined ? set : delete` pattern (removes the hardcoded `'Test/test-repo'` sentinel restore and the describe-registration-time capture divergence).
4. **JSDoc** on `registerGitHubRepoDetectionSuite` documenting the required caller-hoisted `vi.mock('node:child_process')` + `vi.mock('node:fs')`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #225: Harden shared detectGitHubRepo test suite + typecheck/CI coverage | OPEN |
| Implementation | 1 commit on `feat/225-harden-detectgithubrepo-suite` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (726 passed, 4 skipped) | Passed |

## Test Plan
- [ ] `bun run typecheck` passes with `plugins/dev-init/**` now included
- [ ] `bun run test` green (726 passed)
- [ ] CI parity step fails if the two `config.test.ts` diverge
- [ ] dev-init `project.test.ts` (both copies) still pass against the new `workspace-store` mock path

Closes #225

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`