### PR TITLE
fix(ci): enforce merge-commit only + block dependabot semver-major auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,13 @@
 # Auto-merge PRs that have been reviewed and passed all required checks.
-# Adds the PR to GitHub's merge queue (squash) once the "reviewed" label is present.
+# Adds the PR to GitHub's merge queue (merge commit) once the "reviewed" label is present.
 # GitHub natively waits for all required status checks before merging.
+#
+# Project convention: merge commits only (¬squash) — see ~/projects/CLAUDE.md
+# "Release Convention". Squash merges flatten the per-commit history that
+# staging→main promotions rely on.
+#
+# Dependabot guard: semver-major bumps are never auto-merged — they require
+# manual validation (the vite 8 SSR regression stayed dormant 10 weeks).
 #
 # Also closes linked issues after merge, because GITHUB_TOKEN-initiated
 # auto-merges don't trigger GitHub's native "Closes #X" issue closure.
@@ -28,8 +35,22 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'reviewed')
     timeout-minutes: 5
     steps:
-      - name: Enable auto-merge (squash)
-        run: gh pr merge "$PR_NUMBER" --auto --squash --repo "$GITHUB_REPOSITORY"
+      - name: Block dependabot semver-major bumps
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" =~ from\ v?([0-9]+)[^\ ]*\ to\ v?([0-9]+) ]] && [ "${BASH_REMATCH[1]}" != "${BASH_REMATCH[2]}" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body "Auto-merge refusé : bump **semver-major**. Validation manuelle requise (e2e / boot de l'artefact), puis merge à la main."
+            echo "::error::semver-major dependency bump — auto-merge refused"
+            exit 1
+          fi
+
+      - name: Enable auto-merge (merge commit)
+        run: gh pr merge "$PR_NUMBER" --auto --merge --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/shared/adapters/github-infra.ts
+++ b/plugins/dev-core/skills/shared/adapters/github-infra.ts
@@ -69,7 +69,7 @@ export const DEFAULT_RULESET = {
         require_code_owner_review: false,
         require_last_push_approval: false,
         required_review_thread_resolution: true,
-        allowed_merge_methods: ['merge'],  // merge-commit only — project convention (Release Convention)
+        allowed_merge_methods: ['merge'], // merge-commit only — project convention (Release Convention)
       },
     },
   ],

--- a/plugins/dev-core/skills/shared/adapters/github-infra.ts
+++ b/plugins/dev-core/skills/shared/adapters/github-infra.ts
@@ -69,7 +69,7 @@ export const DEFAULT_RULESET = {
         require_code_owner_review: false,
         require_last_push_approval: false,
         required_review_thread_resolution: true,
-        allowed_merge_methods: ['squash', 'rebase', 'merge'],
+        allowed_merge_methods: ['merge'],  // merge-commit only — project convention (Release Convention)
       },
     },
   ],

--- a/plugins/dev-init/skills/init/lib/workflows.ts
+++ b/plugins/dev-init/skills/init/lib/workflows.ts
@@ -21,6 +21,9 @@ export function generateAutoMergeYml(): string {
 # GitHub natively waits for all required status checks before merging.
 # Uses merge commit (not squash) to preserve history — required for staging→main promotions.
 #
+# Dependabot guard: semver-major bumps are never auto-merged — they require
+# manual validation before merge.
+#
 # Also closes linked issues after merge, because GITHUB_TOKEN-initiated
 # auto-merges don't trigger GitHub's native "Closes #X" issue closure.
 name: Auto Merge
@@ -47,6 +50,20 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'reviewed')
     timeout-minutes: 5
     steps:
+      - name: Block dependabot semver-major bumps
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        env:
+          GH_TOKEN: \${{ secrets.PAT }}
+          PR_NUMBER: \${{ github.event.pull_request.number }}
+          PR_TITLE: \${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" =~ from\\ v?([0-9]+)[^\\ ]*\\ to\\ v?([0-9]+) ]] && [ "\${BASH_REMATCH[1]}" != "\${BASH_REMATCH[2]}" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \\
+              --body "Auto-merge refused: **semver-major** bump. Manual validation required (e2e / boot the artifact), then merge by hand."
+            echo "::error::semver-major dependency bump — auto-merge refused"
+            exit 1
+          fi
+
       - name: Enable auto-merge (merge commit)
         run: gh pr merge "$PR_NUMBER" --auto --merge --repo "$GITHUB_REPOSITORY"
         env:

--- a/plugins/dev-init/skills/shared/adapters/github-infra.ts
+++ b/plugins/dev-init/skills/shared/adapters/github-infra.ts
@@ -71,7 +71,7 @@ export const DEFAULT_RULESET = {
         require_code_owner_review: false,
         require_last_push_approval: false,
         required_review_thread_resolution: true,
-        allowed_merge_methods: ['merge'],  // merge-commit only — project convention (Release Convention)
+        allowed_merge_methods: ['merge'], // merge-commit only — project convention (Release Convention)
       },
     },
   ],

--- a/plugins/dev-init/skills/shared/adapters/github-infra.ts
+++ b/plugins/dev-init/skills/shared/adapters/github-infra.ts
@@ -71,7 +71,7 @@ export const DEFAULT_RULESET = {
         require_code_owner_review: false,
         require_last_push_approval: false,
         required_review_thread_resolution: true,
-        allowed_merge_methods: ['squash', 'rebase', 'merge'],
+        allowed_merge_methods: ['merge'],  // merge-commit only — project convention (Release Convention)
       },
     },
   ],


### PR DESCRIPTION
## Contexte

Revue du 2026-06-10 : PR #273 squash-mergé sur staging (violation merge-commit-only) — root cause = `--auto --squash` codé en dur dans auto-merge.yml. Et vite 8 (semver-major dependabot) auto-mergé en mars sans validation → SSR cassé dormant 10 semaines (incident boilerplate #579).

## Changements

- **auto-merge.yml** : `--auto --squash` → `--auto --merge` + guard dependabot — refuse l'auto-merge (job rouge + commentaire) si auteur=dependabot ∧ bump semver-major (regex titre, testée sur 6 formats : npm/pip/docker/actions/v-prefix/groupes)
- **github-infra.ts ×2** (dev-core + dev-init, copy-sync) : `DEFAULT_RULESET.allowed_merge_methods` → `['merge']` — /init et /checkup provisionnent désormais merge-commit-only
- **dev-init workflows.ts** : même guard dans le template des nouveaux repos
- dev-core 0.7.0 → 0.7.1

## Vérifs

- gates R1/R2 ✓ · bun test 8/8 ✓ · template TS compile + rend le YAML attendu ✓
- Côté serveur (déjà appliqué via API) : rulesets PR_Main `["merge"]` sur 14 repos + settings repo-level squash/rebase désactivés sur 14 repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)