### PR TITLE
refactor(dev-core): thread localPath through discoverProject

### DIFF
--- a/plugins/dev-core/skills/shared/__tests__/adapters.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/adapters.test.ts
@@ -1,9 +1,12 @@
 // TODO: Add behavioral tests with mocked Bun.spawnSync and fetch
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { EnvConfigAdapter } from '../adapters/env-config'
 import { GitWorkspaceAdapter } from '../adapters/git-workspace'
 import type { ConfigPort } from '../ports/config'
 import type { WorkspacePort } from '../ports/workspace'
+
+const discoverProjectFn = vi.hoisted(() => vi.fn(async () => []))
+vi.mock('../adapters/github-discovery', () => ({ discoverProject: discoverProjectFn }))
 
 describe('EnvConfigAdapter', () => {
   it('implements ConfigPort', () => {
@@ -29,5 +32,21 @@ describe('GitWorkspaceAdapter', () => {
     expect(typeof adapter.discoverProject).toBe('function')
     expect(typeof adapter.listBranches).toBe('function')
     expect(typeof adapter.listWorktrees).toBe('function')
+  })
+
+  describe('discoverProject', () => {
+    beforeEach(() => discoverProjectFn.mockClear())
+
+    it('forwards localPath to the shared discoverProject', async () => {
+      const adapter = new GitWorkspaceAdapter()
+      await adapter.discoverProject('Roxabi/roxabi-plugins', '/home/me/clone')
+      expect(discoverProjectFn).toHaveBeenCalledWith('Roxabi/roxabi-plugins', '/home/me/clone')
+    })
+
+    it('passes localPath as undefined when the caller omits it', async () => {
+      const adapter = new GitWorkspaceAdapter()
+      await adapter.discoverProject('Roxabi/roxabi-plugins')
+      expect(discoverProjectFn).toHaveBeenCalledWith('Roxabi/roxabi-plugins', undefined)
+    })
   })
 })

--- a/plugins/dev-core/skills/shared/__tests__/adapters.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/adapters.test.ts
@@ -43,10 +43,13 @@ describe('GitWorkspaceAdapter', () => {
       expect(discoverProjectFn).toHaveBeenCalledWith('Roxabi/roxabi-plugins', '/home/me/clone')
     })
 
-    it('passes localPath as undefined when the caller omits it', async () => {
+    it('forwards undefined (never an injected path) when the caller omits localPath', async () => {
       const adapter = new GitWorkspaceAdapter()
       await adapter.discoverProject('Roxabi/roxabi-plugins')
-      expect(discoverProjectFn).toHaveBeenCalledWith('Roxabi/roxabi-plugins', undefined)
+      // toStrictEqual on the exact call args (vs toHaveBeenCalledWith) guards against
+      // a regression that re-injects a detected path — e.g. discoverProjectFn(repo, detectLocalPath(repo)) —
+      // which would re-introduce the shared->cli coupling #219 removed.
+      expect(discoverProjectFn.mock.lastCall).toStrictEqual(['Roxabi/roxabi-plugins', undefined])
     })
   })
 })

--- a/plugins/dev-core/skills/shared/adapters/git-workspace.ts
+++ b/plugins/dev-core/skills/shared/adapters/git-workspace.ts
@@ -16,8 +16,8 @@ export class GitWorkspaceAdapter implements WorkspacePort {
     writeWorkspaceFn(ws)
   }
 
-  async discoverProject(repo: string): Promise<WorkspaceProject[]> {
-    return discoverProjectFn(repo)
+  async discoverProject(repo: string, localPath?: string): Promise<WorkspaceProject[]> {
+    return discoverProjectFn(repo, localPath)
   }
 
   async listBranches(): Promise<Branch[]> {

--- a/plugins/dev-core/skills/shared/ports/workspace.ts
+++ b/plugins/dev-core/skills/shared/ports/workspace.ts
@@ -30,7 +30,7 @@ export interface Workspace {
 export interface WorkspacePort {
   readWorkspace(): Workspace
   writeWorkspace(ws: Workspace): void
-  discoverProject(repo: string): Promise<WorkspaceProject[]>
+  discoverProject(repo: string, localPath?: string): Promise<WorkspaceProject[]>
   listBranches(): Promise<Branch[]>
   listWorktrees(): Promise<Worktree[]>
 }

--- a/plugins/dev-init/skills/shared/ports/workspace.ts
+++ b/plugins/dev-init/skills/shared/ports/workspace.ts
@@ -28,7 +28,7 @@ export interface Workspace {
 export interface WorkspacePort {
   readWorkspace(): Workspace
   writeWorkspace(ws: Workspace): void
-  discoverProject(repo: string): Promise<WorkspaceProject[]>
+  discoverProject(repo: string, localPath?: string): Promise<WorkspaceProject[]>
   listBranches(): Promise<Branch[]>
   listWorktrees(): Promise<Worktree[]>
 }


### PR DESCRIPTION
## Summary
- After the #195 cycle break, `GitWorkspaceAdapter.discoverProject` called the shared `discoverProject(repo)` without a `localPath` arg, so `localPath` was always `undefined` for the adapter (latent, not an active regression — production callers go through the `cli/lib` wrapper which still injects `detectLocalPath(repo)`).
- Adds `localPath?` to `WorkspacePort.discoverProject` and forwards it through the adapter to the shared (cli-free) impl, letting the cli boundary inject it — without re-introducing a shared→cli import (preserves SC#1).
- Behavioral tests assert the param is threaded (both passed and omitted).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #219: thread localPath through GitWorkspaceAdapter.discoverProject | OPEN |
| Implementation | 1 commit on `feat/219-thread-localpath-discoverproject` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2 new) | Passed |

## Test Plan
- [ ] `bun run test` green (728 passed)
- [ ] Adapter forwards `localPath` to shared `discoverProject` when provided
- [ ] Adapter passes `undefined` when caller omits `localPath`

Closes #219

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`