### PR TITLE
fix(dev-core): guard fetch-vercel state with asVercelState coercion (#242)

### DIFF
--- a/plugins/dev-core/skills/issues/__tests__/gh-enums.test.ts
+++ b/plugins/dev-core/skills/issues/__tests__/gh-enums.test.ts
@@ -4,6 +4,7 @@ import {
   asCheckStatusState,
   asMergeableState,
   asPullRequestState,
+  asVercelState,
   asWorkflowConclusion,
   asWorkflowStatus,
 } from '../lib/gh-enums'
@@ -73,6 +74,28 @@ describe('asPullRequestState', () => {
 
   it('maps an unknown string to the sentinel empty string', () => {
     expect(asPullRequestState('DRAFT')).toBe('')
+  })
+})
+
+describe('asVercelState', () => {
+  it('passes a valid member through unchanged', () => {
+    expect(asVercelState('READY')).toBe('READY')
+  })
+
+  it('passes BUILDING through unchanged', () => {
+    expect(asVercelState('BUILDING')).toBe('BUILDING')
+  })
+
+  it('passes CANCELED through unchanged', () => {
+    expect(asVercelState('CANCELED')).toBe('CANCELED')
+  })
+
+  it('maps an unknown string to the sentinel empty string', () => {
+    expect(asVercelState('DEPLOYING')).toBe('')
+  })
+
+  it('maps an empty string to sentinel empty string', () => {
+    expect(asVercelState('')).toBe('')
   })
 })
 

--- a/plugins/dev-core/skills/issues/lib/fetch-vercel.ts
+++ b/plugins/dev-core/skills/issues/lib/fetch-vercel.ts
@@ -1,4 +1,5 @@
 import { FIVE_MINUTES_MS } from './constants'
+import { asVercelState } from './gh-enums'
 import { safeAsync } from './safe-async'
 import type { BuildStep, VercelDeployment } from './types'
 
@@ -109,7 +110,7 @@ export async function fetchVercelDeployments(
         uid: d.uid,
         url: d.url,
         name: d.name ?? '',
-        state: (d.state ?? d.readyState ?? '') as VercelDeployment['state'],
+        state: asVercelState(d.state ?? d.readyState ?? ''),
         target: d.target ?? '',
         createdAt: d.createdAt,
         buildingAt: d.buildingAt ?? 0,

--- a/plugins/dev-core/skills/issues/lib/gh-enums.ts
+++ b/plugins/dev-core/skills/issues/lib/gh-enums.ts
@@ -65,6 +65,11 @@ export function asPullRequestState(v: string): PullRequestState | '' {
   return inSet(PULL_REQUEST_STATES, v) ? v : ''
 }
 
+// VercelState has no empty member — field widened to `VercelState | ''`, unknown → ''
+export function asVercelState(v: string): VercelState | '' {
+  return inSet(VERCEL_STATES, v) ? v : ''
+}
+
 // WorkflowStatus has no empty member — field widened to `WorkflowStatus | ''`, unknown → ''
 export function asWorkflowStatus(v: string): WorkflowStatus | '' {
   return inSet(WORKFLOW_STATUSES, v) ? v : ''

--- a/plugins/dev-core/skills/issues/lib/types.ts
+++ b/plugins/dev-core/skills/issues/lib/types.ts
@@ -89,7 +89,7 @@ export interface VercelDeployment {
   uid: string
   url: string
   name: string
-  state: VercelState
+  state: VercelState | '' // '' = sentinel for unknown/missing Vercel state (see asVercelState)
   isCurrent?: boolean // true for the active production deployment
   target: string
   createdAt: number


### PR DESCRIPTION
## Summary
- Replace the last raw `as VercelDeployment['state']` cast at the `fetch-vercel.ts` map site with an `asVercelState()` coercion guard — closing the one fetch-boundary enum left un-guarded after #237/#238.
- `VercelState` has no empty member, so the guard widens to `VercelState | ''` and returns `''` for unknown/missing values, mirroring `asPullRequestState`/`asWorkflowStatus`. `VercelDeployment.state` widened accordingly.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #242: suggestion: apply enum coercion guard to fetch-vercel.ts VercelDeployment.state | OPEN |
| Implementation | 1 commit on `feat/242-enum-coercion-guard-fetch-vercel` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (5 new cases) | Passed |

## Test Plan
- [ ] `bun run test` — `asVercelState` suite: valid members pass through, unknown/`''` → `''`
- [ ] Consumers (`DEPLOY_STATE_DISPLAY` lookup, `isOngoing`, `parseBuildSteps`) handle `''` gracefully (Record<string> fallback → ❓)

Closes #242

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/pr`