### PR TITLE
feat(issue-triage): create accepts same field flags as set (--type, --lane)

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 33 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/issue-triage/README.md
+++ b/plugins/dev-core/skills/issue-triage/README.md
@@ -15,8 +15,10 @@ Raw GitHub issues lack structure. `/issue-triage` adds Size (XS→XL), Priority 
 /issue-triage set 42 --status "In Progress"
 /issue-triage set 91 --blocked-by 117
 /issue-triage set 164 --parent 163
-/issue-triage create --title "..." --size S --priority Medium --parent 163
+/issue-triage create --title "..." --size S --priority Medium --type feat --lane b --parent 163
 ```
+
+`create` accepts the same field flags as `set`: `--size`, `--priority`, `--status`, `--lane`, `--type` (plus `--parent`, `--add-child`, `--blocked-by`, `--blocks`) — set everything in one shot at creation instead of a follow-up `set`.
 
 Triggers: `"triage"` | `"create issue"` | `"set size"` | `"set priority"` | `"blocked by"` | `"set parent"` | `"sub-issue"` | `"file an issue"` | `"open an issue"`
 

--- a/plugins/dev-core/skills/issue-triage/SKILL.md
+++ b/plugins/dev-core/skills/issue-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-triage
-argument-hint: [list | set <num> | create --title "..." [--parent N] [--size S] [--priority P] | migrate <audit-schema|backfill|rewrite-titles|revert>]
+argument-hint: [list | set <num> | create --title "..." [--parent N] [--size S] [--priority P] [--type T] [--lane L] | migrate <audit-schema|backfill|rewrite-titles|revert>]
 description: Triage/create GitHub issues — set size/priority/status/lane/type, manage dependencies & parent/child, migrate legacy data. Triggers: "triage" | "create issue" | "set size" | "set priority" | "blocked by" | "set parent" | "child of" | "sub-issue" | "file an issue" | "log a bug" | "open an issue" | "file a bug" | "add issue" | "new issue" | "set lane" | "set type" | "migrate" | "backfill" | "audit schema".
 version: 0.3.0
 allowed-tools: Bash, Read, ToolSearch
@@ -18,7 +18,7 @@ Create GitHub issues, assign Size/Priority/Status, manage blockedBy dependencies
 2. ∀ issue: determine Size, Priority, κ (see [Complexity Scoring](#complexity-scoring))
 3. Set values: `τ set <number> --size <S> --priority <P>`
 4. Update status: `τ set <number> --status "In Progress"`
-5. Create issues: `τ create --title "Title" [--body "Body"] [--label "bug,frontend"] [--size M] [--priority High] [--parent 163]`
+5. Create issues: `τ create --title "Title" [--body "Body"] [--label "bug,frontend"] [--size M] [--priority High] [--type feat] [--lane b] [--parent 163]`
 6. → DP(B)if unsure about Size ∨ Priority.
 
 ## Size Guidelines
@@ -80,6 +80,8 @@ Create GitHub issues, assign Size/Priority/Status, manage blockedBy dependencies
 | `--size <S>` | Set size on creation — canonical `S/F-lite/F-full` or legacy `XS/S/M/L/XL` accepted (legacy boards alias canonical names) |
 | `--priority <P>` | Set priority on creation |
 | `--status <S>` | Set status on creation (default: added to project as-is) |
+| `--lane <L>` | Set lane on creation (label-only, additive). Valid: `a1`, `a2`, `a3`, `b`, `c1`, `c2`, `c3`, `d`–`o`, `standalone` |
+| `--type <T>` | Set org issueType on creation (additive). Valid: `fix`, `feat`, `docs`, `test`, `chore`, `ci`, `perf`, `epic`, `research`, `refactor` |
 | `--parent <REF>` | Set parent issue on creation. REF = `#N` or `owner/repo#N` |
 | `--add-child <REF>[,<REF>...]` | Add existing issues as children |
 | `--blocked-by <REF>[,<REF>...]` | Set blocked-by on creation |

--- a/plugins/dev-core/skills/issue-triage/__tests__/create.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/create.test.ts
@@ -33,6 +33,7 @@ process.env.PRIORITY_OPTIONS_JSON = JSON.stringify({
 vi.mock('../../shared/adapters/config-helpers', () => ({
   isProjectConfigured: () => true,
   NOT_CONFIGURED_MSG: 'GitHub Project V2 is not configured.',
+  GITHUB_REPO: 'Test/test-repo',
   GH_PROJECT_ID: 'PVT_test',
   STATUS_FIELD_ID: 'SF_test',
   SIZE_FIELD_ID: 'SZF_test',
@@ -95,10 +96,15 @@ vi.mock('../../shared/adapters/config-helpers', () => ({
     }
     return aliases[input.toUpperCase()]
   },
+  resolveLane: (input: string) =>
+    new Set(['a1', 'a2', 'a3', 'b', 'c1', 'c2', 'c3', 'd', 'e']).has(input) ? input : undefined,
 }))
 
 vi.mock('../../shared/adapters/github-infra', () => ({
   syncPriorityLabel: vi.fn(),
+  syncSizeLabel: vi.fn(),
+  syncLaneLabel: vi.fn(),
+  syncStatusLabel: vi.fn(),
 }))
 
 vi.mock('../../shared/adapters/github-adapter', () => ({
@@ -108,6 +114,8 @@ vi.mock('../../shared/adapters/github-adapter', () => ({
   updateField: vi.fn(),
   addBlockedBy: vi.fn(),
   addSubIssue: vi.fn(),
+  resolveIssueTypeId: vi.fn(),
+  updateIssueIssueType: vi.fn(),
 }))
 
 const github = await import('../../shared/adapters/github-adapter')
@@ -120,6 +128,11 @@ const mockAddSubIssue = github.addSubIssue as ReturnType<typeof vi.fn>
 
 const githubInfra = await import('../../shared/adapters/github-infra')
 const mockSyncPriorityLabel = githubInfra.syncPriorityLabel as ReturnType<typeof vi.fn>
+const mockSyncSizeLabel = githubInfra.syncSizeLabel as ReturnType<typeof vi.fn>
+const mockSyncLaneLabel = githubInfra.syncLaneLabel as ReturnType<typeof vi.fn>
+const mockSyncStatusLabel = githubInfra.syncStatusLabel as ReturnType<typeof vi.fn>
+const mockResolveIssueTypeId = github.resolveIssueTypeId as ReturnType<typeof vi.fn>
+const mockUpdateIssueIssueType = github.updateIssueIssueType as ReturnType<typeof vi.fn>
 
 const { createIssue } = await import('../lib/create')
 
@@ -131,6 +144,7 @@ function setupMocks() {
   })
   mockGetNodeId.mockImplementation(async (num) => `node-${num}`)
   mockAddToProject.mockResolvedValue('item-99')
+  mockResolveIssueTypeId.mockResolvedValue('issue-type-id')
   vi.spyOn(console, 'log').mockImplementation(() => {})
   vi.spyOn(console, 'error').mockImplementation(() => {})
 }
@@ -261,5 +275,56 @@ describe('issue-triage/create > priority label sync', () => {
   it('does not sync priority label when --priority is not provided', async () => {
     await createIssue(['--title', 'Test'])
     expect(mockSyncPriorityLabel).not.toHaveBeenCalled()
+  })
+
+  it('syncs size label when --size is provided', async () => {
+    await createIssue(['--title', 'Test', '--size', 'M'])
+    expect(mockSyncSizeLabel).toHaveBeenCalledWith(99, 'M')
+  })
+
+  it('syncs status label when --status is provided', async () => {
+    await createIssue(['--title', 'Test', '--status', 'In Progress'])
+    expect(mockSyncStatusLabel).toHaveBeenCalledWith(99, 'In Progress')
+  })
+})
+
+describe('issue-triage/create > type', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('sets issue type on creation', async () => {
+    await createIssue(['--title', 'Test', '--type', 'feat'])
+    expect(mockResolveIssueTypeId).toHaveBeenCalledWith('Test', 'feat')
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-99', 'issue-type-id')
+  })
+
+  it('accepts extended types (epic)', async () => {
+    await createIssue(['--title', 'Test', '--type', 'epic'])
+    expect(mockUpdateIssueIssueType).toHaveBeenCalledWith('node-99', 'issue-type-id')
+  })
+
+  it('normalizes type case', async () => {
+    await createIssue(['--title', 'Test', '--type', 'FIX'])
+    expect(mockResolveIssueTypeId).toHaveBeenCalledWith('Test', 'fix')
+  })
+
+  it('does not set type when --type is not provided', async () => {
+    await createIssue(['--title', 'Test'])
+    expect(mockUpdateIssueIssueType).not.toHaveBeenCalled()
+  })
+})
+
+describe('issue-triage/create > lane', () => {
+  beforeEach(setupMocks)
+  afterEach(() => vi.restoreAllMocks())
+
+  it('syncs lane label when --lane is provided', async () => {
+    await createIssue(['--title', 'Test', '--lane', 'a1'])
+    expect(mockSyncLaneLabel).toHaveBeenCalledWith(99, 'a1')
+  })
+
+  it('does not sync lane label when --lane is not provided', async () => {
+    await createIssue(['--title', 'Test'])
+    expect(mockSyncLaneLabel).not.toHaveBeenCalled()
   })
 })

--- a/plugins/dev-core/skills/issue-triage/lib/create.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/create.ts
@@ -4,12 +4,15 @@
  */
 
 import {
+  GITHUB_REPO,
   getSizeOptionId,
   isProjectConfigured,
   NOT_CONFIGURED_MSG,
   PRIORITY_FIELD_ID,
   PRIORITY_OPTIONS,
+  resolveLane,
   resolvePriority,
+  resolveSize,
   resolveStatus,
   SIZE_FIELD_ID,
   STATUS_FIELD_ID,
@@ -21,9 +24,12 @@ import {
   addToProject,
   createGitHubIssue,
   getNodeId,
+  resolveIssueTypeId,
   updateField,
+  updateIssueIssueType,
 } from '../../shared/adapters/github-adapter'
-import { syncPriorityLabel } from '../../shared/adapters/github-infra'
+import { syncLaneLabel, syncPriorityLabel, syncSizeLabel, syncStatusLabel } from '../../shared/adapters/github-infra'
+import { EXTENDED_ISSUE_TYPES, ISSUE_TYPE_NAMES } from '../../shared/domain/issue-types'
 import { formatRef, parseIssueRefs } from '../../shared/domain/parse-issue-ref'
 
 interface CreateOptions {
@@ -33,6 +39,8 @@ interface CreateOptions {
   size?: string
   priority?: string
   status?: string
+  lane?: string
+  type?: string
   parent?: string
   blockedBy?: string
   blocks?: string
@@ -63,6 +71,12 @@ function parseArgs(args: string[]): CreateOptions {
         break
       case '--status':
         opts.status = args[++i]
+        break
+      case '--lane':
+        opts.lane = args[++i]
+        break
+      case '--type':
+        opts.type = args[++i]
         break
       case '--parent':
         opts.parent = args[++i]
@@ -115,6 +129,42 @@ async function applyProjectFields(itemId: string, issueNumber: number, opts: Cre
     }
     await updateField(itemId, PRIORITY_FIELD_ID, PRIORITY_OPTIONS[canonical])
     console.log(`Priority=${canonical} #${issueNumber}`)
+  }
+}
+
+const VALID_TYPES: string[] = [...ISSUE_TYPE_NAMES, ...EXTENDED_ISSUE_TYPES]
+
+async function applyType(issueNumber: number, nodeId: string, type: string): Promise<void> {
+  const canonical = type.toLowerCase()
+  if (!VALID_TYPES.includes(canonical)) {
+    console.error(`Error: Invalid type. Valid: ${VALID_TYPES.join(', ')}`)
+    process.exit(1)
+  }
+  const org = GITHUB_REPO.split('/')[0]
+  const typeId = await resolveIssueTypeId(org, canonical)
+  await updateIssueIssueType(nodeId, typeId)
+  console.log(`Type=${canonical} #${issueNumber}`)
+}
+
+async function syncLabels(issueNumber: number, opts: CreateOptions): Promise<void> {
+  if (opts.priority) {
+    const canonical = resolvePriority(opts.priority)
+    if (canonical) await syncPriorityLabel(issueNumber, canonical)
+  }
+  if (opts.size) {
+    const canonical = resolveSize(opts.size)
+    if (canonical) await syncSizeLabel(issueNumber, canonical)
+  }
+  if (opts.lane) {
+    const canonical = resolveLane(opts.lane)
+    if (canonical) {
+      await syncLaneLabel(issueNumber, canonical)
+      console.log(`Lane=${canonical} #${issueNumber}`)
+    }
+  }
+  if (opts.status) {
+    const canonical = resolveStatus(opts.status)
+    if (canonical) await syncStatusLabel(issueNumber, canonical)
   }
 }
 
@@ -193,11 +243,13 @@ export async function createIssue(args: string[]): Promise<void> {
     console.error(NOT_CONFIGURED_MSG)
   }
 
-  // Sync priority label (independent of project board)
-  if (opts.priority) {
-    const canonical = resolvePriority(opts.priority)
-    if (canonical) await syncPriorityLabel(issueNumber, canonical)
+  // Issue type is independent of the project board
+  if (opts.type) {
+    await applyType(issueNumber, nodeId, opts.type)
   }
+
+  // Sync labels (independent of project board)
+  await syncLabels(issueNumber, opts)
 
   await applyRelationships(nodeId, issueNumber, opts)
 }


### PR DESCRIPTION
## What

`triage create` now reaches flag parity with `set`:

- **`--type`** — set org issueType at creation (`feat`, `fix`, `epic`, …)
- **`--lane`** — set lane label at creation (`a1`…`o`, `standalone`)
- label syncs for **size / status / lane** (previously only priority synced)

Set every field in one shot at creation instead of a follow-up `set`.
`rm-*` / `rm-parent` intentionally omitted — no meaning at creation.

## Tests

- 27 create tests (added type, lane, size/status label-sync cases)
- Full issue-triage suite: **142/142 green**, biome clean

## Version

dev-core `0.6.0 → 0.6.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)