### PR TITLE
fix(issue-triage): drop status:* label sync from set (issues-only model)

### DIFF
--- a/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
@@ -429,6 +429,11 @@ describe('issue-triage/set > cross-repo subject', () => {
     expect(mockUpdateField).not.toHaveBeenCalled()
     const errCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]))
     expect(errCalls.some((m) => m.includes('not supported for cross-repo'))).toBe(true)
+    // issues-only model: --status no longer participates in label sync, so the
+    // label-sync warning must NOT fire for a cross-repo --status-only call
+    // (only the board-side applyProjectFields warning above does).
+    expect(mockSyncStatusLabel).not.toHaveBeenCalled()
+    expect(errCalls.every((m) => !m.includes('label sync'))).toBe(true)
   })
 
   it('skips label sync for cross-repo subject with --size', async () => {

--- a/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
+++ b/plugins/dev-core/skills/issue-triage/__tests__/set.test.ts
@@ -192,10 +192,11 @@ describe('issue-triage/set > field updates', () => {
     expect(mockUpdateField).toHaveBeenCalledWith('item-123', expect.any(String), 'pri-high')
   })
 
-  it('updates status via label + project field', async () => {
+  it('updates status via project field only — no status:* label sync', async () => {
     await setIssue(['42', '--status', 'In Progress'])
     expect(mockUpdateField).toHaveBeenCalledWith('item-123', expect.any(String), 'status-inprog')
-    expect(mockSyncStatusLabel).toHaveBeenCalledWith(42, 'In Progress')
+    // issues-only model: status is open/closed + board field; no redundant status:* label
+    expect(mockSyncStatusLabel).not.toHaveBeenCalled()
   })
 
   it('exits with error for invalid --size value', async () => {

--- a/plugins/dev-core/skills/issue-triage/lib/set.ts
+++ b/plugins/dev-core/skills/issue-triage/lib/set.ts
@@ -30,7 +30,7 @@ import {
   updateField,
   updateIssueIssueType,
 } from '../../shared/adapters/github-adapter'
-import { syncLaneLabel, syncPriorityLabel, syncSizeLabel, syncStatusLabel } from '../../shared/adapters/github-infra'
+import { syncLaneLabel, syncPriorityLabel, syncSizeLabel } from '../../shared/adapters/github-infra'
 import { EXTENDED_ISSUE_TYPES, ISSUE_TYPE_NAMES } from '../../shared/domain/issue-types'
 import { formatRef, parseIssueRef, parseIssueRefs } from '../../shared/domain/parse-issue-ref'
 
@@ -336,10 +336,15 @@ export async function setIssue(args: string[]): Promise<void> {
     }
   }
 
-  // Sync labels (independent of project board) — skipped for cross-repo subjects
-  if (opts.subjectRepo && (opts.priority || opts.size || opts.lane || opts.status)) {
+  // Sync labels (independent of project board) — skipped for cross-repo subjects.
+  // Status is intentionally excluded: in the issues-only model status is just
+  // open/closed and the dep-graph derives ready/blocked/done from edges, so a
+  // `status:*` label is redundant (and noisy on repos that lack the label). The
+  // board-side `--status` write still happens in applyProjectFields (gated on
+  // isProjectConfigured) for repos still on a ProjectV2 board.
+  if (opts.subjectRepo && (opts.priority || opts.size || opts.lane)) {
     console.error(
-      `Warning: --size/--priority/--lane/--status label sync is not supported for cross-repo subjects (${opts.subjectRepo}#${opts.issueNumber}) — skipped`,
+      `Warning: --size/--priority/--lane label sync is not supported for cross-repo subjects (${opts.subjectRepo}#${opts.issueNumber}) — skipped`,
     )
   } else {
     if (opts.priority) {
@@ -356,10 +361,6 @@ export async function setIssue(args: string[]): Promise<void> {
         await syncLaneLabel(opts.issueNumber, canonical)
         console.log(`Lane=${canonical} #${opts.issueNumber}`)
       }
-    }
-    if (opts.status) {
-      const canonical = resolveStatus(opts.status)
-      if (canonical) await syncStatusLabel(opts.issueNumber, canonical)
     }
   }
 


### PR DESCRIPTION
## Summary
- `issue-triage set --status` no longer mirrors status onto a `status:*` label. In the issues-only model (no ProjectV2 board) status is just **open/closed** and the dep-graph derives ready/blocked/done from edges, so the label is redundant.
- Removes the noisy `'status:Done' not found` warning emitted on every close/triage for repos lacking those labels (surfaced in Roxabi/roxabi-live#118).
- **Kept:** board-side `--status` write (`applyProjectFields`, gated on `isProjectConfigured()`) — repos still on a board are unaffected.
- **Kept:** `syncSize/Priority/Lane` label sync — those labels exist and are used.
- `syncStatusLabel` helper retained (still used by `create.ts` — out of scope per #260).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #260: Drop status:* label sync from issue-triage set | OPEN |
| Implementation | 1 commit on `feat/260-drop-status-label-sync` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (857 pass / 4 skip, 57 files) | Passed |

## Test Plan
- [ ] `bunx vitest run plugins/dev-core/skills/issue-triage/__tests__/set.test.ts` — 42 pass
- [ ] `set 42 --status "In Progress"` writes board field, no `status:*` label added
- [ ] `set <repo>#N --status X` (cross-repo) still warns via board-side guard, no label sync

Closes #260

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`