### PR TITLE
chore(dev-core): tier agent models + bump 0.6.2

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/agents/architect.md
+++ b/plugins/dev-core/agents/architect.md
@@ -1,6 +1,6 @@
 ---
 name: architect
-model: sonnet
+model: opus
 description: |
   Use this agent for system design decisions, cross-cutting architecture,
   and technical planning across the monorepo.

--- a/plugins/dev-core/agents/axial-adr-review.md
+++ b/plugins/dev-core/agents/axial-adr-review.md
@@ -1,6 +1,6 @@
 ---
 name: axial-adr-review
-model: sonnet
+model: opus
 description: |
   Read-only review agent for axial-decomposition drift. Parses the project's axial ADR (`axial: true` frontmatter) and reviews a diff or spec for drift along the non-primary axis (N×M trap). Emits Conventional Comments findings tagged with the canonical `target-axis-trap` class.
 

--- a/plugins/dev-core/agents/doc-writer.md
+++ b/plugins/dev-core/agents/doc-writer.md
@@ -9,7 +9,7 @@ description: |
   user: "Document the new auth module"
   assistant: "I'll use the doc-writer agent to create the documentation."
   </example>
-model: sonnet
+model: haiku
 color: white
 tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions

--- a/plugins/dev-core/agents/recall.md
+++ b/plugins/dev-core/agents/recall.md
@@ -1,6 +1,6 @@
 ---
 name: recall
-model: sonnet
+model: haiku
 description: |
   Targeted recall agent for cross-chunk class join in /code-review.
   Receives only callsites + context window, never the full diff.

--- a/plugins/dev-core/agents/security-auditor.md
+++ b/plugins/dev-core/agents/security-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: security-auditor
-model: sonnet
+model: opus
 description: |
   Audit code for security vulnerabilities, review auth flows,
   and verify compliance with OWASP top 10.


### PR DESCRIPTION
## What
All 12 dev-core agents were uniformly `model: sonnet`. Differentiate by role:

| Model | Agents | Rationale |
|---|---|---|
| **opus** | architect, security-auditor, axial-adr-review | design / security / boundary review — error-costly |
| **haiku** | recall, doc-writer | mechanical / low-judgment |
| sonnet | 7 others (unchanged) | default |

Bumps `dev-core` `0.6.1 → 0.6.2` so the change reaches installed caches (plugin.json version wins; release-please only manages the root package).

## Why
From the Stripe-practices portfolio review (F3): the tier system existed but mapped no models. Cheaper on mechanical sub-agents, stronger on high-stakes review. Affects `/code-review`, `/implement`, `/dev`.

## Dials (revisit if needed)
- `security-auditor → opus` runs on **every** `/code-review` → cost ↑. Dial to sonnet if too pricey.
- `doc-writer → haiku` — repromote to sonnet if doc quality drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)