### PR TITLE
refactor(dev-core): silent-error logging + enum state types + perf (#197)

### DIFF
--- a/artifacts/frames/197-silent-errors-weak-types-perf-hotspots-frame.mdx
+++ b/artifacts/frames/197-silent-errors-weak-types-perf-hotspots-frame.mdx
@@ -1,0 +1,81 @@
+---
+title: Silent errors, weak types, perf hotspots in dev-core
+issue: 197
+status: approved
+tier: F-lite
+date: 2026-05-31
+---
+
+## Problem
+
+A dev-core audit surfaced three classes of latent quality debt in the `issues`
+tooling and supporting hooks/tools:
+
+1. **Silent errors** — bare `catch {}` blocks swallow failures with no log, so
+   transient GitHub/git/Vercel/workflow fetch failures vanish silently and
+   degrade the dashboard with no diagnostic trail.
+2. **Weak types** — GitHub/Vercel/workflow state fields are typed `string`
+   instead of enum literal unions, so invalid states pass `tsc` unchecked and
+   typos in comparisons go undetected.
+3. **Perf hotspots** — redundant IO and roundtrips: `security-check.js` reads +
+   writes its state file once per changed file; `show.ts` issues 3 sequential
+   GraphQL roundtrips; `licenseChecker.ts` re-reads `package.json` already
+   parsed by `readPackageInfo()`.
+
+Why now: a `/recheck` confirmed 6 of 7 audited items are still live against
+current code (line numbers shifted; symbols intact). The 7th — `graph.ts` O(n²)
+topo sort — was already resolved by #193 (extracted to `topo-sort.ts`, Set-based).
+
+## Who
+
+- **Primary:** dev-core maintainers — the `issues` dashboard/show tooling and
+  CI/security hooks they run and debug.
+- **Secondary:** any plugin consumer relying on accurate dashboard state and
+  fast pre-commit security checks.
+
+## Constraints
+
+- **Staging churn** — the cited files (`fetch-*.ts`, `types.ts`, `show.ts`,
+  `licenseChecker.ts`, `security-check.js`) are hot: 8 commits in the day since
+  the audit. Expect collisions; descope contested files to the irreducible core
+  at spec time if churn continues.
+- Single domain (dev-core TS/JS); no new architecture.
+- Zero behavioral regressions — dashboard output and security-check semantics
+  must be unchanged.
+- Style: single quotes, no semicolons; biome-clean; vitest green; tsc clean.
+
+## Out of Scope
+
+- `graph.ts` topo sort (already resolved by #193 — drop).
+- Any new features or dashboard rendering/layout changes.
+- Refactors beyond the enumerated audit items.
+
+## Premise Validity
+
+**Success in 6 months:** swallowed catches log at minimum; `CICheck`/`PR`/
+`VercelDeployment`/`WorkflowRun` state fields are enum literal unions checked by
+`tsc`; `security-check.js` performs 1 state read + 1 write per run;
+`show.ts` ≤2 GraphQL roundtrips; `licenseChecker.ts` reuses the already-parsed
+`package.json`. Zero behavioral regressions.
+
+**Failure in 6 months:** `grep` still finds ≥6 bare `catch {}` in `fetch-*.ts`
+OR `: string` still typed on `status`/`conclusion`/`state` fields in `types.ts`
+after this work merges → the cleanup never landed. (falsifiable, measurable via
+grep + tsc).
+
+**Simplest alternative:** add a `console.error` to each swallowing catch and
+stop there.
+**Why not simplest:** it ignores the weak-types compile-time bug class and the
+perf hotspots; a `safeAsync<T>(fn, fallback)` helper standardizes the catch
+pattern and prevents recurrence, which scattered one-off logs do not.
+
+## Complexity
+
+**Tier: F-lite** — clear, enumerated scope across ~7 files in a single domain
+(dev-core), no architectural unknowns, but >3 files and benefits from a spec to
+sequence the independent fixes and a plan to group them by file/agent.
+
+Signals observed:
+- ~7 files, single domain, no new arch → above S, below F-full.
+- Well-bounded checklist; no cross-domain coupling.
+- `chore` label, complexity 5.

--- a/artifacts/plans/197-silent-errors-weak-types-perf-hotspots-plan.mdx
+++ b/artifacts/plans/197-silent-errors-weak-types-perf-hotspots-plan.mdx
@@ -1,0 +1,246 @@
+---
+title: "Plan: Silent errors, weak types, perf hotspots in dev-core"
+issue: 197
+spec: artifacts/specs/197-silent-errors-weak-types-perf-hotspots-spec.mdx
+complexity: 5/10
+tier: F-lite
+generated: 2026-05-31
+---
+
+## Summary
+
+Three independent dev-core cleanups: route 6 outer fetch catches through a new
+`safeAsync<T>` helper (stderr-logged), replace 8 `string`-typed GitHub/Vercel/
+workflow state fields with enum literal unions, and remove three redundant-IO
+perf hotspots. Slices are file-disjoint where possible and individually
+shippable.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph S1[Slice 1 — silent errors]
+    SA[safe-async.ts<br/>safeAsync&lt;T&gt;]
+    FG[fetch-github.ts<br/>fetchPRs · fetchBranchCI]
+    FGit[fetch-git.ts<br/>fetchBranches · fetchWorktrees]
+    FV[fetch-vercel.ts<br/>fetchVercelDeployments]
+    FW[fetch-workflow.ts<br/>fetchWorkflowRuns]
+    SA --> FG & FGit & FV & FW
+  end
+  subgraph S2[Slice 2 — enum types]
+    GE[gh-enums.ts]
+    TY[types.ts<br/>CICheck · PR · VercelDeployment · WorkflowRun]
+    GE --> TY
+    TY --> FG & FV & FW
+    TY --> COMP[components.ts<br/>ciIcon · ciClass · ciSummary]
+  end
+  subgraph S3[Slice 3 — perf]
+    LC[licenseChecker.ts<br/>readPackageInfo → detectLicense]
+    SH[show.ts<br/>1 merged GraphQL]
+    SEC[security-check.js<br/>state IO in main]
+  end
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+  subgraph lib[skills/issues/lib]
+    safeasync[safe-async.ts]
+    types[types.ts + gh-enums.ts]
+    fgh[fetch-github.ts]
+    fgit[fetch-git.ts]
+    fver[fetch-vercel.ts]
+    fwf[fetch-workflow.ts]
+    comps[components.ts]
+  end
+  subgraph tools[tools]
+    lic[licenseChecker.ts]
+  end
+  subgraph skills[skills/issues]
+    show[show.ts]
+    t1[__tests__/safe-async.test.ts]
+  end
+  subgraph hooks[hooks]
+    sec[security-check.js]
+  end
+  subgraph toolstest[tools/__tests__]
+    t2[licenseChecker.test.ts]
+  end
+  safeasync --> fgh & fgit & fver & fwf
+  types --> fgh & fver & fwf & comps
+  t1 -.tests.-> safeasync
+  t2 -.tests.-> lic
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T1, T2, T4, T5 | `safe-async.ts` (new), `fetch-github.ts`, `fetch-git.ts`, `fetch-vercel.ts`, `fetch-workflow.ts`, `types.ts`, `gh-enums.ts` (new), `components.ts` |
+| backend-dev-B | T6, T7, T8 | `tools/licenseChecker.ts`, `skills/issues/show.ts`, `hooks/security-check.js` |
+| tester-A | T3, T9 | `skills/issues/__tests__/safe-async.test.ts` (new), `tools/__tests__/licenseChecker.test.ts` |
+
+## Bootstrap Context
+
+Ref patterns (read for conventions before writing):
+- Test style: `plugins/dev-core/skills/issues/__tests__/topo-sort.test.ts`, `plugins/dev-core/tools/__tests__/licenseChecker.test.ts` (vitest, single quotes, no semicolons).
+- Type style: `plugins/dev-core/skills/issues/lib/types.ts` (interfaces, exported).
+- GraphQL exec: `plugins/dev-core/skills/issues/lib/gh-exec.ts` (`ghGraphQLExec`).
+- vitest excludes `**/.claude/worktrees/**` and `**/cli/__tests__/**`; sets `GITHUB_REPO=Test/test-repo`.
+
+## Wave Structure
+
+2 waves, max 3 parallel agents. Elapsed ~1 session vs ~2 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | backend-dev-A: T1 · backend-dev-B: T6, T7, T8 |
+| 2 | Wave 1 done | 2 ∥ | backend-dev-A: T2→T4→T5 · tester-A: T3, T9 |
+
+Slice 3 (B) is fully parallel with slices 1+2 (A) — disjoint file sets, zero shared state.
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 create safe-async.ts | 1 | bounded | 2 | — |
+| T2 convert 6 catches | 6 | judgmental | 6 | — |
+| T3 safe-async test | 1 | bounded | 3 | — |
+| T4 gh-enums + types.ts | 1 | judgmental | 5 | — |
+| T5 reconcile consumers | 1 | judgmental | 6 | — |
+| T6 licenseChecker reuse | 1 | judgmental | 5 | — |
+| T7 show.ts merge GraphQL | 1 | judgmental | 4 | — |
+| T8 security-check state | 1 | bounded | 3 | — |
+| T9 extend licenseChecker test | 1 | judgmental | 4 | — |
+
+**Total estimated ops: 38**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2, T4, T5 | 19 | error-handling, types | — |
+| backend-dev-B | T6, T7, T8 | 12 | perf | — |
+| tester-A | T3, T9 | 7 | tests | — |
+
+All instances ≤4 tasks, ≤2 subjects, ≤50 ops — no split required.
+
+## Consistency Report
+
+- Spec criteria covered: 8/8.
+  - SC1 → T1, T3 · SC2 → T2 · SC3 → T4, T5 · SC4 → all (typecheck/lint/test) · SC5 → T6, T9 · SC6 → T7 · SC7 → T8 · SC8 → all.
+- Uncovered criteria: none.
+- Untraced tasks: none.
+- Exemptions: T7 (show.ts) and T8 (security-check.js) verified by grep call-count / fixture run rather than a new unit test — both are I/O-shaped with output-identical guarantees; noted, not gaps.
+
+## Micro-Tasks
+
+### V1 — Silent errors
+
+**T1 — Create `safeAsync<T>` helper** · backend-dev-A · RED→GREEN · diff 2
+- File: `plugins/dev-core/skills/issues/lib/safe-async.ts` (new)
+- Shape:
+  ```ts
+  export async function safeAsync<T>(fn: () => Promise<T>, fallback: T, context: string): Promise<T> {
+    try {
+      return await fn()
+    } catch (err) {
+      process.stderr.write(`[${context}] ${err instanceof Error ? err.message : String(err)}\n`)
+      return fallback
+    }
+  }
+  ```
+- Verify: `bun run typecheck`
+- Spec trace: SC1
+
+**T2 — Route 6 outer catches through `safeAsync`** · backend-dev-A · GREEN · diff 3 · blockedBy T1
+- Files: `fetch-github.ts` (`fetchPRs`, `fetchBranchCI`), `fetch-git.ts` (`fetchBranches`, `fetchWorktrees`), `fetch-vercel.ts` (`fetchVercelDeployments`), `fetch-workflow.ts` (`fetchWorkflowRuns`)
+- Each: wrap the existing body in `safeAsync(async () => { ...body... }, [], 'fetchX')`. Do NOT touch the intentional inner guards in `fetchBuildLogs` / `getGitHubToken`.
+- Verify: read the 6 functions — each delegates to `safeAsync` with a context tag; `bun run typecheck`
+- Spec trace: SC2
+
+**T3 — Unit test `safeAsync`** · tester-A · RED-GATE(V1) · diff 2 · blockedBy T1
+- File: `plugins/dev-core/skills/issues/__tests__/safe-async.test.ts` (new)
+- Cases: returns fn result on success; returns fallback + writes context-tagged line to stderr on throw (spy `process.stderr.write`).
+- Verify: `bun run test safe-async`
+- Spec trace: SC1
+
+### V2 — Enum types
+
+**T4 — Define enum unions + apply to `types.ts`** · backend-dev-A · REFACTOR · diff 3 · blockedBy T2
+- Files: `plugins/dev-core/skills/issues/lib/gh-enums.ts` (new), `types.ts`
+- Define the 8 unions (see spec Data Model table). Replace `string` on `CICheck.status`/`conclusion` (incl. `'' `), `PR.state`/`mergeable`, `VercelDeployment.state`, `WorkflowRun.status`/`conclusion`. Leave `BranchCI.overallState` as `string` (out of scope).
+- Verify: `bun run typecheck`
+- Spec trace: SC3
+
+**T5 — Reconcile map sites + consumers** · backend-dev-A · REFACTOR · diff 4 · blockedBy T4
+- Files: `fetch-github.ts`, `fetch-vercel.ts`, `fetch-workflow.ts` map sites; `components.ts` (`ciIcon`/`ciClass`/`ciSummary`)
+- Ensure mapped values satisfy the unions (keep `?? ''` / `|| ''` fallbacks); keep consumer params `string`-compatible (union ⊆ string). Add a deliberately-invalid literal in a scratch check to confirm `tsc` rejects, then remove.
+- Verify: `bun run typecheck && bun run lint`
+- Spec trace: SC3, SC4
+
+### V3 — Perf (parallel with V1/V2)
+
+**T6 — licenseChecker single-read** · backend-dev-B · REFACTOR · diff 3
+- File: `plugins/dev-core/tools/licenseChecker.ts`
+- Extend `RawPackageInfo` with optional `license`/`licenses` extracted at parse time in `readPackageInfo` (keep defensive `Object.create(null)`). `detectLicense` consumes them; re-read only if absent.
+- Verify: `bun run test licenseChecker`
+- Spec trace: SC5
+
+**T7 — show.ts merge GraphQL** · backend-dev-B · REFACTOR · diff 3
+- File: `plugins/dev-core/skills/issues/show.ts`
+- Merge the two `ghGraphQLExec` calls (subIssues + trackedInIssues) into one `repository{ issue{ subIssues{...} trackedInIssues{...} } }` query; destructure both from the single response.
+- Verify: `grep -c 'ghGraphQLExec' plugins/dev-core/skills/issues/show.ts` → 1 (import line excluded — count call-sites); `bun run typecheck`
+- Spec trace: SC6
+
+**T8 — security-check.js state IO** · backend-dev-B · REFACTOR · diff 2
+- File: `plugins/dev-core/hooks/security-check.js`
+- Lift `loadState()`/`saveState()` to `main()`; pass `state` into `checkContent(content, path, state)`; track a dirty flag and call `saveState` only when a new warning was added.
+- Verify: run hook with `CLAUDE_TOOL_INPUT` fixture containing a known secret pattern → blocks once, no state write on second clean run.
+- Spec trace: SC7
+
+**T9 — Extend licenseChecker test** · tester-A · RED-GATE(V3) · diff 3 · blockedBy T6
+- File: `plugins/dev-core/tools/__tests__/licenseChecker.test.ts`
+- Assert `package.json` read once per package (spy `readFileSync`) and `checkCompliance` output unchanged on a fixture tree.
+- Verify: `bun run test licenseChecker`
+- Spec trace: SC5
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | error-handling |
+| T6 | backend-dev-B | — | perf |
+| T7 | backend-dev-B | — | perf |
+| T8 | backend-dev-B | — | perf |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | backend-dev-A | T1 | error-handling |
+| T4 | backend-dev-A | T2 | types |
+| T5 | backend-dev-A | T4 | types |
+| T3 | tester-A | T1 | tests |
+| T9 | tester-A | T6 | tests |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 13 — error-handling
+- T2: 14 — error-handling
+- T3: 15 — tests
+- T4: 16 — types
+- T5: 17 — types
+- T6: 18 — perf
+- T7: 19 — perf
+- T8: 20 — perf
+- T9: 21 — tests

--- a/artifacts/specs/197-silent-errors-weak-types-perf-hotspots-spec.mdx
+++ b/artifacts/specs/197-silent-errors-weak-types-perf-hotspots-spec.mdx
@@ -1,0 +1,161 @@
+---
+title: Silent errors, weak types, perf hotspots in dev-core
+issue: 197
+status: approved
+tier: F-lite
+date: 2026-05-31
+promoted_from: artifacts/frames/197-silent-errors-weak-types-perf-hotspots-frame.mdx
+---
+
+## Context
+
+Source: `artifacts/frames/197-silent-errors-weak-types-perf-hotspots-frame.mdx`.
+A dev-core audit (#197) enumerated robustness + perf debt in the `issues`
+tooling and hooks. `/recheck` confirmed 6 of 7 items live against current code;
+the 7th (`graph.ts` O(n²) topo) was resolved by #193 and is **out of scope**.
+
+All cited paths are under `plugins/dev-core/`. Line numbers below are
+current-HEAD (post-churn), not the issue's stale numbers.
+
+## Goal
+
+Eliminate silent fetch failures, replace `string`-typed GitHub/Vercel/workflow
+state fields with enum literal unions checked by `tsc`, and remove three
+redundant-IO perf hotspots — with zero behavioral regressions.
+
+## Users
+
+- **Primary:** dev-core maintainers running/debugging the `issues` dashboard,
+  `show`, the license checker, and the security-check hook.
+- **Secondary:** plugin consumers relying on accurate dashboard state and a fast
+  pre-commit hook.
+
+## Expected Behavior
+
+1. When a `fetch*` call throws (network, auth, malformed payload), the failure is
+   logged to **stderr** with a context tag, and the function still returns its
+   empty fallback — the dashboard degrades gracefully **and** leaves a trail.
+2. `tsc` rejects assigning an invalid literal (e.g. `state: 'OPN'`) to a typed
+   state field; valid GraphQL/REST states + the existing `''` fallback compile.
+3. The license checker reads each package's `package.json` **once**; output of
+   `checkCompliance` is byte-identical to today.
+4. `show.ts` produces identical output with **one** GraphQL roundtrip for
+   sub-issues + blockers instead of two.
+5. The security-check hook writes its state file only when a new warning is
+   recorded; blocking decisions are unchanged.
+
+## Data Model & Consumers
+
+### Data structures (enum unions replace `string`)
+
+```mermaid
+classDiagram
+  class CICheck {
+    +string name
+    +CheckStatusState|StatusState|'' status
+    +CheckConclusionState|'' conclusion
+    +string detailsUrl
+  }
+  class PR {
+    +PullRequestState state
+    +MergeableState mergeable
+    +CICheck[] checks
+  }
+  class VercelDeployment {
+    +VercelState state
+  }
+  class WorkflowRun {
+    +WorkflowStatus status
+    +WorkflowConclusion|null conclusion
+  }
+  PR "1" --> "*" CICheck
+```
+
+Enum members (GraphQL = UPPER, REST = lower — divergence is intentional, not a bug):
+
+| Type | Members |
+|---|---|
+| `CheckStatusState` | `QUEUED REQUESTED IN_PROGRESS COMPLETED WAITING PENDING` |
+| `CheckConclusionState` | `ACTION_REQUIRED TIMED_OUT CANCELLED FAILURE SUCCESS NEUTRAL SKIPPED STARTUP_FAILURE STALE` |
+| `StatusState` (commit status contexts) | `EXPECTED ERROR FAILURE PENDING SUCCESS` |
+| `PullRequestState` | `OPEN CLOSED MERGED` |
+| `MergeableState` | `MERGEABLE CONFLICTING UNKNOWN` |
+| `VercelState` | `QUEUED BUILDING ERROR INITIALIZING READY CANCELED` |
+| `WorkflowStatus` (REST) | `queued in_progress completed waiting requested pending` |
+| `WorkflowConclusion` (REST) | `success failure neutral cancelled skipped timed_out action_required stale startup_failure` |
+
+`''` is a union member of `CICheck.status`/`CICheck.conclusion` because
+`fetch-github.ts` maps via `node.status || node.state || ''` and `?? ''`.
+
+> **Out of scope (types):** `BranchCI.overallState` stays `string`. Its value
+> comes from the `StatusCheckRollup.state` commit-level rollup (a separate
+> field, not driven through the `ciIcon`/`ciClass` switch paths). Tightening it
+> is deferred to avoid widening the diff on a hot file.
+
+### Consumer map
+
+```mermaid
+flowchart LR
+  fg[fetch-github.ts] -->|CICheck, PR| comp[components.ts ciIcon/ciClass/ciSummary]
+  fv[fetch-vercel.ts] -->|VercelDeployment.state| comp
+  fw[fetch-workflow.ts] -->|WorkflowRun| comp
+  comp --> dash[dashboard.ts / page.ts]
+```
+
+| Consumer | Fields consumed | Status |
+|---|---|---|
+| `components.ts` `ciIcon`/`ciClass` | `CICheck.status`, `CICheck.conclusion` (string literals) | this issue — params stay `string`-compatible via union widening |
+| `components.ts` `ciSummary` | `CICheck.status`/`conclusion` | this issue |
+| `fetch-vercel.ts` | `VercelDeployment.state === 'READY'` | this issue |
+| `dashboard.ts`/`page.ts` | render-only, no comparisons | unaffected |
+
+> **Consumer-safety rule:** `ciIcon(status: string, ...)` callers pass union
+> values — union ⊆ string, so signatures may stay `string` or tighten to the
+> union; either compiles. Do **not** narrow consumer params in a way that breaks
+> the `''` fallback paths.
+
+## Breadboard
+
+| ID | Affordance | Handler | Data |
+|---|---|---|---|
+| N1 | `safeAsync<T>(fn, fallback, context)` | new `skills/issues/lib/safe-async.ts` | logs `err.message` to stderr, returns `fallback` |
+| N2 | 6 **outer** fetch try/catch → `safeAsync` | `fetch-github.ts` `fetchPRs`+`fetchBranchCI`, `fetch-git.ts` `fetchBranches`+`fetchWorktrees`, `fetch-vercel.ts` `fetchVercelDeployments`, `fetch-workflow.ts` `fetchWorkflowRuns` | wraps existing body, fallback `[]` |
+| N3 | enum union types | `skills/issues/lib/types.ts` (+ optional `gh-enums.ts`) | the 8 unions above |
+| N4 | `RawPackageInfo` carries `license`/`licenses` | `tools/licenseChecker.ts` `readPackageInfo` | populated at parse time (defensive `Object.create(null)`) |
+| N5 | `detectLicense` reuses N4 fields | `tools/licenseChecker.ts` | re-read only if fields absent |
+| N6 | merge 2 GraphQL → 1 | `show.ts` | single `issue(){ subIssues, trackedInIssues }` query |
+| N7 | lift `loadState`/`saveState` to `main()` | `hooks/security-check.js` | `checkContent(content, path, state)`; dirty flag → conditional `saveState` |
+
+Wiring: N1→N2 (helper before callers). N3 independent. N4→N5 (field before reuse). N6, N7 independent.
+
+> **Intentional inner swallow-guards — NOT wrapped:** `fetchBuildLogs`'s inner
+> catch (`fetch-vercel.ts`) and `getGitHubToken`'s inner catch
+> (`fetch-workflow.ts`) deliberately return a local empty/`''` value and are
+> already graceful by design. They are **excluded** from N2; SC2's grep targets
+> only the 6 named outer functions.
+
+## Slices
+
+| # | Slice | Affordances | Files | Demo |
+|---|---|---|---|---|
+| 1 | Silent errors → `safeAsync` | N1, N2 | `safe-async.ts` (new), `fetch-github.ts`, `fetch-git.ts`, `fetch-vercel.ts`, `fetch-workflow.ts` | force a fetch throw → stderr log + `[]` returned; unit test on `safeAsync` |
+| 2 | Weak types → enum unions | N3 | `types.ts` (+ `gh-enums.ts`), `fetch-*.ts` map sites, `components.ts` | `tsc` clean; bad-literal assignment fails typecheck |
+| 3 | Perf hotspots | N4, N5, N6, N7 | `licenseChecker.ts`, `show.ts`, `security-check.js` | license report byte-identical; `show.ts` 1 roundtrip; hook skips redundant write |
+
+Slices are independent and individually shippable. **Descope order under staging
+churn** (per project convention): slice 3 perf items are the most deferrable;
+slice 1 (silent errors) is the irreducible core. **Within slice 3** the three
+items (N4/N5 licenseChecker, N6 show.ts, N7 security-check) are mutually
+independent and individually deferrable — drop N7 first (lowest value: hook is
+single-file-per-invocation), then N6, then N4/N5.
+
+## Success Criteria
+
+- [ ] `safeAsync<T>(fn, fallback, context)` exists in `skills/issues/lib/safe-async.ts`, logs `context` + error message to stderr, returns `fallback` on throw; has a unit test covering success + throw paths.
+- [ ] The 6 named outer fetch functions (`fetchPRs`, `fetchBranchCI`, `fetchBranches`, `fetchWorktrees`, `fetchVercelDeployments`, `fetchWorkflowRuns`) route failures through `safeAsync` with a context tag; none retains a bare swallow. The 2 intentional inner guards (`fetchBuildLogs`, `getGitHubToken`) are left as-is. (verify by reading the 6 functions, not a blanket `catch` grep — `catch (e) {` forms also count as bare if unlogged.)
+- [ ] `CICheck`, `PR`, `VercelDeployment`, `WorkflowRun` state/status/conclusion/mergeable fields are enum literal unions (no bare `string`); a deliberately-invalid literal fails `tsc`.
+- [ ] `bun run typecheck`, `bun run lint`, `bun run test` all pass. Zero behavioral regression pinned per-slice: SC5 (license report unchanged), SC6 (`show.ts` output identical for the two fixture cases), SC7 (block decisions reproduce) — no separate global dashboard diff is required since the dashboard fetch paths are output-identical by construction (fallback values unchanged).
+- [ ] `licenseChecker.ts` reads each `package.json` once: `detectLicense` consumes parsed fields from `RawPackageInfo` (re-read only when absent); `checkCompliance` output unchanged on this repo.
+- [ ] `show.ts` issues exactly one `ghGraphQLExec` for sub-issues + blockers; output identical for an issue with sub-issues and one without.
+- [ ] `security-check.js` loads state once and writes only when a new warning is added; existing block decisions reproduce on the known patterns.
+- [ ] No new runtime deps; biome-clean; conventional commits per slice.

--- a/plugins/dev-core/hooks/security-check.js
+++ b/plugins/dev-core/hooks/security-check.js
@@ -116,7 +116,8 @@ function main() {
         }),
       )
     }
-  } catch {
+  } catch (e) {
+    process.stderr.write(`security-check: ${e?.message ? e.message : String(e)}\n`)
     process.exit(0)
   }
 }

--- a/plugins/dev-core/hooks/security-check.js
+++ b/plugins/dev-core/hooks/security-check.js
@@ -65,8 +65,7 @@ function getWarningKey(file, ruleId) {
   return `${toRelativePath(file)}:${ruleId}`
 }
 
-function checkContent(content, filePath) {
-  const state = loadState()
+function checkContent(content, filePath, state) {
   const blocked = []
 
   for (const rule of SECURITY_PATTERNS) {
@@ -80,7 +79,6 @@ function checkContent(content, filePath) {
     rule.pattern.lastIndex = 0
   }
 
-  saveState(state)
   return blocked
 }
 
@@ -101,7 +99,14 @@ function main() {
       process.exit(0)
     }
 
-    const blocked = checkContent(content, filePath)
+    const state = loadState()
+    const warningsBefore = Object.keys(state.warnings).length
+    const blocked = checkContent(content, filePath, state)
+    const dirty = Object.keys(state.warnings).length > warningsBefore
+
+    if (dirty) {
+      saveState(state)
+    }
 
     if (blocked.length > 0) {
       console.log(

--- a/plugins/dev-core/skills/issues/__tests__/components.test.ts
+++ b/plugins/dev-core/skills/issues/__tests__/components.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { ciClass, ciIcon } from '../lib/components'
+import { ciClass, ciIcon, ciSummary } from '../lib/components'
+import type { CICheck } from '../lib/types'
 
 const CI_SPINNER_HTML = '<span class="ci-spinner"></span>'
 
@@ -40,6 +41,46 @@ describe('ciClass — StatusContext rows (conclusion="")', () => {
 describe('ciClass — CheckRun rows (status=COMPLETED)', () => {
   it('COMPLETED,SUCCESS → ci-success', () => {
     expect(ciClass('COMPLETED', 'SUCCESS')).toBe('ci-success')
+  })
+})
+
+describe('ciSummary — failure counting, ERROR-conclusion removal regression lock', () => {
+  // Pins the invariant: 'ERROR' is not a valid CheckConclusionState value (it only appears in
+  // StatusState / StatusContext rows, not CheckRun conclusions).  ciSummary must count
+  // status='FAILURE' and status='ERROR' as failures, and conclusion='FAILURE' as a failure,
+  // but must NOT treat conclusion='ERROR' as a failure (no such conclusion exists in the type).
+
+  it('status=FAILURE counts as failing', () => {
+    const checks: CICheck[] = [{ name: 'ci', status: 'FAILURE', conclusion: '', detailsUrl: '' }]
+    const result = ciSummary(checks)
+    expect(result).toEqual({ icon: '❌', label: '1/1 failed', cssClass: 'ci-failure' })
+  })
+
+  it('status=ERROR counts as failing', () => {
+    const checks: CICheck[] = [{ name: 'ci', status: 'ERROR', conclusion: '', detailsUrl: '' }]
+    const result = ciSummary(checks)
+    expect(result).toEqual({ icon: '❌', label: '1/1 failed', cssClass: 'ci-failure' })
+  })
+
+  it('conclusion=FAILURE counts as failing', () => {
+    const checks: CICheck[] = [{ name: 'ci', status: 'COMPLETED', conclusion: 'FAILURE', detailsUrl: '' }]
+    const result = ciSummary(checks)
+    expect(result).toEqual({ icon: '❌', label: '1/1 failed', cssClass: 'ci-failure' })
+  })
+
+  it('conclusion=SUCCESS with status=COMPLETED is NOT failing', () => {
+    const checks: CICheck[] = [{ name: 'ci', status: 'COMPLETED', conclusion: 'SUCCESS', detailsUrl: '' }]
+    const result = ciSummary(checks)
+    expect(result).toEqual({ icon: '✅', label: '1 passed', cssClass: 'ci-success' })
+  })
+
+  it('mixed: 1 failure + 1 success → failure summary', () => {
+    const checks: CICheck[] = [
+      { name: 'a', status: 'COMPLETED', conclusion: 'FAILURE', detailsUrl: '' },
+      { name: 'b', status: 'COMPLETED', conclusion: 'SUCCESS', detailsUrl: '' },
+    ]
+    const result = ciSummary(checks)
+    expect(result).toEqual({ icon: '❌', label: '1/2 failed', cssClass: 'ci-failure' })
   })
 })
 

--- a/plugins/dev-core/skills/issues/__tests__/safe-async.test.ts
+++ b/plugins/dev-core/skills/issues/__tests__/safe-async.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { safeAsync } from '../lib/safe-async'
+
+// ─── safeAsync ────────────────────────────────────────────────────────────────
+
+describe('safeAsync', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    stderrSpy.mockRestore()
+  })
+
+  describe('success path', () => {
+    it('returns the resolved value from fn', async () => {
+      // Arrange
+      const fn = async () => 42
+      // Act
+      const result = await safeAsync(fn, 0, 'ctx')
+      // Assert
+      expect(result).toBe(42)
+    })
+
+    it('does NOT write to stderr when fn succeeds', async () => {
+      // Arrange
+      const fn = async () => 'hello'
+      // Act
+      await safeAsync(fn, '', 'ctx')
+      // Assert — negative: stderr must not be called
+      expect(stderrSpy).not.toHaveBeenCalled()
+    })
+
+    it('works with a non-primitive resolved value', async () => {
+      // Arrange
+      const value = { a: 1, b: [2, 3] }
+      const fn = async () => value
+      // Act
+      const result = await safeAsync(fn, null, 'ctx')
+      // Assert
+      expect(result).toBe(value)
+    })
+  })
+
+  describe('throw path — Error instance', () => {
+    it('returns the fallback when fn throws an Error', async () => {
+      // Arrange
+      const fn = async (): Promise<number> => {
+        throw new Error('boom')
+      }
+      // Act
+      const result = await safeAsync(fn, -1, 'ctx')
+      // Assert
+      expect(result).toBe(-1)
+    })
+
+    it('writes a line to stderr containing the context tag', async () => {
+      // Arrange
+      const fn = async (): Promise<string> => {
+        throw new Error('something went wrong')
+      }
+      // Act
+      await safeAsync(fn, 'fallback', 'my-context')
+      // Assert
+      expect(stderrSpy).toHaveBeenCalledOnce()
+      const written = String((stderrSpy.mock.calls[0] as unknown[])[0])
+      expect(written).toContain('[my-context]')
+    })
+
+    it('writes a line to stderr containing the error message', async () => {
+      // Arrange
+      const msg = 'something went wrong'
+      const fn = async (): Promise<string> => {
+        throw new Error(msg)
+      }
+      // Act
+      await safeAsync(fn, 'fallback', 'my-context')
+      // Assert
+      const written = String((stderrSpy.mock.calls[0] as unknown[])[0])
+      expect(written).toContain(msg)
+    })
+
+    it('stderr line ends with a newline', async () => {
+      // Arrange
+      const fn = async (): Promise<number> => {
+        throw new Error('err')
+      }
+      // Act
+      await safeAsync(fn, 0, 'ctx')
+      // Assert
+      const written = String((stderrSpy.mock.calls[0] as unknown[])[0])
+      expect(written.endsWith('\n')).toBe(true)
+    })
+  })
+
+  describe('throw path — non-Error (string, number, object)', () => {
+    it('returns fallback when fn throws a string', async () => {
+      // Arrange
+      const fn = async (): Promise<number> => {
+        throw 'string error'
+      }
+      // Act
+      const result = await safeAsync(fn, -99, 'ctx')
+      // Assert
+      expect(result).toBe(-99)
+    })
+
+    it('writes the stringified thrown value to stderr', async () => {
+      // Arrange
+      const fn = async (): Promise<number> => {
+        throw 'string error'
+      }
+      // Act
+      await safeAsync(fn, 0, 'ctx')
+      // Assert
+      const written = String((stderrSpy.mock.calls[0] as unknown[])[0])
+      expect(written).toContain('string error')
+    })
+
+    it('returns fallback when fn throws a number', async () => {
+      // Arrange
+      const fn = async (): Promise<string> => {
+        throw 42
+      }
+      // Act
+      const result = await safeAsync(fn, 'fallback', 'ctx')
+      // Assert
+      expect(result).toBe('fallback')
+    })
+
+    it('includes context tag in stderr even for non-Error throws', async () => {
+      // Arrange
+      const fn = async (): Promise<boolean> => {
+        throw 'oops'
+      }
+      // Act
+      await safeAsync(fn, false, 'my-tag')
+      // Assert
+      const written = String((stderrSpy.mock.calls[0] as unknown[])[0])
+      expect(written).toContain('[my-tag]')
+    })
+  })
+})

--- a/plugins/dev-core/skills/issues/lib/components.ts
+++ b/plugins/dev-core/skills/issues/lib/components.ts
@@ -188,9 +188,7 @@ function ciSummary(checks: PR['checks']): { icon: string; label: string; cssClas
       c.conclusion === 'SKIPPED' ||
       c.conclusion === 'NEUTRAL',
   ).length
-  const fail = checks.filter(
-    (c) => c.conclusion === 'FAILURE' || c.conclusion === 'ERROR' || c.status === 'FAILURE' || c.status === 'ERROR',
-  ).length
+  const fail = checks.filter((c) => c.conclusion === 'FAILURE' || c.status === 'FAILURE' || c.status === 'ERROR').length
   const running = checks.filter((c) => c.status === 'IN_PROGRESS').length
 
   if (fail > 0) return { icon: '\u274c', label: `${fail}/${total} failed`, cssClass: 'ci-failure' }

--- a/plugins/dev-core/skills/issues/lib/components.ts
+++ b/plugins/dev-core/skills/issues/lib/components.ts
@@ -178,7 +178,7 @@ export function ciClass(status: string, conclusion: string): string {
   return 'ci-pending'
 }
 
-function ciSummary(checks: PR['checks']): { icon: string; label: string; cssClass: string } {
+export function ciSummary(checks: PR['checks']): { icon: string; label: string; cssClass: string } {
   if (checks.length === 0) return { icon: '', label: '', cssClass: '' }
   const total = checks.length
   const pass = checks.filter(

--- a/plugins/dev-core/skills/issues/lib/fetch-git.ts
+++ b/plugins/dev-core/skills/issues/lib/fetch-git.ts
@@ -1,45 +1,50 @@
 import { run } from '../../shared/adapters/github-adapter'
+import { safeAsync } from './safe-async'
 import type { Branch, Worktree } from './types'
 
 export { run }
 
 export async function fetchBranches(cwd?: string): Promise<Branch[]> {
-  try {
-    const out = await run(['git', 'branch', '--list'], cwd)
-    if (!out) return []
-    return out
-      .split('\n')
-      .filter(Boolean)
-      .map((line) => ({
-        name: line.replace(/^[*+]?\s+/, ''),
-        isCurrent: line.startsWith('*'),
-      }))
-  } catch {
-    return []
-  }
+  return safeAsync(
+    async () => {
+      const out = await run(['git', 'branch', '--list'], cwd)
+      if (!out) return []
+      return out
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => ({
+          name: line.replace(/^[*+]?\s+/, ''),
+          isCurrent: line.startsWith('*'),
+        }))
+    },
+    [],
+    'fetchBranches',
+  )
 }
 
 export async function fetchWorktrees(cwd?: string): Promise<Worktree[]> {
-  try {
-    const out = await run(['git', 'worktree', 'list', '--porcelain'], cwd)
-    if (!out) return []
-    const trees: Worktree[] = []
-    let current: Partial<Worktree> = {}
-    for (const line of out.split('\n')) {
-      if (line.startsWith('worktree ')) {
-        if (current.path) trees.push(current as Worktree)
-        current = { path: line.slice(9), branch: '', commit: '', isBare: false }
-      } else if (line.startsWith('HEAD ')) {
-        current.commit = line.slice(5, 12)
-      } else if (line.startsWith('branch ')) {
-        current.branch = line.slice(7).replace('refs/heads/', '')
-      } else if (line === 'bare') {
-        current.isBare = true
+  return safeAsync(
+    async () => {
+      const out = await run(['git', 'worktree', 'list', '--porcelain'], cwd)
+      if (!out) return []
+      const trees: Worktree[] = []
+      let current: Partial<Worktree> = {}
+      for (const line of out.split('\n')) {
+        if (line.startsWith('worktree ')) {
+          if (current.path) trees.push(current as Worktree)
+          current = { path: line.slice(9), branch: '', commit: '', isBare: false }
+        } else if (line.startsWith('HEAD ')) {
+          current.commit = line.slice(5, 12)
+        } else if (line.startsWith('branch ')) {
+          current.branch = line.slice(7).replace('refs/heads/', '')
+        } else if (line === 'bare') {
+          current.isBare = true
+        }
       }
-    }
-    if (current.path) trees.push(current as Worktree)
-    return trees
-  } catch {
-    return []
-  }
+      if (current.path) trees.push(current as Worktree)
+      return trees
+    },
+    [],
+    'fetchWorktrees',
+  )
 }

--- a/plugins/dev-core/skills/issues/lib/fetch-github.ts
+++ b/plugins/dev-core/skills/issues/lib/fetch-github.ts
@@ -8,7 +8,7 @@ import {
   PRS_QUERY,
 } from '../../shared/queries'
 import type { RawItem } from '../../shared/types'
-
+import { safeAsync } from './safe-async'
 import type { BranchCI, CICheck, Issue, PR } from './types'
 
 interface SlotNames {
@@ -69,8 +69,8 @@ interface RawBranchRef {
 export function mapRawCheck(node: RawCheckNode): CICheck {
   return {
     name: node.name || node.context || 'unknown',
-    status: node.status || node.state || '',
-    conclusion: node.conclusion || '',
+    status: (node.status || node.state || '') as CICheck['status'],
+    conclusion: (node.conclusion || '') as CICheck['conclusion'],
     detailsUrl: node.detailsUrl || node.targetUrl || '',
   }
 }
@@ -203,77 +203,81 @@ export async function fetchIssues(): Promise<Issue[]> {
 }
 
 export async function fetchPRs(repoSlug: string = GITHUB_REPO): Promise<PR[]> {
-  try {
-    const [owner, repo] = repoSlug.split('/')
-    const data = (await ghGraphQL(PRS_QUERY, { owner, repo })) as {
-      data: { repository: { pullRequests: { nodes: RawPRNode[] } } }
-    }
-
-    return data.data.repository.pullRequests.nodes.map((pr) => {
-      const commitNode = pr.commits.nodes[0]
-      const rawChecks = commitNode?.commit.statusCheckRollup?.contexts.nodes ?? []
-      const checks: CICheck[] = rawChecks.map(mapRawCheck)
-
-      return {
-        number: pr.number,
-        title: pr.title,
-        branch: pr.headRefName,
-        state: pr.state,
-        isDraft: pr.isDraft,
-        url: pr.url,
-        author: pr.author?.login ?? '',
-        updatedAt: pr.updatedAt,
-        additions: pr.additions ?? 0,
-        deletions: pr.deletions ?? 0,
-        reviewDecision: pr.reviewDecision ?? '',
-        labels: pr.labels.nodes.map((l) => l.name),
-        mergeable: pr.mergeable ?? 'UNKNOWN',
-        checks,
+  return safeAsync(
+    async () => {
+      const [owner, repo] = repoSlug.split('/')
+      const data = (await ghGraphQL(PRS_QUERY, { owner, repo })) as {
+        data: { repository: { pullRequests: { nodes: RawPRNode[] } } }
       }
-    })
-  } catch {
-    return []
-  }
-}
 
-export async function fetchBranchCI(repoSlug: string = GITHUB_REPO): Promise<BranchCI[]> {
-  try {
-    const [owner, repo] = repoSlug.split('/')
-    const data = (await ghGraphQL(BRANCH_CI_QUERY, { owner, repo })) as {
-      data: { repository: { main: RawBranchRef | null; master: RawBranchRef | null; staging: RawBranchRef | null } }
-    }
-
-    const refs: [string, RawBranchRef | null][] = [
-      ['main', data.data.repository.main ?? data.data.repository.master],
-      ['staging', data.data.repository.staging],
-    ]
-
-    return refs
-      .filter((entry): entry is [string, RawBranchRef] => entry[1] !== null)
-      .map(([branch, ref]) => {
-        const target = ref.target
-        if (!target) {
-          return {
-            branch,
-            commitSha: '',
-            commitMessage: '',
-            committedAt: '',
-            overallState: '',
-            checks: [],
-          }
-        }
-        const rawChecks = target.statusCheckRollup?.contexts.nodes ?? []
+      return data.data.repository.pullRequests.nodes.map((pr) => {
+        const commitNode = pr.commits.nodes[0]
+        const rawChecks = commitNode?.commit.statusCheckRollup?.contexts.nodes ?? []
         const checks: CICheck[] = rawChecks.map(mapRawCheck)
+
         return {
-          branch,
-          commitSha: target.oid.slice(0, 7),
-          commitMessage: target.messageHeadline,
-          committedAt: target.committedDate,
-          overallState: target.statusCheckRollup?.state ?? '',
+          number: pr.number,
+          title: pr.title,
+          branch: pr.headRefName,
+          state: pr.state as PR['state'],
+          isDraft: pr.isDraft,
+          url: pr.url,
+          author: pr.author?.login ?? '',
+          updatedAt: pr.updatedAt,
+          additions: pr.additions ?? 0,
+          deletions: pr.deletions ?? 0,
+          reviewDecision: pr.reviewDecision ?? '',
+          labels: pr.labels.nodes.map((l) => l.name),
+          mergeable: (pr.mergeable ?? 'UNKNOWN') as PR['mergeable'],
           checks,
         }
       })
-  } catch {
-    return []
-  }
+    },
+    [],
+    'fetchPRs',
+  )
+}
+
+export async function fetchBranchCI(repoSlug: string = GITHUB_REPO): Promise<BranchCI[]> {
+  return safeAsync(
+    async () => {
+      const [owner, repo] = repoSlug.split('/')
+      const data = (await ghGraphQL(BRANCH_CI_QUERY, { owner, repo })) as {
+        data: { repository: { main: RawBranchRef | null; master: RawBranchRef | null; staging: RawBranchRef | null } }
+      }
+
+      const refs: [string, RawBranchRef | null][] = [
+        ['main', data.data.repository.main ?? data.data.repository.master],
+        ['staging', data.data.repository.staging],
+      ]
+
+      return refs
+        .filter((entry): entry is [string, RawBranchRef] => entry[1] !== null)
+        .map(([branch, ref]) => {
+          const target = ref.target
+          if (!target) {
+            return {
+              branch,
+              commitSha: '',
+              commitMessage: '',
+              committedAt: '',
+              overallState: '',
+              checks: [],
+            }
+          }
+          const rawChecks = target.statusCheckRollup?.contexts.nodes ?? []
+          const checks: CICheck[] = rawChecks.map(mapRawCheck)
+          return {
+            branch,
+            commitSha: target.oid.slice(0, 7),
+            commitMessage: target.messageHeadline,
+            committedAt: target.committedDate,
+            overallState: target.statusCheckRollup?.state ?? '',
+            checks,
+          }
+        })
+    },
+    [],
+    'fetchBranchCI',
+  )
 }

--- a/plugins/dev-core/skills/issues/lib/fetch-vercel.ts
+++ b/plugins/dev-core/skills/issues/lib/fetch-vercel.ts
@@ -1,4 +1,5 @@
 import { FIVE_MINUTES_MS } from './constants'
+import { safeAsync } from './safe-async'
 import type { BuildStep, VercelDeployment } from './types'
 
 const VERCEL_PROJECT_ID = process.env.VERCEL_PROJECT_ID ?? ''
@@ -95,75 +96,77 @@ export async function fetchVercelDeployments(
   const token = getVercelToken()
   if (!token || !projectId || !teamId) return []
 
-  try {
-    const url = `https://api.vercel.com/v6/deployments?projectId=${projectId}&teamId=${teamId}&limit=10`
-    const res = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
-    if (!res.ok) return []
-    const data = (await res.json()) as { deployments: RawVercelDeployment[] }
+  return safeAsync(
+    async () => {
+      const url = `https://api.vercel.com/v6/deployments?projectId=${projectId}&teamId=${teamId}&limit=10`
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) return []
+      const data = (await res.json()) as { deployments: RawVercelDeployment[] }
 
-    const mapped = data.deployments.map((d) => ({
-      uid: d.uid,
-      url: d.url,
-      name: d.name ?? '',
-      state: d.state ?? d.readyState ?? '',
-      target: d.target ?? '',
-      createdAt: d.createdAt,
-      buildingAt: d.buildingAt ?? 0,
-      ready: d.ready ?? 0,
-      source: d.source ?? '',
-      meta: {
-        githubCommitRef: d.meta?.githubCommitRef,
-        githubCommitMessage: d.meta?.githubCommitMessage,
-      },
-      inspectorUrl: d.inspectorUrl ?? '',
-      buildSteps: [] as BuildStep[],
-      isCurrent: false,
-    }))
+      const mapped = data.deployments.map((d) => ({
+        uid: d.uid,
+        url: d.url,
+        name: d.name ?? '',
+        state: (d.state ?? d.readyState ?? '') as VercelDeployment['state'],
+        target: d.target ?? '',
+        createdAt: d.createdAt,
+        buildingAt: d.buildingAt ?? 0,
+        ready: d.ready ?? 0,
+        source: d.source ?? '',
+        meta: {
+          githubCommitRef: d.meta?.githubCommitRef,
+          githubCommitMessage: d.meta?.githubCommitMessage,
+        },
+        inspectorUrl: d.inspectorUrl ?? '',
+        buildSteps: [] as BuildStep[],
+        isCurrent: false,
+      }))
 
-    const now = Date.now()
-    const isOngoing = (d: (typeof mapped)[0]) => ['BUILDING', 'QUEUED', 'INITIALIZING'].includes(d.state)
+      const now = Date.now()
+      const isOngoing = (d: (typeof mapped)[0]) => ['BUILDING', 'QUEUED', 'INITIALIZING'].includes(d.state)
 
-    // Production: current (latest READY prod) + latest prod error if newer than current
-    const currentProd = mapped.find((d) => d.state === 'READY' && d.target === 'production')
-    if (currentProd) currentProd.isCurrent = true
-    const latestProdError = mapped.find((d) => d.state === 'ERROR' && d.target === 'production')
-    const showProdError = latestProdError && (!currentProd || latestProdError.createdAt > currentProd.createdAt)
+      // Production: current (latest READY prod) + latest prod error if newer than current
+      const currentProd = mapped.find((d) => d.state === 'READY' && d.target === 'production')
+      if (currentProd) currentProd.isCurrent = true
+      const latestProdError = mapped.find((d) => d.state === 'ERROR' && d.target === 'production')
+      const showProdError = latestProdError && (!currentProd || latestProdError.createdAt > currentProd.createdAt)
 
-    // Preview: latest ongoing preview + latest completed preview if within last 5 min
-    const latestOngoingPreview = mapped.find((d) => isOngoing(d) && d.target !== 'production')
-    const latestCompletedPreview = mapped.find(
-      (d) => !isOngoing(d) && d.target !== 'production' && now - d.createdAt < FIVE_MINUTES_MS,
-    )
+      // Preview: latest ongoing preview + latest completed preview if within last 5 min
+      const latestOngoingPreview = mapped.find((d) => isOngoing(d) && d.target !== 'production')
+      const latestCompletedPreview = mapped.find(
+        (d) => !isOngoing(d) && d.target !== 'production' && now - d.createdAt < FIVE_MINUTES_MS,
+      )
 
-    // Also include ongoing production deployments
-    const ongoingProd = mapped.filter((d) => isOngoing(d) && d.target === 'production')
+      // Also include ongoing production deployments
+      const ongoingProd = mapped.filter((d) => isOngoing(d) && d.target === 'production')
 
-    const seen = new Set<string>()
-    const filtered: typeof mapped = []
-    const candidates = [
-      ...ongoingProd,
-      ...(currentProd ? [currentProd] : []),
-      ...(showProdError ? [latestProdError] : []),
-      ...(latestOngoingPreview ? [latestOngoingPreview] : []),
-      ...(latestCompletedPreview ? [latestCompletedPreview] : []),
-    ]
-    for (const d of candidates) {
-      if (!seen.has(d.uid)) {
-        seen.add(d.uid)
-        filtered.push(d)
+      const seen = new Set<string>()
+      const filtered: typeof mapped = []
+      const candidates = [
+        ...ongoingProd,
+        ...(currentProd ? [currentProd] : []),
+        ...(showProdError ? [latestProdError] : []),
+        ...(latestOngoingPreview ? [latestOngoingPreview] : []),
+        ...(latestCompletedPreview ? [latestCompletedPreview] : []),
+      ]
+      for (const d of candidates) {
+        if (!seen.has(d.uid)) {
+          seen.add(d.uid)
+          filtered.push(d)
+        }
       }
-    }
 
-    // Fetch build logs in parallel for all visible deployments
-    const logResults = await Promise.all(filtered.map((d) => fetchBuildLogs(token, d.uid, teamId)))
-    for (let i = 0; i < filtered.length; i++) {
-      filtered[i].buildSteps = parseBuildSteps(logResults[i], filtered[i].state)
-    }
+      // Fetch build logs in parallel for all visible deployments
+      const logResults = await Promise.all(filtered.map((d) => fetchBuildLogs(token, d.uid, teamId)))
+      for (let i = 0; i < filtered.length; i++) {
+        filtered[i].buildSteps = parseBuildSteps(logResults[i], filtered[i].state)
+      }
 
-    return filtered
-  } catch {
-    return []
-  }
+      return filtered
+    },
+    [],
+    'fetchVercelDeployments',
+  )
 }

--- a/plugins/dev-core/skills/issues/lib/fetch-workflow.ts
+++ b/plugins/dev-core/skills/issues/lib/fetch-workflow.ts
@@ -1,6 +1,7 @@
 import { GITHUB_REPO } from '../../shared/adapters/config-helpers'
 import { getGitHubToken as _getGitHubToken } from '../../shared/adapters/github-adapter'
 import { FIVE_MINUTES_MS } from './constants'
+import { safeAsync } from './safe-async'
 import type { WorkflowRun } from './types'
 
 interface RawWorkflowRun {
@@ -29,46 +30,48 @@ export async function fetchWorkflowRuns(repoSlug: string = GITHUB_REPO): Promise
   const token = getGitHubToken()
   if (!token) return []
 
-  try {
-    const url = `https://api.github.com/repos/${repoSlug}/actions/workflows/deploy-preview.yml/runs?per_page=10`
-    const res = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-    })
-    if (!res.ok) return []
+  return safeAsync(
+    async () => {
+      const url = `https://api.github.com/repos/${repoSlug}/actions/workflows/deploy-preview.yml/runs?per_page=10`
+      const res = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      })
+      if (!res.ok) return []
 
-    const data = (await res.json()) as { workflow_runs: RawWorkflowRun[] }
-    const now = Date.now()
+      const data = (await res.json()) as { workflow_runs: RawWorkflowRun[] }
+      const now = Date.now()
 
-    const filtered = data.workflow_runs.filter((run) => {
-      const ongoing = run.status === 'in_progress' || run.status === 'queued'
-      const recentCompleted = run.status === 'completed' && now - new Date(run.updated_at).getTime() < FIVE_MINUTES_MS
-      return ongoing || recentCompleted
-    })
+      const filtered = data.workflow_runs.filter((run) => {
+        const ongoing = run.status === 'in_progress' || run.status === 'queued'
+        const recentCompleted = run.status === 'completed' && now - new Date(run.updated_at).getTime() < FIVE_MINUTES_MS
+        return ongoing || recentCompleted
+      })
 
-    return filtered.map((run) => {
-      const rawMsg = run.head_commit?.message ?? ''
-      const firstLine = rawMsg.split('\n')[0]
-      const headCommitMessage = firstLine.length > 60 ? `${firstLine.slice(0, 60)}...` : firstLine
+      return filtered.map((run) => {
+        const rawMsg = run.head_commit?.message ?? ''
+        const firstLine = rawMsg.split('\n')[0]
+        const headCommitMessage = firstLine.length > 60 ? `${firstLine.slice(0, 60)}...` : firstLine
 
-      return {
-        id: run.id,
-        name: run.name,
-        displayTitle: run.display_title,
-        event: run.event,
-        status: run.status,
-        conclusion: run.conclusion,
-        htmlUrl: run.html_url,
-        createdAt: run.created_at,
-        updatedAt: run.updated_at,
-        headBranch: run.head_branch,
-        headCommitMessage,
-      }
-    })
-  } catch {
-    return []
-  }
+        return {
+          id: run.id,
+          name: run.name,
+          displayTitle: run.display_title,
+          event: run.event,
+          status: run.status as WorkflowRun['status'],
+          conclusion: run.conclusion as WorkflowRun['conclusion'],
+          htmlUrl: run.html_url,
+          createdAt: run.created_at,
+          updatedAt: run.updated_at,
+          headBranch: run.head_branch,
+          headCommitMessage,
+        }
+      })
+    },
+    [],
+    'fetchWorkflowRuns',
+  )
 }

--- a/plugins/dev-core/skills/issues/lib/gh-enums.ts
+++ b/plugins/dev-core/skills/issues/lib/gh-enums.ts
@@ -30,4 +30,3 @@ export type WorkflowConclusion =
   | 'timed_out'
   | 'action_required'
   | 'stale'
-  | 'startup_failure'

--- a/plugins/dev-core/skills/issues/lib/gh-enums.ts
+++ b/plugins/dev-core/skills/issues/lib/gh-enums.ts
@@ -1,0 +1,33 @@
+export type CheckStatusState = 'QUEUED' | 'REQUESTED' | 'IN_PROGRESS' | 'COMPLETED' | 'WAITING' | 'PENDING'
+
+export type CheckConclusionState =
+  | 'ACTION_REQUIRED'
+  | 'TIMED_OUT'
+  | 'CANCELLED'
+  | 'FAILURE'
+  | 'SUCCESS'
+  | 'NEUTRAL'
+  | 'SKIPPED'
+  | 'STARTUP_FAILURE'
+  | 'STALE'
+
+export type StatusState = 'EXPECTED' | 'ERROR' | 'FAILURE' | 'PENDING' | 'SUCCESS'
+
+export type PullRequestState = 'OPEN' | 'CLOSED' | 'MERGED'
+
+export type MergeableState = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+
+export type VercelState = 'QUEUED' | 'BUILDING' | 'ERROR' | 'INITIALIZING' | 'READY' | 'CANCELED'
+
+export type WorkflowStatus = 'queued' | 'in_progress' | 'completed' | 'waiting' | 'requested' | 'pending'
+
+export type WorkflowConclusion =
+  | 'success'
+  | 'failure'
+  | 'neutral'
+  | 'cancelled'
+  | 'skipped'
+  | 'timed_out'
+  | 'action_required'
+  | 'stale'
+  | 'startup_failure'

--- a/plugins/dev-core/skills/issues/lib/safe-async.ts
+++ b/plugins/dev-core/skills/issues/lib/safe-async.ts
@@ -1,0 +1,8 @@
+export async function safeAsync<T>(fn: () => Promise<T>, fallback: T, context: string): Promise<T> {
+  try {
+    return await fn()
+  } catch (err) {
+    process.stderr.write(`[${context}] ${err instanceof Error ? err.message : String(err)}\n`)
+    return fallback
+  }
+}

--- a/plugins/dev-core/skills/issues/lib/types.ts
+++ b/plugins/dev-core/skills/issues/lib/types.ts
@@ -5,7 +5,6 @@
 import type { WorkspaceProject } from '../../shared/ports/workspace'
 
 export type { RawContent, RawFieldValue, RawItem, RawSubIssue } from '../../shared/types'
-export type { WorkspaceProject }
 // re-export to expose gh-enums types to this module's consumers; import for local use in interface bodies below
 export type {
   CheckConclusionState,
@@ -17,6 +16,7 @@ export type {
   WorkflowConclusion,
   WorkflowStatus,
 } from './gh-enums'
+export type { WorkspaceProject }
 
 import type {
   CheckConclusionState,

--- a/plugins/dev-core/skills/issues/lib/types.ts
+++ b/plugins/dev-core/skills/issues/lib/types.ts
@@ -6,6 +6,7 @@ import type { WorkspaceProject } from '../../shared/ports/workspace'
 
 export type { RawContent, RawFieldValue, RawItem, RawSubIssue } from '../../shared/types'
 export type { WorkspaceProject }
+// re-export to expose gh-enums types to this module's consumers; import for local use in interface bodies below
 export type {
   CheckConclusionState,
   CheckStatusState,

--- a/plugins/dev-core/skills/issues/lib/types.ts
+++ b/plugins/dev-core/skills/issues/lib/types.ts
@@ -6,6 +6,27 @@ import type { WorkspaceProject } from '../../shared/ports/workspace'
 
 export type { RawContent, RawFieldValue, RawItem, RawSubIssue } from '../../shared/types'
 export type { WorkspaceProject }
+export type {
+  CheckConclusionState,
+  CheckStatusState,
+  MergeableState,
+  PullRequestState,
+  StatusState,
+  VercelState,
+  WorkflowConclusion,
+  WorkflowStatus,
+} from './gh-enums'
+
+import type {
+  CheckConclusionState,
+  CheckStatusState,
+  MergeableState,
+  PullRequestState,
+  StatusState,
+  VercelState,
+  WorkflowConclusion,
+  WorkflowStatus,
+} from './gh-enums'
 
 export interface Issue {
   number: number
@@ -24,8 +45,8 @@ export interface Issue {
 
 export interface CICheck {
   name: string
-  status: string
-  conclusion: string
+  status: CheckStatusState | StatusState | ''
+  conclusion: CheckConclusionState | ''
   detailsUrl: string
 }
 
@@ -33,7 +54,7 @@ export interface PR {
   number: number
   title: string
   branch: string
-  state: string
+  state: PullRequestState
   isDraft: boolean
   url: string
   author: string
@@ -42,7 +63,7 @@ export interface PR {
   deletions: number
   reviewDecision: string
   labels: string[]
-  mergeable: string
+  mergeable: MergeableState
   checks: CICheck[]
 }
 
@@ -67,7 +88,7 @@ export interface VercelDeployment {
   uid: string
   url: string
   name: string
-  state: string
+  state: VercelState
   isCurrent?: boolean // true for the active production deployment
   target: string
   createdAt: number
@@ -93,8 +114,8 @@ export interface WorkflowRun {
   name: string
   displayTitle: string
   event: string
-  status: string
-  conclusion: string | null
+  status: WorkflowStatus
+  conclusion: WorkflowConclusion | null
   htmlUrl: string
   createdAt: string
   updatedAt: string

--- a/plugins/dev-core/skills/issues/show.ts
+++ b/plugins/dev-core/skills/issues/show.ts
@@ -80,37 +80,40 @@ interface SubIssue {
 }
 
 const [owner, repo] = detectGitHubRepo().split('/')
-const gqlRaw = ghGraphQLExec(`{
-  repository(owner: "${owner}", name: "${repo}") {
-    issue(number: ${issueNum}) {
-      subIssues(first: 50) {
-        nodes { number title state }
-      }
-    }
-  }
-}`) as { data: { repository: { issue: { subIssues: { nodes: SubIssue[] } } } } }
 
-const subIssues: SubIssue[] = gqlRaw.data.repository.issue?.subIssues?.nodes ?? []
-
-// ── 3. Blocked-by state via GraphQL (actual GitHub blockers, not just body) ──
+// ── 3. Sub-issues + blocked-by in a single GraphQL request ──────────────────
 interface BlockerNode {
   number: number
   title: string
   state: 'OPEN' | 'CLOSED'
 }
 
-const blockersRaw = ghGraphQLExec(`{
+const gqlRaw = ghGraphQLExec(`{
   repository(owner: "${owner}", name: "${repo}") {
     issue(number: ${issueNum}) {
+      subIssues(first: 50) {
+        nodes { number title state }
+      }
       trackedInIssues(first: 20) {
         nodes { number title state }
       }
     }
   }
-}`) as { data: { repository: { issue: { trackedInIssues: { nodes: BlockerNode[] } } } } }
+}`) as {
+  data: {
+    repository: {
+      issue: {
+        subIssues: { nodes: SubIssue[] }
+        trackedInIssues: { nodes: BlockerNode[] }
+      }
+    }
+  }
+}
+
+const subIssues: SubIssue[] = gqlRaw.data.repository.issue?.subIssues?.nodes ?? []
 
 // Fall back to body-parsed blockers if GraphQL returns nothing
-const graphqlBlockers: BlockerNode[] = blockersRaw.data.repository.issue?.trackedInIssues?.nodes ?? []
+const graphqlBlockers: BlockerNode[] = gqlRaw.data.repository.issue?.trackedInIssues?.nodes ?? []
 const bodyBlockerNums = parseBlockedBy(issue.body)
 const blockers: BlockerNode[] =
   graphqlBlockers.length > 0

--- a/plugins/dev-core/tools/__tests__/licenseChecker.test.ts
+++ b/plugins/dev-core/tools/__tests__/licenseChecker.test.ts
@@ -915,3 +915,139 @@ describe('printSummary', () => {
     expect(output).toContain('/tmp/report.json')
   })
 })
+
+// ─── readPackageInfo → detectLicense: single read per package (SC5) ──────────
+//
+// Strategy: ESM named imports are not configurable, so vi.spyOn(fs, 'readFileSync')
+// is not available. Instead we verify the invariant behaviorally:
+// when carried fields (license/licenses) are present on RawPackageInfo, detectLicense
+// returns immediately without needing to read package.json from disk. We prove this
+// by passing a RawPackageInfo whose dir does NOT exist on disk — if detectLicense
+// tried to re-read package.json it would fail; since it succeeds, no re-read occurred.
+
+describe('readPackageInfo → detectLicense: package.json read-once invariant', () => {
+  const policy: LicensePolicy = { allowedLicenses: ['MIT', 'ISC'], overrides: {} }
+
+  it('resolves license from carried license field without touching disk', () => {
+    // Arrange — dir does not exist; readFileSync would throw if called
+    const pkg: RawPackageInfo = {
+      name: 'carried-mit',
+      version: '1.0.0',
+      dir: '/nonexistent/__test__/carried-mit',
+      license: 'MIT',
+    }
+    // Act — if detectLicense re-reads package.json it will throw (dir missing)
+    const result = detectLicense(pkg, policy)
+    // Assert — succeeded without disk access; license came from carried field
+    expect(result.license).toBe('MIT')
+    expect(result.source).toBe('package.json')
+  })
+
+  it('resolves license from carried licenses array without touching disk', () => {
+    // Arrange — dir does not exist
+    const pkg: RawPackageInfo = {
+      name: 'carried-isc',
+      version: '2.0.0',
+      dir: '/nonexistent/__test__/carried-isc',
+      licenses: [{ type: 'ISC' }],
+    }
+    // Act
+    const result = detectLicense(pkg, policy)
+    // Assert
+    expect(result.license).toBe('ISC')
+    expect(result.source).toBe('package.json')
+  })
+
+  it('falls back to disk read only when neither license nor licenses is carried', () => {
+    // Arrange — no carried fields AND dir does not exist → detectLicense will attempt re-read
+    const pkg: RawPackageInfo = {
+      name: 'no-carry',
+      version: '1.0.0',
+      dir: '/nonexistent/__test__/no-carry',
+      // no license, no licenses
+    }
+    // Act — detectLicense catches the readFileSync error and falls through to file detection
+    // (also fails), ultimately returning null — this confirms the fallback code path executes
+    const result = detectLicense(pkg, policy)
+    // Assert — null because neither package.json nor LICENSE file is accessible
+    expect(result.license).toBeNull()
+    expect(result.source).toBeNull()
+  })
+})
+
+// ─── checkCompliance — regression pin (SC5) ──────────────────────────────────
+
+describe('checkCompliance — regression pin', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir('license-regression-')
+  })
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns correct report structure for a mixed fixture (allowed + violation + unknown)', () => {
+    // Arrange
+    const policy: LicensePolicy = { allowedLicenses: ['MIT', 'ISC'], overrides: { 'overridden@3.0.0': 'MIT' } }
+    const pkgMit = makePackageDir(tmpDir, 'mit-pkg', { name: 'mit-pkg', version: '1.0.0', license: 'MIT' })
+    const pkgViolation = makePackageDir(tmpDir, 'gpl-pkg', { name: 'gpl-pkg', version: '2.0.0', license: 'GPL-3.0' })
+    const pkgUnknown = makePackageDir(tmpDir, 'mystery-pkg', { name: 'mystery-pkg', version: '0.1.0' })
+    const pkgOverride = makePackageDir(tmpDir, 'overridden', {
+      name: 'overridden',
+      version: '3.0.0',
+      license: 'GPL-3.0',
+    })
+
+    // Act
+    const report = checkCompliance([pkgMit, pkgViolation, pkgUnknown, pkgOverride], policy)
+
+    // Assert — summary counts
+    expect(report.summary.totalPackages).toBe(4)
+    expect(report.summary.violations).toBe(1)
+    expect(report.summary.warnings).toBe(1)
+
+    // Assert — license distribution
+    // MIT x2 (mit-pkg + override resolves to MIT), GPL-3.0 x1; unknown not counted (null license)
+    expect(report.summary.licenses['MIT']).toBe(2)
+    expect(report.summary.licenses['GPL-3.0']).toBe(1)
+
+    // Assert — package statuses
+    const byName = Object.fromEntries(report.packages.map((p) => [p.name, p]))
+    expect(byName['mit-pkg'].status).toBe('allowed')
+    expect(byName['gpl-pkg'].status).toBe('violation')
+    expect(byName['mystery-pkg'].status).toBe('unknown')
+    expect(byName['overridden'].status).toBe('override')
+
+    // Assert — violations array
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0].name).toBe('gpl-pkg')
+    expect(report.violations[0].license).toBe('GPL-3.0')
+
+    // Assert — warnings array (unknown license)
+    const unknownWarning = report.warnings.find((w) => w.name === 'mystery-pkg')
+    expect(unknownWarning).toBeDefined()
+    expect(unknownWarning?.reason).toContain('No license')
+
+    // Assert — timestamps and shape present
+    expect(report.timestamp).toBeDefined()
+    expect(typeof report.timestamp).toBe('string')
+  })
+
+  it('returns zero violations and zero warnings for an all-allowed fixture', () => {
+    // Arrange
+    const policy: LicensePolicy = { allowedLicenses: ['MIT', 'ISC'], overrides: {} }
+    const p1 = makePackageDir(tmpDir, 'a', { name: 'a', version: '1.0.0', license: 'MIT' })
+    const p2 = makePackageDir(tmpDir, 'b', { name: 'b', version: '1.0.0', license: 'ISC' })
+
+    // Act
+    const report = checkCompliance([p1, p2], policy)
+
+    // Assert
+    expect(report.summary.totalPackages).toBe(2)
+    expect(report.summary.violations).toBe(0)
+    expect(report.summary.warnings).toBe(0)
+    expect(report.violations).toHaveLength(0)
+    expect(report.warnings).toHaveLength(0)
+  })
+})

--- a/plugins/dev-core/tools/licenseChecker.ts
+++ b/plugins/dev-core/tools/licenseChecker.ts
@@ -84,6 +84,10 @@ export interface RawPackageInfo {
   name: string
   version: string
   dir: string
+  /** License string extracted from package.json at scan time (string field). */
+  license?: string
+  /** Licenses array extracted from package.json at scan time (deprecated format). */
+  licenses?: Array<string | { type?: string }>
 }
 
 const IGNORED_ENTRIES = new Set(['.cache', '.bin', '.package-lock.json'])
@@ -174,7 +178,10 @@ function readPackageInfo(pkgDir: string): RawPackageInfo | null {
       JSON.parse(raw) as Record<string, unknown>,
     )
     if (!(pkg.name && pkg.version)) return null
-    return { name: String(pkg.name), version: String(pkg.version), dir: realDir }
+    const info: RawPackageInfo = { name: String(pkg.name), version: String(pkg.version), dir: realDir }
+    if (typeof pkg.license === 'string') info.license = pkg.license
+    if (Array.isArray(pkg.licenses)) info.licenses = pkg.licenses as Array<string | { type?: string }>
+    return info
   } catch {
     return null
   }
@@ -266,29 +273,47 @@ export function detectLicense(
     return { license: policy.overrides[key], source: 'override' }
   }
 
-  // 2-3. package.json license field
-  const pkgJsonPath = join(pkg.dir, 'package.json')
-  try {
-    const raw = readFileSync(pkgJsonPath, 'utf-8')
-    const pkgJson = Object.assign(
-      Object.create(null) as Record<string, unknown>,
-      JSON.parse(raw) as Record<string, unknown>,
-    )
+  // 2-3. package.json license field — use carried fields when available, re-read only as fallback
+  const carriedLicense = pkg.license
+  const carriedLicenses = pkg.licenses
 
-    // 2. license field (string)
-    if (typeof pkgJson.license === 'string' && (pkgJson.license as string).trim()) {
-      return { license: (pkgJson.license as string).trim(), source: 'package.json' }
+  if (carriedLicense !== undefined || carriedLicenses !== undefined) {
+    // 2. license field (string) — carried from readPackageInfo
+    if (typeof carriedLicense === 'string' && carriedLicense.trim()) {
+      return { license: carriedLicense.trim(), source: 'package.json' }
     }
 
-    // 3. licenses array (deprecated)
-    const licenses = pkgJson.licenses
-    if (Array.isArray(licenses) && licenses.length > 0) {
-      const first = licenses[0] as string | { type?: string } | null
+    // 3. licenses array (deprecated) — carried from readPackageInfo
+    if (Array.isArray(carriedLicenses) && carriedLicenses.length > 0) {
+      const first = carriedLicenses[0] as string | { type?: string } | null
       const licenseStr = typeof first === 'string' ? first : (first as { type?: string } | null)?.type
       if (licenseStr) return { license: licenseStr, source: 'package.json' }
     }
-  } catch {
-    // Fall through to file detection
+  } else {
+    // Fallback: re-read package.json (e.g. RawPackageInfo constructed without carried fields)
+    const pkgJsonPath = join(pkg.dir, 'package.json')
+    try {
+      const raw = readFileSync(pkgJsonPath, 'utf-8')
+      const pkgJson = Object.assign(
+        Object.create(null) as Record<string, unknown>,
+        JSON.parse(raw) as Record<string, unknown>,
+      )
+
+      // 2. license field (string)
+      if (typeof pkgJson.license === 'string' && (pkgJson.license as string).trim()) {
+        return { license: (pkgJson.license as string).trim(), source: 'package.json' }
+      }
+
+      // 3. licenses array (deprecated)
+      const licenses = pkgJson.licenses
+      if (Array.isArray(licenses) && licenses.length > 0) {
+        const first = licenses[0] as string | { type?: string } | null
+        const licenseStr = typeof first === 'string' ? first : (first as { type?: string } | null)?.type
+        if (licenseStr) return { license: licenseStr, source: 'package.json' }
+      }
+    } catch {
+      // Fall through to file detection
+    }
   }
 
   // 4. LICENSE file


### PR DESCRIPTION
## Summary
- **Silent errors** — new `safeAsync<T>(fn, fallback, context)` helper logs fetch failures to stderr with a context tag and returns a fallback; the 6 outer fetch functions (`fetchPRs`, `fetchBranchCI`, `fetchBranches`, `fetchWorktrees`, `fetchVercelDeployments`, `fetchWorkflowRuns`) route through it. The 2 intentional inner guards (`fetchBuildLogs`, `getGitHubToken`) are left untouched.
- **Weak types** — new `gh-enums.ts` defines 8 literal-union types (GraphQL UPPER / REST lower — divergence intentional); `types.ts` replaces bare `string` on CI/PR/Vercel/workflow state fields (incl. the `''` fallback member). `tsc` now rejects invalid state literals. `BranchCI.overallState` left `string` (separate rollup field, out of scope).
- **Perf hotspots** — `licenseChecker` carries parsed `license`/`licenses` on `RawPackageInfo` (no double-read); `show.ts` merges 2 GraphQL roundtrips into 1; `security-check.js` lifts state I/O to `main()` and writes only when a new warning is added.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #197: Silent errors, weak types, perf hotspots in dev-core | OPEN (chore) |
| Frame | [197-…-frame.mdx](artifacts/frames/197-silent-errors-weak-types-perf-hotspots-frame.mdx) | Present |
| Analysis | — | Skipped (F-lite) |
| Spec | [197-…-spec.mdx](artifacts/specs/197-silent-errors-weak-types-perf-hotspots-spec.mdx) | Present |
| Plan | [197-…-plan.mdx](artifacts/plans/197-silent-errors-weak-types-perf-hotspots-plan.mdx) | Present |
| Implementation | 3 slice commits on `feat/197-silent-errors-weak-types-perf-hotspots` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (798 passed / 4 skipped, 2 new test files) | Passed |

## Test Plan
- [ ] `bun run typecheck && bun run lint && bun run test` → all green
- [ ] Force a `fetch*` throw → stderr shows `[fetchX] <msg>` and the function returns its `[]` fallback (no silent swallow)
- [ ] Assign an invalid state literal (e.g. `state: 'OPN'`) → `tsc` rejects
- [ ] License report on this repo byte-identical to before; `show.ts` output identical for an issue with and without sub-issues; security-check still blocks known secrets and skips the state write on a clean run

## Notes
- Zero behavioral regression is pinned per-slice (license report, `show.ts` output, block decisions).
- Pre-existing gap noted (out of #197 scope): `.claude/security_warnings/` runtime state dir is not gitignored.

Closes #197

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
