### PR TITLE
docs(issue-triage): document GITHUB_REPO= cross-repo create workflow

### DIFF
--- a/plugins/dev-core/references/issue-taxonomy.md
+++ b/plugins/dev-core/references/issue-taxonomy.md
@@ -38,6 +38,7 @@ Single fact source for issue metadata across every Roxabi repo (`lyra`, `voiceCL
 | Assignees | ❌ per-repo | no cross-repo user list, but user identity is org-wide |
 | Sub-issues | ✅ cross-org | |
 | blocked_by / blocking | ✅ cross-repo | `addBlockedBy` hits EMU restrictions cross-org; not a concern for Roxabi |
+| **Issue create target** | ⚙️ env/config | Fields and edges above are native cross-repo; the CREATE target is cwd-bound by default. Override: set `GITHUB_REPO=owner/repo` env var (or `github_repo` in dev-core config) to create in a different repo. Caveat 1: retargets the entire invocation — bare `#N` refs resolve against the override, not the cwd; always use `OWNER/REPO#N`. Caveat 2: `addToProject` only succeeds if the target repo is linked to the configured `GH_PROJECT_ID` (non-fatal warning otherwise). |
 
 ---
 

--- a/plugins/dev-core/skills/issue-triage/README.md
+++ b/plugins/dev-core/skills/issue-triage/README.md
@@ -20,6 +20,16 @@ Raw GitHub issues lack structure. `/issue-triage` adds Size (XS→XL), Priority 
 
 Triggers: `"triage"` | `"create issue"` | `"set size"` | `"set priority"` | `"blocked by"` | `"set parent"` | `"sub-issue"` | `"file an issue"` | `"open an issue"`
 
+## Cross-repo create
+
+Prefix `GITHUB_REPO=<owner/repo>` to create an issue in a different repo than the current cwd:
+
+```bash
+GITHUB_REPO=Roxabi/voiceCLI /issue-triage create --title "..." --blocked-by Roxabi/lyra#728
+```
+
+Cross-repo relation flags (`--blocked-by`, `--blocks`, `--parent`, `--add-child`) accept `OWNER/REPO#N` natively and work independently of `GITHUB_REPO`. When the env var is set, always use fully-qualified refs — bare `#N` resolves against the overridden repo.
+
 ## Size Guidelines
 
 | Size | Description |

--- a/plugins/dev-core/skills/issue-triage/SKILL.md
+++ b/plugins/dev-core/skills/issue-triage/SKILL.md
@@ -85,6 +85,25 @@ Create GitHub issues, assign Size/Priority/Status, manage blockedBy dependencies
 | `--blocked-by <REF>[,<REF>...]` | Set blocked-by on creation |
 | `--blocks <REF>[,<REF>...]` | Set blocking on creation |
 
+### Cross-repo create
+
+Set `GITHUB_REPO=<owner/repo>` to retarget the CREATE to a different repo than the cwd's git remote:
+
+```bash
+# File a voiceCLI issue while cwd is lyra (or any other repo)
+GITHUB_REPO=Roxabi/voiceCLI τ create \
+  --title 'STT: audio dropout at segment boundary' \
+  --blocked-by Roxabi/lyra#728
+```
+
+Cross-repo **relations** (`--blocked-by`, `--blocks`, `--parent`, `--add-child`) accept `OWNER/REPO#N` natively — they work regardless of `GITHUB_REPO`.
+
+**Caveat 1 — keep refs fully-qualified:** `GITHUB_REPO` retargets the entire invocation. A bare `#N` in any ref resolves against the overridden repo, not the cwd repo → always use `OWNER/REPO#N` for any cross-repo ref when the env var is set.
+
+**Caveat 2 — project board:** `addToProject` uses the single configured `GH_PROJECT_ID`. The new issue joins the board only if the target repo is linked to that project; otherwise a non-fatal warning is printed and the issue is still created.
+
+**Resolution order** (`detectGitHubRepo`): (1) `github_repo` in dev-core config ∨ `GITHUB_REPO` env var (validated as `owner/repo`) → (2) fallback `git remote get-url origin` of the cwd.
+
 ## Deferred Follow-Ups — Sibling Rule
 
 **Defer ≠ decomposition.** When an issue A defers work to a new follow-up B (out-of-scope finding, post-merge gap, "do this later"), B is a **sibling** of A under their shared parent — NOT a child of A.


### PR DESCRIPTION
## Summary

Closes #228.

Documents the `GITHUB_REPO=<owner/repo>` env override — the supported way to **create** an issue in a different repo than the cwd's git remote (e.g. file a voiceCLI issue while in lyra). The behaviour already works in code (`detectGitHubRepo` → `createGitHubIssue`) but was documented nowhere.

## Changes (docs-only)

| File | Change |
|---|---|
| `SKILL.md` | New `### Cross-repo create` section — `GITHUB_REPO=` prefix, example, both caveats, resolution order |
| `README.md` | Short cross-repo create pointer near create docs |
| `references/issue-taxonomy.md` | New row in §2 Cross-repo behavior — create-target resolution + caveats |

## Caveats documented

1. `GITHUB_REPO` retargets the **entire** invocation → keep refs fully-qualified (`OWNER/REPO#N`); bare `#N` resolves against the override.
2. Project board: cross-repo issue joins the configured `GH_PROJECT_ID` board only if the target repo is linked, else non-fatal warning.

## Out of scope

First-class `--repo` flag on `create`/`set` (separate F-lite issue if friction persists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)