### PR TITLE
feat(dev-core): compact pause between /plan and /implement (F-lite/F-full)

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 33 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.5.0",
+  "version": "0.4.9",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 33 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -2,7 +2,7 @@
 name: dev
 argument-hint: '[#N | "idea" | --from <step> | --audit]'
 description: Workflow orchestrator — single entry point for the full dev lifecycle. Triggers: "dev" | "start working on" | "work on issue" | "work on #" | "develop" | "pick up issue" | "tackle issue" | "let's work on".
-version: 0.4.0
+version: 0.3.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---
 

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -2,7 +2,7 @@
 name: dev
 argument-hint: '[#N | "idea" | --from <step> | --audit]'
 description: Workflow orchestrator — single entry point for the full dev lifecycle. Triggers: "dev" | "start working on" | "work on issue" | "work on #" | "develop" | "pick up issue" | "tackle issue" | "let's work on".
-version: 0.3.0
+version: 0.4.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---
 
@@ -253,7 +253,7 @@ audit ∧ S* ∈ critical → reasoning audit per [reasoning-audit.md](${CLAUDE_
 | frame | gate | `skill: "frame", args: "{N:+--issue $N}"` | analyze (F-full) ∨ spec (F-lite) |
 | analyze | adv | `skill: "analyze", args: "{N:+--issue $N}"` | spec |
 | spec | gate | `skill: "spec", args: "{N:+--issue $N}"` | plan |
-| plan | gate | `skill: "plan", args: "{N:+--issue $N}"` | implement (auto-chain after approval) |
+| plan | gate | `skill: "plan", args: "{N:+--issue $N}"` | implement — via Step 8b compact pause (F-lite/F-full; ¬auto-chain) |
 | implement | adv | `skill: "implement", args: "{N:+--issue $N}"` | pr |
 | pr | adv | `skill: "pr"` (auto-detects branch + issue) | ci-watch |
 | ci-watch | adv | `skill: "ci-watch", args: "--pr {PR#}"` | validate |
@@ -274,7 +274,8 @@ Skill returns → **IMMEDIATELY in the same turn, silently:**
 1. `TaskUpdate(task_id_map[S*], status: "completed")`
 2. `Σ_s[step] = true`
 3. Goto Step 1 (re-scan Σ)
-4. Execute Step 7 for new S*
+4. **Compact pause** (Step 8b) — completed step == plan ∧ τ ∈ {F-lite, F-full} ∧ new S* == implement → present pause, **STOP this turn** (¬Step 7).
+5. Execute Step 7 for new S*
 
 **¬write** "Step X complete" message between skill return and re-scan.
 **¬write** "Moving to Y" message between re-scan and Step 7.
@@ -284,8 +285,30 @@ Skill returns → **IMMEDIATELY in the same turn, silently:**
 Skill fails/aborts → leave task `in_progress` → present recovery decision via protocol (Pattern A): **Retry** | **Skip** | **Abort**.
 Σ_s ensures within-session advancement for artifact-less steps (validate, review, fix).
 Session restart → Σ_s = ∅ → artifact-less steps re-run. 2b.1 will find the existing tasks (status possibly `completed` from last run) and skip re-seeding.
-gate → re-scan detects updated artifact → Step 6 gate → Step 7 immediately (¬second prompt).
+gate → re-scan detects updated artifact → Step 6 gate → Step 7 immediately (¬second prompt). **Exception:** completed gate == plan ∧ τ ∈ {F-lite, F-full} → Step 8b compact pause (¬Step 7 this turn).
 adv → re-scan → Step 7 immediately.
+
+## Step 8b — Compact Pause (plan→implement, F-lite/F-full)
+
+**Trigger:** in Step 8, the step that just completed == `plan` ∧ τ ∈ {F-lite, F-full} ∧ new S* == `implement`.
+τ=S never reaches here — `plan` is skipped, so the pipeline goes straight to `implement` with no pause.
+
+**Why:** `/plan` consumed heavy context (spec read, scope glob/grep, micro-task generation, mermaid). `/implement` spawns fresh agents whose context is injected from the task list + plan artifact — the planning conversation is dead weight. Tasks persist (task list + plan artifact `## Task IDs`); `/implement` Step 1b re-attaches after a context reset. `/compact` = soft restart → safe.
+
+**Behavior:** do **NOT** auto-chain to `/implement`. Print the recommendation block below and **STOP this turn** (Claude cannot invoke `/compact` — it is user-typed):
+
+```
+✓ Plan approved — {n} tasks seeded + committed ({τ}).
+  Tasks persist (task list + plan artifact ## Task IDs) → safe to compact.
+
+  Recommended before building:
+    1. /compact          clear planning context
+    2. /dev #{N}         resume → re-attaches tasks → ≡ /implement #{N}
+
+  Skip compact? → /implement --issue {N} directly.
+```
+
+**Re-fire guard:** the pause is keyed to *plan having just run this turn*, not to *implement being next*. On the resume turn (`/dev #{N}` after `/compact`), `/dev` did not execute `plan` (Σ.plan already true on disk) → Step 8b does not apply → Step 7 invokes `/implement` directly, no second prompt.
 
 ## Phases + Gate Summary
 
@@ -293,7 +316,7 @@ adv → re-scan → Step 7 immediately.
 |-------|-------|-----------|
 | Frame | triage → recheck → frame | frame approval (status: approved) |
 | Shape | analyze → spec | spec approval |
-| Build | plan → implement → pr | plan approval (then auto-chains implement → pr) |
+| Build | plan → implement → pr | plan approval → compact pause (F-lite/F-full, Step 8b) before implement → pr |
 | Verify | ci-watch → validate → review → fix | post-review: fix/merge/stop. Merge = feature→staging (via /code-review Phase 8). |
 | Ship | promote → cleanup | promote always skipped. cleanup runs if worktree/branches stale. |
 

--- a/plugins/dev-core/skills/plan/README.md
+++ b/plugins/dev-core/skills/plan/README.md
@@ -33,4 +33,4 @@ artifacts/plans/{N}-{slug}-plan.mdx
 
 ## Chain position
 
-**Predecessor:** `/spec` | **Successor:** `/implement` (auto-chains after approval)
+**Predecessor:** `/spec` | **Successor:** `/implement` (via a compact pause after approval — `/dev` recommends `/compact` before building, then `/dev #N` ≡ `/implement #N`)

--- a/plugins/dev-core/skills/plan/SKILL.md
+++ b/plugins/dev-core/skills/plan/SKILL.md
@@ -2,7 +2,7 @@
 name: plan
 argument-hint: '[--issue <N> | --spec <path> | --audit]'
 description: Implementation plan — tasks, agents, file groups, dependencies. Triggers: "plan" | "plan this" | "implementation plan" | "break it down" | "plan this feature" | "how should we build this" | "make a plan" | "create a plan" | "break this down into tasks" | "task breakdown".
-version: 0.4.0
+version: 0.5.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---
 
@@ -322,6 +322,8 @@ This lets `/implement` re-attach to tasks after a session restart (TaskList woul
 
 `git add artifacts/plans/{N}-{slug}-plan.mdx` + commit per CLAUDE.md Rule 5.
 
+→ Then **Exit** — approval lands on a compact pause (recommend `/compact` before `/implement`), ¬auto-chain. See Exit.
+
 ## Edge Cases
 
 Read [references/edge-cases.md](${CLAUDE_SKILL_DIR}/references/edge-cases.md).
@@ -337,8 +339,8 @@ Read [references/edge-cases.md](${CLAUDE_SKILL_DIR}/references/edge-cases.md).
 
 - **Phase:** Build
 - **Predecessor:** `/spec` (artifact: `artifacts/specs/{N}-{slug}-spec.mdx`)
-- **Successor:** `/implement` (auto-chain after approval)
-- **Class:** gate (user approval of plan artifact required) → adv (auto-chain to `/implement`)
+- **Successor:** `/implement` (via compact pause — `/dev` Step 8b; ¬auto-chain for F-lite/F-full)
+- **Class:** gate (user approval of plan artifact required) → **pause** (compact recommendation before `/implement`)
 
 ## Task Integration
 
@@ -348,8 +350,14 @@ Read [references/edge-cases.md](${CLAUDE_SKILL_DIR}/references/edge-cases.md).
 
 ## Exit
 
-- **Approved via `/dev`:** run Steps 6a/6b/6c (seed tasks, persist IDs, commit) → return silently. ¬ask "proceed to /implement?". `/dev` re-scans and auto-chains to `/implement` **in the same turn** (no second prompt).
-- **Approved standalone:** print one line: `Approved. Next: /implement --issue N`. Stop.
+`/plan` runs only for τ ∈ {F-lite, F-full} (τ=S skips plan) → approval always lands on a **compact pause** before `/implement`.
+
+- **Approved via `/dev`:** run Steps 6a/6b/6c (seed tasks, persist IDs, commit) → return silently. ¬ask "proceed to /implement?". `/dev` re-scans → **Step 8b compact pause** (¬auto-chain): recommends `/compact` then `/implement` (or `/dev #N`) and stops the turn.
+- **Approved standalone:** print the compact recommendation + stop:
+  ```
+  ✓ Plan approved — {n} tasks seeded + committed.
+    Recommended: /compact → then /implement --issue {N}  (/dev #{N} ≡ /implement #{N})
+  ```
 - **Modify requested:** loop in-skill, re-present.
 - **Rejected/aborted:** return → `/dev` marks task `cancelled`.
 

--- a/plugins/dev-core/skills/plan/SKILL.md
+++ b/plugins/dev-core/skills/plan/SKILL.md
@@ -2,7 +2,7 @@
 name: plan
 argument-hint: '[--issue <N> | --spec <path> | --audit]'
 description: Implementation plan — tasks, agents, file groups, dependencies. Triggers: "plan" | "plan this" | "implementation plan" | "break it down" | "plan this feature" | "how should we build this" | "make a plan" | "create a plan" | "break this down into tasks" | "task breakdown".
-version: 0.5.0
+version: 0.4.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---
 

--- a/plugins/dev-core/skills/shared/references/chain-contract.md
+++ b/plugins/dev-core/skills/shared/references/chain-contract.md
@@ -9,9 +9,11 @@ Defines how the 13 dev-core pipeline skills participate in the `/dev` orchestrat
 ## Pipeline
 
 ```
-issue-triage → frame → analyze → spec → plan → implement → pr
+issue-triage → frame → analyze → spec → plan ⏸→ implement → pr
             → ci-watch → validate → code-review → {fix ↺ review | merge → cleanup}
 ```
+
+> `plan ⏸→ implement`: for τ ∈ {F-lite, F-full}, `/dev` inserts a **compact pause** between plan and implement (Step 8b) — recommend `/compact` before building. τ=S skips plan entirely. See the gate-class Exit `/plan` exception.
 
 ## Ownership model
 
@@ -20,6 +22,7 @@ issue-triage → frame → analyze → spec → plan → implement → pr
 | dev-pipeline task lifecycle (seed, in_progress, completed, cancelled) | `/dev` |
 | Step transitions (what runs next) | `/dev` Step 5 STEPS list + Step 7 invocation map |
 | Gate approval prompts (frame, spec, plan) | `/dev` Step 6 + the skill itself |
+| Compact pause (plan→implement, F-lite/F-full) | `/dev` Step 8b |
 | Standalone invocation fallback | Each skill's Exit section |
 | Sub-task creation (with `kind` ≠ `dev-pipeline`) | Individual skills (plan, code-review) |
 | Loop handling (review ↔ fix) | Follow-up TaskCreate with `metadata.iteration` |
@@ -29,7 +32,7 @@ issue-triage → frame → analyze → spec → plan → implement → pr
 | Class | Meaning | Skills | Exit behavior |
 |---|---|---|---|
 | **adv** | Continuous flow, no user gate | issue-triage, analyze, implement, pr, ci-watch, validate, cleanup | Return silently; `/dev` auto-advances |
-| **gate** | User approval of artifact required | frame, spec, plan | Present artifact → on approve, return silently; `/dev` auto-chains to successor |
+| **gate** | User approval of artifact required | frame, spec, plan | Present artifact → on approve, return silently; `/dev` auto-chains to successor (**plan exception:** compact pause before `/implement` — see below) |
 | **verdict** | Branches based on outcome | code-review | APPROVED → merge → cleanup; CHANGES_REQUESTED → `/fix` |
 | **loop** | Cycles back to predecessor (bounded) | fix | On success → TaskCreate follow-up review; max 2 iterations |
 | **standalone** | Never auto-triggered by `/dev` | promote | Runs only on explicit user invocation |
@@ -99,6 +102,8 @@ fix-iter-2 (dev-pipeline)
 - **Modify requested:** loop in-skill, re-present.
 - **Rejected/aborted:** return → `/dev` marks task `cancelled`.
 ```
+
+**`/plan` exception — compact pause:** `/plan` (τ ∈ {F-lite, F-full} only; τ=S skips it) does **not** auto-chain to `/implement`. After seed+commit, `/dev` Step 8b prints a compact-pause recommendation (`/compact` → `/implement`, where `/dev #N` ≡ `/implement #N`) and stops the turn. Rationale: planning context is dead weight for the build phase; tasks persist (task list + artifact `## Task IDs`) so `/implement` Step 1b re-attaches after the compact. Re-fire guard: the pause is keyed to *plan having just run*, so the post-compact `/dev #N` resume goes straight to `/implement`.
 
 ### verdict-class Exit (code-review)
 


### PR DESCRIPTION
## What

Replace the `/plan → /implement` **auto-chain** with a **compact pause** for F-lite/F-full tiers.

```
before:  /plan approve → seed → commit → [/dev auto-chain] → /implement
after:   /plan approve → seed → commit → ⏸ Step 8b → recommend /compact → STOP
```

After `/plan` seeds + commits its tasks, `/dev` Step 8b prints a recommendation and stops the turn (instead of invoking `/implement`):

```
✓ Plan approved — {n} tasks seeded + committed ({τ}).
  Recommended before building:
    1. /compact          clear planning context
    2. /dev #{N}         resume → re-attaches tasks → ≡ /implement #{N}
  Skip compact? → /implement --issue {N} directly.
```

## Why

Planning context (spec read, scope glob/grep, micro-task generation, mermaid) is dead weight for the build phase. `/implement` spawns fresh agents whose context is injected from the task list + plan artifact — not from the planning conversation. Compacting before building frees the budget for agent spawning + QG loops.

Safe because tasks **persist** (Claude Code task list + plan artifact `## Task IDs`) and `/implement` Step 1b already re-attaches after a context reset (1b.1 verify / 1b.2 partial / 1b.3 total miss). `/compact` is a soft restart — the re-attach infra already existed.

## Guarantees

| Point | Mechanism |
|---|---|
| S-tier unaffected | `plan` is skipped for S → straight to `implement`, no pause |
| Tasks survive compact | task list + artifact `## Task IDs`; `/implement` Step 1b re-attaches |
| No re-prompt on resume | pause keyed to *plan-just-ran*, not *implement-is-next* → `/dev #N` after `/compact` invokes `/implement` directly |

## Files (4)

- `dev/SKILL.md` — Step 8 list, **new Step 8b** (compact pause), gate exception, invocation map, phase summary
- `plan/SKILL.md` — Exit (via-`/dev` + standalone), Chain Position `gate→pause`, Step 6c pointer
- `plan/README.md` — chain position line
- `shared/references/chain-contract.md` — pipeline `⏸`, ownership row, gate-class `/plan` exception

No version bumps — versioning is automated (`release-please`).

## Notes

- ADR-010 (chain contract) is already `superseded` and left untouched — the compact pause is consistent with its decision (`/dev` owns transitions).
- Orthogonal/pre-existing: `validate_plugins.py` personal-data scan flags `mickaelV0` in `cli/__tests__/workspace.test.ts` (present on staging, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)