### PR TITLE
chore(dev-core): residual hygiene from #214 review

### DIFF
--- a/artifacts/frames/229-residual-hygiene-214-frame.mdx
+++ b/artifacts/frames/229-residual-hygiene-214-frame.mdx
@@ -1,0 +1,53 @@
+---
+title: residual hygiene from #214 review (symlink deref, regex drift, lefthook hook)
+issue: 229
+status: approved
+tier: F-lite
+date: 2026-05-31
+---
+
+## Problem
+
+Three low-priority parity gaps surfaced during the #214 reconcile re-review and were deferred so #214 could merge. Each is a self-contained asymmetry between two code paths that should behave identically:
+
+1. **Symlink non-resolution** — `tools/sync-shared.ts:32` `assertInRepo` uses `resolve()` (normalizes `..` only), not `realpathSync`. A symlink target outside the repo would pass the containment check. The Python validator (`validate_plugins.py`) already derefs via `.resolve()` — the TS side is asymmetric.
+2. **`REPO_SLUG_RE` drift** — `config-helpers.ts:98` owner segment `[A-Za-z0-9-]+` vs `cwd-resolver.ts:6` tightened `[A-Za-z0-9][A-Za-z0-9._-]*`. Two canonical forms for the same concept (#217 shipped a third).
+3. **No scoped lefthook hook for `shared-sources-sync`** — covered only by the bare `taxonomy-sync` hook, which `.venv`-gates locally → silently skips if `.venv` absent. CI always enforces; local does not.
+
+Observable impact: low (inputs are repo-controlled), but drift compounds and the silent local skip ships un-synced copies that only fail in CI.
+
+## Who
+
+- **Primary:** roxabi-plugins maintainers — consistency of governance gates (copy-sync, containment checks) across TS/Python.
+- **Secondary:** contributors without a local `.venv` — currently ship un-synced `config-helpers.ts` copies that fail only in CI.
+
+## Constraints
+
+- Item 2 touches the copy-synced governance file `config-helpers.ts` — dev-core canonical edited; dev-init copy re-synced via `bun run sync:shared` (byte-equality gate via `validate_plugins.py --check shared-sources-sync`).
+- Owner-segment test updates must land in `plugins/shared/__tests__/detect-github-repo.suite.ts` (shared-import test factory).
+- No `--force` / `--hard` / `--amend`. Merge-commit only.
+- `realpathSync` must catch `ENOENT` for not-yet-written targets (parity with Python's resolve-then-check).
+
+## Out of Scope
+
+- Re-litigating #217's third regex form beyond reconciling to one canonical.
+- Broader sync-shared.ts refactor — only the symlink-deref alignment.
+- Any non-deferred #214 work (already merged).
+
+## Premise Validity
+
+**Success in 6 months:** All 3 parity gaps closed — TS↔Python symlink handling symmetric (`realpathSync`), one canonical `REPO_SLUG_RE` across `config-helpers` + `cwd-resolver`, lefthook hook enforces `shared-sources-sync` locally. CI + local gates agree, no regression.
+
+**Failure in 6 months (falsifiable):** Any one observable after merge — (a) `shared-sources-sync` still silently skips locally when `.venv` absent; (b) a 4th `REPO_SLUG_RE` form appears (divergence reintroduced); (c) a symlink target outside the repo passes `assertInRepo`.
+
+**Simplest alternative:** Do nothing — inputs are repo-controlled, low risk.
+**Why not simplest:** Regex drift is already at 3 forms (#217) and compounds; silent local skip ships un-synced copies that only fail in CI → wasted contributor round-trips.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (dev tooling), ~5 files, no unknowns; warrants spec/plan gates due to copy-sync governance sensitivity.
+
+Signals observed:
+- 5 files, single domain → above S threshold
+- No new architecture, no unknowns → below F-full
+- Copy-synced governance file in scope → spec/plan gates justified

--- a/artifacts/plans/229-residual-hygiene-214-plan.mdx
+++ b/artifacts/plans/229-residual-hygiene-214-plan.mdx
@@ -1,0 +1,193 @@
+---
+title: "Plan: residual hygiene from #214 review"
+issue: 229
+spec: artifacts/specs/229-residual-hygiene-214-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: 2026-05-31
+---
+
+## Summary
+
+Close three deferred parity gaps from #214: (1) symlink-deref `assertInRepo` in `sync-shared.ts`, (2) single-source `REPO_SLUG_RE` (export from `config-helpers.ts`, import in `cwd-resolver.ts`), (3) a bun-native `shared-sources-sync` lefthook hook. Three independent slices, mechanical.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph sync["tools/sync-shared.ts"]
+        AIR["assertInRepo(abs, rel)"]
+        RPS["realpathSync + ENOENT catch"]
+        AIR --> RPS
+    end
+    subgraph ch["config-helpers.ts (canonical)"]
+        RE["export REPO_SLUG_RE"]
+        AVR["assertValidRepoSlug"]
+        RE --> AVR
+    end
+    subgraph cw["cwd-resolver.ts"]
+        IMP["import REPO_SLUG_RE"]
+        PGR["parseGitRemoteUrl / .roxabi"]
+        IMP --> PGR
+    end
+    subgraph di["dev-init copy"]
+        COPY["config-helpers.ts (byte-identical)"]
+    end
+    subgraph lh["lefthook.yml"]
+        HOOK["shared-sources-sync → bun run sync:shared --check"]
+    end
+    RE -- import --> IMP
+    RE -. copy-sync .-> COPY
+    HOOK -. validates .-> COPY
+```
+
+```mermaid
+flowchart LR
+    CH["config-helpers.ts<br/>REPO_SLUG_RE, assertValidRepoSlug"]
+    CW["cwd-resolver.ts<br/>parseGitRemoteUrl, resolveRepoFromCwd"]
+    SS["sync-shared.ts<br/>assertInRepo"]
+    SUITE["detect-github-repo.suite.ts<br/>owner-segment tests"]
+    CH --> CW
+    SUITE --> CH
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T1, T2, T3, T4 | tools/sync-shared.ts, plugins/dev-core/skills/shared/adapters/config-helpers.ts, plugins/dev-core/cli/lib/cwd-resolver.ts, (sync run) |
+| tester-A | T5 | plugins/shared/__tests__/detect-github-repo.suite.ts |
+| devops-A | T6 | lefthook.yml |
+
+## Wave Structure
+
+3 waves, max 2 parallel agents. Elapsed ~1 short session vs ~1 sequential (small).
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | backend-dev-A: T1→T2 · devops-A: T6 |
+| 2 | Wave 1 done | 1 | backend-dev-A: T3→T4 |
+| 3 | Wave 2 done | 1 | tester-A: T5 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 | 1 | judgmental | 5 | — |
+| T2 | 1 | bounded | 3 | — |
+| T3 | 1 | bounded | 3 | — |
+| T4 | 1 | trivial | 2 | — |
+| T5 | 1 | judgmental | 5 | — |
+| T6 | 1 | bounded | 3 | — |
+
+**Total estimated ops: ~21**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2, T3, T4 | 13 | symlink, regex | — |
+| tester-A | T5 | 5 | regex | — |
+| devops-A | T6 | 3 | hook | — |
+
+## Consistency Report
+
+Covered: 7/7 success criteria. Untraced tasks: 0. Exemptions: none.
+
+- SC1, SC2 → T1
+- SC3 → T2, T3
+- SC4 → T4
+- SC5 → T5
+- SC6 → T6
+- SC7 → all (validate gate)
+
+## Micro-Tasks
+
+### Slice V1 — symlink deref parity
+
+**T1** — `realpathSync` deref in `assertInRepo` (both call sites)
+- File: `tools/sync-shared.ts`
+- Shape: in `assertInRepo`, resolve real path: `let real = abs; try { real = realpathSync(abs) } catch (e) { if (e.code !== 'ENOENT') throw }` then run the existing containment check on `real`. Import `realpathSync` from `node:fs`.
+- Verify: `bun run typecheck && bun run sync:shared --check`
+- Expected: typecheck clean; check exits 0 (no drift). Out-of-repo symlink would throw `Refusing path outside repo`.
+- Agent: backend-dev-A · Subject: symlink · Spec trace: SC1, SC2 · Phase: GREEN · Difficulty: 3 · `[P]`
+
+### Slice V2 — regex single-source + copy-sync + tests
+
+**T2** — export canonical `REPO_SLUG_RE`
+- File: `plugins/dev-core/skills/shared/adapters/config-helpers.ts`
+- Shape: `export const REPO_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/` (was `/^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/`, line 98). Update the doc-comment to describe the leading-alphanumeric rule.
+- Verify: `bun run typecheck`
+- Expected: clean.
+- Agent: backend-dev-A · Subject: regex · Spec trace: SC3 · Phase: GREEN · Difficulty: 2 · `[P]`
+
+**T3** — import in cwd-resolver, delete local const
+- File: `plugins/dev-core/cli/lib/cwd-resolver.ts`
+- Shape: `import { REPO_SLUG_RE } from '../../skills/shared/adapters/config-helpers'`; delete local `const REPO_SLUG_RE` (line 6). Keep the explanatory comment, point it at the canonical.
+- Verify: `bun run typecheck && grep -c 'const REPO_SLUG_RE' plugins/dev-core/cli/lib/cwd-resolver.ts`
+- Expected: typecheck clean; grep count 0.
+- Agent: backend-dev-A · Subject: regex · Spec trace: SC3 · Phase: GREEN · Difficulty: 2 · blockedBy: T2
+
+**T4** — re-sync dev-init copy
+- File: `plugins/dev-init/skills/shared/adapters/config-helpers.ts` (generated)
+- Shape: run `bun run sync:shared`
+- Verify: `bun run sync:shared --check`
+- Expected: exits 0, "All shared sources are in sync."
+- Agent: backend-dev-A · Subject: regex · Spec trace: SC4 · Phase: GREEN · Difficulty: 1 · blockedBy: T2,T3
+
+**T5** — extend owner-segment tests
+- File: `plugins/shared/__tests__/detect-github-repo.suite.ts`
+- Shape: add a test asserting a leading-special-char owner/name (e.g. `-bad/repo`, `owner/-bad`) throws `Expected "owner/repo" format`. Confirm existing dot/underscore-owner rejection + `my.repo_name` acceptance + numeric-only still pass.
+- Verify: `bun run test`
+- Expected: full suite green incl. new case.
+- Agent: tester-A · Subject: regex · Spec trace: SC5 · Phase: RED-GATE · Difficulty: 3 · blockedBy: T3,T4
+
+### Slice V3 — scoped lefthook hook
+
+**T6** — add `shared-sources-sync` hook
+- File: `lefthook.yml`
+- Shape: under `pre-commit.commands`, add:
+  ```yaml
+  shared-sources-sync:
+    run: bun run sync:shared --check
+    glob: "**/skills/shared/adapters/config-helpers.ts"
+  ```
+- Verify: stage a shared-source file edit and run the hook locally; `grep -A2 shared-sources-sync lefthook.yml`
+- Expected: hook present; fires on shared-source edits without `.venv`.
+- Agent: devops-A · Subject: hook · Spec trace: SC6 · Phase: GREEN · Difficulty: 2 · `[P]`
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | symlink |
+| T2 | backend-dev-A | — | regex |
+| T6 | devops-A | — | hook |
+
+### Wave 2 — after Wave 1, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-A | T2 | regex |
+| T4 | backend-dev-A | T2,T3 | regex |
+
+### Wave 3 — after Wave 2, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | tester-A | T3,T4 | regex |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 11 — symlink (backend-dev-A)
+- T2: 12 — regex (backend-dev-A)
+- T3: 13 — regex (backend-dev-A)
+- T4: 14 — regex (backend-dev-A)
+- T5: 15 — regex (tester-A)
+- T6: 16 — hook (devops-A)

--- a/artifacts/specs/229-residual-hygiene-214-spec.mdx
+++ b/artifacts/specs/229-residual-hygiene-214-spec.mdx
@@ -1,0 +1,121 @@
+---
+title: residual hygiene from #214 review (symlink deref, regex drift, lefthook hook)
+issue: 229
+status: approved
+tier: F-lite
+date: 2026-05-31
+promoted_from: artifacts/frames/229-residual-hygiene-214-frame.mdx
+---
+
+## Context
+
+Source: [frame](../frames/229-residual-hygiene-214-frame.mdx). Three deferred parity gaps from the #214 reconcile re-review. Each is independent and self-contained. Two refinements vs the issue text, both from expert review (see `## Deviations from issue text`).
+
+## Goal
+
+Close three TS/Python (and local/CI) parity gaps so the same input is treated identically by both sides, with no silent local skips and no re-drift.
+
+## Users
+
+- **Primary:** roxabi-plugins maintainers — gate consistency.
+- **Secondary:** contributors without local `.venv` — currently ship un-synced copies caught only in CI.
+
+## Deviations from issue text
+
+| Item | Issue said | Spec does | Why |
+|------|-----------|-----------|-----|
+| 2 | "reconcile the two regexes to one canonical **form**" | one canonical **symbol** — export from `config-helpers.ts`, import in `cwd-resolver.ts` | byte-identical literals re-drift with no gate (frame failure mode b). Single source = drift impossible. Intra-dev-core import (cli→skills/shared), allowed by self-containment. |
+| 3 | mirror `taxonomy-class-list-sync` (`.venv`-gated `validate_plugins.py`) | run `bun run sync:shared --check` (bun-native, no `.venv`) | the `.venv`-gated form still silently skips without `.venv` (frame failure mode a) — and the bare `taxonomy-sync` already runs that Python check. The bun check needs no `.venv` → actually closes the silent-skip gap. |
+
+## Expected Behavior
+
+**Item 1 — symlink deref (`tools/sync-shared.ts`).**
+`assertInRepo` resolves the real (symlink-dereferenced) path via `realpathSync` before the containment check, matching `validate_plugins.py`'s non-strict `.resolve()`. A path that is a symlink pointing outside the repo is **rejected**. A path that does not yet exist (not-yet-written copy, write mode) must **not** throw on resolution — `realpathSync` `ENOENT` is caught and the check falls back to the lexically-resolved `abs` already passed in. Applies to **both** call sites (`canonicalAbs` and `targetAbs`).
+
+Precondition (documented invariant): the fallback is safe because manifest `rel` paths contain no `..` segment, so `resolve(REPO_ROOT, rel)` is unconditionally inside the repo. A future manifest entry with `..` would need its own guard.
+
+**Item 2 — `REPO_SLUG_RE` reconcile (`config-helpers.ts` → `cwd-resolver.ts`).**
+`config-helpers.ts` becomes the single definition; `cwd-resolver.ts` imports it (no longer declares its own). Canonical form:
+
+```
+/^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
+```
+
+- Owner = `[A-Za-z0-9][A-Za-z0-9-]*` — alphanumeric + hyphen, must start alphanumeric (GitHub's real username rule). Rejects dots/underscores in owner.
+- Name = `[A-Za-z0-9][A-Za-z0-9._-]*` — allows dots/underscores after first char (preserves `my.repo_name`), must start alphanumeric.
+
+Behavioral deltas vs today (verified against the suite by the architect — no valid slug regresses):
+- `config-helpers`: name now must start alphanumeric (was `[A-Za-z0-9._-]+`, accepted `.hidden`). Hardening.
+- `cwd-resolver`: owner now rejects `.`/`_` (was `[A-Za-z0-9._-]*`). Real GitHub owners never contain these → safe; a `.roxabi` marker / remote with such an owner now silently falls through (no throw), unchanged failure semantics.
+
+Export of `REPO_SLUG_RE` from the canonical also lands (byte-identically) in the dev-init copy via copy-sync — an unused export there, harmless.
+
+**Item 3 — scoped lefthook hook (`lefthook.yml`).**
+A new `shared-sources-sync` pre-commit command runs `bun run sync:shared --check`, globbed so editing either the canonical or the dev-init copy triggers it locally. Bun is the project runtime → always present → no `.venv` gate, no silent skip. CI continues to enforce unconditionally (and the bun check additionally now backs the local gate).
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+    class RepoSlug {
+        +string owner  "[A-Za-z0-9][A-Za-z0-9-]*"
+        +string name   "[A-Za-z0-9][A-Za-z0-9._-]*"
+    }
+    class REPO_SLUG_RE {
+        <<single exported const>>
+        defined in config-helpers.ts
+    }
+    REPO_SLUG_RE ..> RepoSlug : validates
+```
+
+```mermaid
+flowchart LR
+    RE[REPO_SLUG_RE<br/>exported from config-helpers.ts]
+    CH[config-helpers.ts<br/>assertValidRepoSlug]
+    CW[cwd-resolver.ts<br/>parseGitRemoteUrl + .roxabi marker]
+    DI[dev-init copy<br/>config-helpers.ts]
+    SUITE[detect-github-repo.suite.ts<br/>owner-segment tests]
+    RE --> CH
+    RE -- import --> CW
+    CH -. copy-sync .-> DI
+    SUITE --> CH
+```
+
+| Consumer | Uses | When | Status |
+|----------|------|------|--------|
+| `config-helpers.assertValidRepoSlug` | `REPO_SLUG_RE` (defines) | yaml/env + git-remote fallback validation | this issue |
+| `cwd-resolver.parseGitRemoteUrl` / `.roxabi` marker | `REPO_SLUG_RE` (imports) | repo-slug resolution from cwd | this issue |
+| dev-init `config-helpers.ts` copy | byte-identical via copy-sync | CI + lefthook gate | this issue (re-sync) |
+| `detect-github-repo.suite.ts` | owner-segment assertions | test run | this issue (extend) |
+
+## Breadboard
+
+| ID | Affordance | Handler | Data |
+|----|-----------|---------|------|
+| N1 | `assertInRepo(abs, rel)` | `realpathSync(abs)`, catch ENOENT → fall back to `abs`; then containment check | abs path, REPO_ROOT; fallback = lexical `abs` |
+| N2 | exported `REPO_SLUG_RE` in config-helpers | add `export`; cwd-resolver imports, deletes its local const | regex literal |
+| N3 | dev-init copy-sync | `bun run sync:shared` → byte-equality (now also re-exports the const) | config-helpers.ts |
+| N4 | `shared-sources-sync` lefthook command | `bun run sync:shared --check`, glob `**/skills/shared/adapters/config-helpers.ts` | staged shared-source files |
+| U1 | suite owner-segment tests | extend: add leading-special-char rejection case | test cases |
+
+Wiring: N1 standalone (Item 1). N2 → N3 (export from canonical, re-sync copy) → U1 (tests stay green / extended) — Item 2. N4 standalone (Item 3), validates N3's gate.
+
+## Slices
+
+| # | Slice | Affordances | Demo |
+|---|-------|-------------|------|
+| 1 | Symlink deref parity | N1 | `assertInRepo` rejects out-of-repo symlink; ENOENT target still passes |
+| 2 | Regex single-source + copy-sync + tests | N2, N3, U1 | cwd-resolver imports the regex; `sync:shared --check` green; suite green |
+| 3 | Scoped lefthook hook | N4 | editing a shared-source file fires `shared-sources-sync` locally without `.venv` |
+
+Slices are independent across slices — any order. **Within Slice 2**, ordering is fixed: export from `config-helpers.ts` → update `cwd-resolver.ts` import → `bun run sync:shared` → update suite.
+
+## Success Criteria
+
+- [ ] `assertInRepo` dereferences symlinks via `realpathSync` before the containment check (both call sites); an out-of-repo symlink target is rejected.
+- [ ] `realpathSync` `ENOENT` (not-yet-written target) is caught and does not throw; the not-yet-existing in-repo target still passes.
+- [ ] `REPO_SLUG_RE` is defined once (`config-helpers.ts`, exported) and imported by `cwd-resolver.ts`; `cwd-resolver.ts` no longer declares its own; the literal is `/^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/`.
+- [ ] dev-init `config-helpers.ts` copy is re-synced; `bun run sync:shared --check` exits 0.
+- [ ] `detect-github-repo.suite.ts` owner-segment tests pass (incl. existing dot/underscore-owner rejection); a leading-special-char rejection case is added to the suite.
+- [ ] `lefthook.yml` has a `shared-sources-sync` pre-commit command running `bun run sync:shared --check`, glob-scoped to `**/skills/shared/adapters/config-helpers.ts` (no `.venv` gate).
+- [ ] `bun run test`, `bun run typecheck`, `bun run lint`, and `bun run sync:shared --check` all pass.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -29,7 +29,8 @@ pre-commit:
       glob: "plugins/dev-core/skills/code-review/{review-classes.yml,SKILL.md}"
     shared-sources-sync:
       run: bun run sync:shared --check
-      glob: "**/skills/shared/adapters/config-helpers.ts"
+      # Covers the full shared-sources manifest (adapters/ + domain/), not just config-helpers.ts.
+      glob: "**/skills/shared/**/*.ts"
     taxonomy-subsumption-pairs:
       run: "if [ -f .venv/bin/python ]; then .venv/bin/python tools/validate_plugins.py --check subsumption-pairs; else echo 'SKIP: taxonomy-subsumption-pairs (no .venv)' >&2; fi"
       glob: "plugins/dev-core/skills/code-review/{review-classes.yml,SKILL.md}"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,6 +27,9 @@ pre-commit:
     taxonomy-class-list-sync:
       run: "if [ -f .venv/bin/python ]; then .venv/bin/python tools/validate_plugins.py --check class-list-sync; else echo 'SKIP: taxonomy-class-list-sync (no .venv)' >&2; fi"
       glob: "plugins/dev-core/skills/code-review/{review-classes.yml,SKILL.md}"
+    shared-sources-sync:
+      run: bun run sync:shared --check
+      glob: "**/skills/shared/adapters/config-helpers.ts"
     taxonomy-subsumption-pairs:
       run: "if [ -f .venv/bin/python ]; then .venv/bin/python tools/validate_plugins.py --check subsumption-pairs; else echo 'SKIP: taxonomy-subsumption-pairs (no .venv)' >&2; fi"
       glob: "plugins/dev-core/skills/code-review/{review-classes.yml,SKILL.md}"

--- a/plugins/dev-core/cli/lib/cwd-resolver.ts
+++ b/plugins/dev-core/cli/lib/cwd-resolver.ts
@@ -1,9 +1,9 @@
 import { existsSync, readFileSync, statSync } from 'node:fs'
+// REPO_SLUG_RE — canonical slug regex defined in config-helpers.ts (owner must start alphanumeric,
+// no dots/underscores in owner; name allows dots/underscores after leading alphanumeric).
+import { REPO_SLUG_RE } from '../../skills/shared/adapters/config-helpers'
 import type { WorkspaceProject } from './workspace-store'
 
-// GitHub repo slugs: owner/name. First character of each segment must be alphanumeric
-// (matches GitHub's own rule that usernames and repo names cannot start with . - or _).
-const REPO_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
 // Cap on .roxabi marker size. Defense against memory-pressure from a crafted file planted on walk-up path.
 const ROXABI_MAX_BYTES = 64 * 1024
 

--- a/plugins/dev-core/skills/shared/adapters/config-helpers.ts
+++ b/plugins/dev-core/skills/shared/adapters/config-helpers.ts
@@ -92,10 +92,12 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
 
 /**
  * A GitHub repo slug: exactly `owner/repo`.
- * GitHub owner: [A-Za-z0-9-], repo name: [A-Za-z0-9._-].
+ * Owner: alphanumeric + hyphen, must start with an alphanumeric character
+ * (GitHub username rule — dots/underscores not allowed in owner segment).
+ * Name: allows dots/underscores after a leading alphanumeric character.
  * Callers do `detectGitHubRepo().split('/')` and expect exactly two non-empty segments.
  */
-const REPO_SLUG_RE = /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/
+export const REPO_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
 
 /**
  * Validate a candidate GitHub repo slug and throw a clear error if it doesn't match.

--- a/plugins/dev-init/skills/shared/adapters/config-helpers.ts
+++ b/plugins/dev-init/skills/shared/adapters/config-helpers.ts
@@ -94,10 +94,12 @@ function loadDevCoreConfig(key: string, envKey?: string): string | undefined {
 
 /**
  * A GitHub repo slug: exactly `owner/repo`.
- * GitHub owner: [A-Za-z0-9-], repo name: [A-Za-z0-9._-].
+ * Owner: alphanumeric + hyphen, must start with an alphanumeric character
+ * (GitHub username rule — dots/underscores not allowed in owner segment).
+ * Name: allows dots/underscores after a leading alphanumeric character.
  * Callers do `detectGitHubRepo().split('/')` and expect exactly two non-empty segments.
  */
-const REPO_SLUG_RE = /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/
+export const REPO_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
 
 /**
  * Validate a candidate GitHub repo slug and throw a clear error if it doesn't match.

--- a/plugins/shared/__tests__/detect-github-repo.suite.ts
+++ b/plugins/shared/__tests__/detect-github-repo.suite.ts
@@ -229,6 +229,20 @@ export function registerGitHubRepoDetectionSuite(opts: {
       expect(spawnSyncSpy).not.toHaveBeenCalled()
     })
 
+    it('throws when the owner segment starts with a hyphen', () => {
+      // Both segments must start with an alphanumeric — leading special chars are rejected.
+      process.env.GITHUB_REPO = '-bad/repo'
+      expect(() => detectGitHubRepo()).toThrow('Invalid GitHub repo "-bad/repo"')
+      expect(spawnSyncSpy).not.toHaveBeenCalled()
+    })
+
+    it('throws when the repo-name segment starts with a hyphen', () => {
+      // Both segments must start with an alphanumeric — leading special chars are rejected.
+      process.env.GITHUB_REPO = 'owner/-bad'
+      expect(() => detectGitHubRepo()).toThrow('Invalid GitHub repo "owner/-bad"')
+      expect(spawnSyncSpy).not.toHaveBeenCalled()
+    })
+
     it('parses SSH remote URL', () => {
       spawnSyncSpy.mockImplementation((cmd: string[]) => {
         if (cmd[0] === 'gh') return { stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode: 1, success: false }

--- a/plugins/shared/__tests__/detect-github-repo.suite.ts
+++ b/plugins/shared/__tests__/detect-github-repo.suite.ts
@@ -222,6 +222,14 @@ export function registerGitHubRepoDetectionSuite(opts: {
       expect(spawnSyncSpy).not.toHaveBeenCalled()
     })
 
+    it('accepts single-char owner and repo-name segments', () => {
+      // Each segment is [A-Za-z0-9][...]* — the continuation is optional, so a/b is valid.
+      // Pins the `*` quantifier against an accidental change to `+` (which would require ≥2 chars).
+      process.env.GITHUB_REPO = 'a/b'
+      expect(detectGitHubRepo()).toBe('a/b')
+      expect(spawnSyncSpy).not.toHaveBeenCalled()
+    })
+
     it('accepts dots and underscores in the repo-name segment', () => {
       // Repo names may contain . and _ — owner tightening must not regress this.
       process.env.GITHUB_REPO = 'owner/my.repo_name'

--- a/tools/sync-shared.ts
+++ b/tools/sync-shared.ts
@@ -8,7 +8,7 @@
  *   bun run tools/sync-shared.ts --check   — verify targets match; exit 1 if drifted
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs'
 import { resolve, sep } from 'node:path'
 
 interface SharedEntry {
@@ -30,7 +30,13 @@ function buildGenerated(canonicalPath: string, canonicalContent: string): string
 }
 
 function assertInRepo(abs: string, rel: string): void {
-  if (abs !== REPO_ROOT && !abs.startsWith(REPO_ROOT + sep)) {
+  let real = abs
+  try {
+    real = realpathSync(abs)
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e
+  }
+  if (real !== REPO_ROOT && !real.startsWith(REPO_ROOT + sep)) {
     throw new Error(`Refusing path outside repo: ${rel}`)
   }
 }

--- a/tools/sync-shared.ts
+++ b/tools/sync-shared.ts
@@ -34,7 +34,9 @@ function assertInRepo(abs: string, rel: string): void {
   try {
     real = realpathSync(abs)
   } catch (e) {
-    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e
+    // Only a genuine ENOENT (path not yet written) falls back to the lexical abs;
+    // a non-Error throw or any other errno (ELOOP, EACCES, …) must rethrow.
+    if (!(e instanceof Error) || (e as NodeJS.ErrnoException).code !== 'ENOENT') throw e
   }
   if (real !== REPO_ROOT && !real.startsWith(REPO_ROOT + sep)) {
     throw new Error(`Refusing path outside repo: ${rel}`)


### PR DESCRIPTION
## Summary
- Closes three deferred parity gaps from the #214 reconcile re-review — each an independent, self-contained TS↔Python (and local↔CI) asymmetry.
- **Symlink deref** — `assertInRepo` in `tools/sync-shared.ts` now resolves the real path via `realpathSync` (ENOENT caught for not-yet-written targets) before the containment check, matching `validate_plugins.py`'s non-strict `.resolve()`. An out-of-repo symlink target is now rejected.
- **`REPO_SLUG_RE` single-source** — the regex is exported once from `config-helpers.ts` and imported by `cwd-resolver.ts` (local duplicate deleted), reconciled to `/^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/`. Single source ⇒ re-drift impossible. dev-init copy re-synced; suite gains a leading-special-char rejection case.
- **Scoped lefthook hook** — `shared-sources-sync` runs `bun run sync:shared --check` (bun-native, no `.venv` gate), so local commits enforce copy-sync parity with CI instead of silently skipping when `.venv` is absent.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #229: residual hygiene from #214 review | OPEN |
| Analysis | — (F-lite, analyze skipped) | Absent |
| Spec | [229-residual-hygiene-214-spec.mdx](artifacts/specs/229-residual-hygiene-214-spec.mdx) | Present |
| Implementation | 1 impl commit on `feat/229-residual-hygiene-214` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (786 pass, suite extended) | Passed |

## Test Plan
- [ ] `bun run test` — full suite green incl. new leading-special-char owner/name rejection cases
- [ ] `bun run sync:shared --check` exits 0 (dev-init copy byte-identical)
- [ ] Staging a `config-helpers.ts` edit fires the `shared-sources-sync` pre-commit hook locally with no `.venv` present
- [ ] A symlink in the manifest pointing outside the repo is rejected by `assertInRepo`; a not-yet-written in-repo target still passes (ENOENT fallback)

Closes #229

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`