### PR TITLE
revert(implement): keep worktree CWD inheritance for subagents

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.5.1",
+  "version": "0.5.0",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 33 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/cli/__tests__/workspace.test.ts
+++ b/plugins/dev-core/cli/__tests__/workspace.test.ts
@@ -49,7 +49,7 @@ describe('workspace list', () => {
       workspacePath,
       makeWorkspaceJson([
         { repo: 'Roxabi/roxabi-plugins', projectId: 'PVT_kwDORa9q-M4Aqkwn', label: 'Roxabi Plugins' },
-        { repo: 'mickaelV0/repo-b', projectId: 'PVT_aabbcc', label: 'Personal Repo B' },
+        { repo: 'octocat/repo-b', projectId: 'PVT_aabbcc', label: 'Personal Repo B' },
       ]),
     )
     const originalHome = process.env.HOME
@@ -195,7 +195,7 @@ describe('workspace remove (registered repo)', () => {
       workspacePath,
       makeWorkspaceJson([
         { repo: 'Roxabi/roxabi-plugins', projectId: 'PVT_aaa', label: 'Plugins' },
-        { repo: 'mickaelV0/repo-b', projectId: 'PVT_bbb', label: 'Repo B' },
+        { repo: 'octocat/repo-b', projectId: 'PVT_bbb', label: 'Repo B' },
       ]),
     )
     const originalHome = process.env.HOME
@@ -220,7 +220,7 @@ describe('workspace remove (registered repo)', () => {
 
       const written = JSON.parse(readFileSync(workspacePath, 'utf8'))
       expect(written.projects).toHaveLength(1)
-      expect(written.projects[0].repo).toBe('mickaelV0/repo-b')
+      expect(written.projects[0].repo).toBe('octocat/repo-b')
 
       const output = lines.join('\n')
       expect(output).toContain('Roxabi/roxabi-plugins')
@@ -244,7 +244,7 @@ describe('workspace remove (unregistered repo)', () => {
     const workspacePath = join(vaultDir, 'workspace.json')
     require('node:fs').writeFileSync(
       workspacePath,
-      makeWorkspaceJson([{ repo: 'mickaelV0/repo-b', projectId: 'PVT_bbb', label: 'Repo B' }]),
+      makeWorkspaceJson([{ repo: 'octocat/repo-b', projectId: 'PVT_bbb', label: 'Repo B' }]),
     )
     const originalHome = process.env.HOME
     process.env.HOME = tmpDir

--- a/plugins/dev-core/skills/implement/SKILL.md
+++ b/plugins/dev-core/skills/implement/SKILL.md
@@ -2,7 +2,7 @@
 name: implement
 argument-hint: '[--issue <N> | --plan <path> | --audit]'
 description: Execute plan — setup worktree, spawn agents, write code + tests. Triggers: "implement" | "build this" | "execute plan" | "start coding" | "write the code" | "code this up" | "let's build it" | "build it out" | "ship it".
-version: 0.3.1
+version: 0.3.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---
 
@@ -111,11 +111,6 @@ Emits: `repo`, `base`, `branch_exists`, `legacy_worktree`, `worktree`, `dirty` (
 
 **2e. Worktree:**
 
-Capture absolute path before entering (used in subagent prompts):
-```bash
-ABS_WT=$(git rev-parse --show-toplevel)/.claude/worktrees/{N}-{slug}
-```
-
 Enter existing worktree (created by `/setup-worktree` or prior `/dev` run):
 ```
 EnterWorktree(path: ".claude/worktrees/{N}-{slug}")
@@ -169,7 +164,7 @@ Read spec + ref patterns → create + implement → tests → QG → loop until 
 
 Spawn via `Task` tool (subagent/domain). Sequential ∨ parallel (2–3 max).
 
-**Worktree isolation:** Main context is already inside ω (Step 2). Subagents spawned via `Task` do NOT inherit this CWD — they start at the project root. The orchestrator injects `EnterWorktree` as the first action of every subagent prompt (see spawn template below).
+**Worktree isolation:** Main context is already inside ω (Step 2). Subagents spawned via `Task` inherit this CWD. All file operations must stay within `.claude/worktrees/{N}-{slug}`. Do not `cd` to repo root or other paths outside ω.
 
 **Per agent spawn:**
 1. `TaskUpdate(task_id, status: "in_progress", owner: "{agent}")`.
@@ -179,7 +174,7 @@ Spawn via `Task` tool (subagent/domain). Sequential ∨ parallel (2–3 max).
    Task(
      subagent_type: "dev-core:{agent}",
      description: "{agent}: {phase} — #{N} {slug}",
-     prompt: "Issue #{N}. Task: {TaskGet.description}. Target: {file_path}. Skeleton: {code_snippet}. Verify: {verify_command}. Ref pattern: {pattern_file}. First action: call EnterWorktree with path `{ABS_WT}` — do this before reading or writing any file. ¬TaskCreate — task lifecycle managed by lead."
+     prompt: "Issue #{N}. Task: {TaskGet.description}. Target: {file_path}. Skeleton: {code_snippet}. Verify: {verify_command}. Ref pattern: {pattern_file}. Worktree: `.claude/worktrees/{N}-{slug}` — you are already inside it; do not leave this directory. ¬TaskCreate — task lifecycle managed by lead."
    )
    ```
    Agent name map: `tester` → `dev-core:tester` | `frontend-dev` → `dev-core:frontend-dev` | `backend-dev` → `dev-core:backend-dev` | `devops` → `dev-core:devops` | `doc-writer` → `dev-core:doc-writer` | `architect` → `dev-core:architect` | `security-auditor` → `dev-core:security-auditor`


### PR DESCRIPTION
## What

Two changes on this branch:

1. **`revert(implement)`** — reverts `275cbfa`, which had injected a per-subagent `EnterWorktree` call into every `/dev-core:implement` spawn prompt on the premise that *"subagents start at the project root."*
2. **`test(dev-core)`** — scrubs a personal-data fixture (`mickaelV0/repo-b` → `octocat/repo-b`) that the revert surfaced.

## Why the revert

The premise of `275cbfa` is **empirically false in this harness.** Tested directly:

| Probe | Agent type | Worktree entry | Result |
|---|---|---|---|
| `pwd` + `git rev-parse --show-toplevel` | general-purpose | `name`-created | worktree ✓ |
| relative-path `Write` | general-purpose | `name`-created | landed **in** worktree, not main repo ✓ |
| `pwd` | `dev-core:backend-dev` | **`path`-entered** (skill's exact flow) | worktree ✓ |

`Task`-spawned subagents **inherit** the orchestrator's `EnterWorktree` CWD. The orchestrator already enters ω at `implement/SKILL.md` Step 2e (`EnterWorktree(path: …)`, marked `ω mandatory ∀ τ — ¬exception`), so the injected call was redundant. The revert restores the accurate isolation note (`subagents inherit this CWD`) + the `you are already inside it` prompt clause, and drops the `ABS_WT` capture.

## Why the fixture fix is bundled

The full `validate_plugins.py` run flagged `mickaelV0/repo-b` in `cli/__tests__/workspace.test.ts` (personal-data scan, pattern `mickael`) — a violation of the repo's zero-personal-data / English-names-only rule. Renamed all 4 occurrences (the write→assert pair stays consistent).

It leaked because **neither gate covers it**: CI's `bun run test` excludes `**/cli/__tests__/**` (root `vitest.config.ts` — those use `bun:test`), and `ci.yml` runs `validate_plugins.py` only with `--check class-list-sync` / `shared-sources-sync`, not the personal-data scan. Closing those gaps is follow-up CI work, out of scope here.

## Version

`plugin.json 0.5.1 → 0.5.0`, `implement 0.3.1 → 0.3.0`. `0.5.1` never left `staging`, so no released version regresses.

## Verification

- `python3 tools/validate_plugins.py` → **all checks pass**
- `bun test __tests__/workspace.test.ts` → **19 pass, 0 fail**
- pre-commit + pre-push hooks (typecheck, trufflehog, conventional-commits, full vitest) → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
