### PR TITLE
chore(plugins): drop idna refs from marketplace + README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,12 +62,6 @@
       "category": "productivity"
     },
     {
-      "name": "idna",
-      "description": "IDNA — Idea DNA evolutionary selector. Explore variants, pick a winner, converge through amplify/blend/refine mutations. Self-driving: browser → Claude CLI → imageCLI → auto-advance.",
-      "source": "./plugins/idna",
-      "category": "productivity"
-    },
-    {
       "name": "gitnexus",
       "description": "GitNexus CLI integration — code knowledge graph tools (impact analysis, symbol context, query). CLI-only alternative to MCP for minimal token overhead.",
       "source": "./plugins/gitnexus",

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Plugins are project-agnostic: they read your stack from `.claude/stack.yml` at r
 |--------|-------------|
 | [linkedin-post-generator](plugins/linkedin-post-generator/README.md) | Generate LinkedIn posts with best practices and visual identity |
 | [image-prompt-generator](plugins/image-prompt-generator/README.md) | Generate AI image prompts with style consistency |
-| [idna](plugins/idna/README.md) | Evolutionary idea selector — explore variants, pick, converge (amplify/blend/refine), finalize. Self-driving: browser → Claude API → imageCLI → auto-advance. |
 
 > **Forge** has moved to its own marketplace: [Roxabi/roxabi-forge](https://github.com/Roxabi/roxabi-forge). Install: `claude plugin marketplace add Roxabi/roxabi-forge`
+> **IDNA** is now a standalone Python service at [Roxabi/roxabi-idna](https://github.com/Roxabi/roxabi-idna) — no longer shipped as a Claude Code plugin.
 
 ### Career tools
 


### PR DESCRIPTION
Companion cleanup to 3d9cf0e which deleted plugins/idna/; marketplace entry was a broken install pointer (source path no longer exists). README table row removed and pointer note added directing to the standalone service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)