### PR TITLE
fix(dev-core): gate-driven merge discipline — no manual merge mid-CI, purge squash

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/checkup/cookbooks/devcore-checks.md
+++ b/plugins/dev-core/skills/checkup/cookbooks/devcore-checks.md
@@ -25,6 +25,6 @@
 | trufflehog not in lefthook | Run `/init` Phase 10d — regenerates `lefthook.yml` |
 | license check not in lefthook | Run `/init` Phase 10d — regenerates `lefthook.yml` |
 | `PR_Main` ruleset missing | `bun $I_TS protect-branches --repo <owner/repo>` |
-| `PR_Main` missing `merge` method | Update ruleset via `gh api repos/:owner/:repo/rulesets/<id> --method PUT` with `allowed_merge_methods: ["squash","rebase","merge"]` — merge needed for promotion PRs |
+| `PR_Main` allowed_merge_methods ≠ `["merge"]` | Update ruleset via `gh api repos/:owner/:repo/rulesets/<id> --method PUT` with `allowed_merge_methods: ["merge"]` — merge-commit only (Release Convention); squash/rebase cause history divergence on promotion |
 
 Issues requiring interactive auth / multi-step scaffolding → display exact command + explanation. Never silently redirect.

--- a/plugins/dev-core/skills/code-review/SKILL.md
+++ b/plugins/dev-core/skills/code-review/SKILL.md
@@ -332,7 +332,7 @@ Q:
 ## Safety Rules
 
 1. Fresh agents only — ¬implementation context
-2. ¬auto-merge, ¬approve PRs on GitHub
+2. ¬approve PRs on GitHub; ¬enable auto-merge outside the Phase 8 human decision (label gate)
 3. Merge = merge commit only (¬squash — Release Convention); merge executes via the gate (label + auto-merge), never manually mid-CI
 4. ¬fix code — findings only. Fixing = `/fix` skill
 5. ∃ PR → must post comment (Phase 6)

--- a/plugins/dev-core/skills/code-review/SKILL.md
+++ b/plugins/dev-core/skills/code-review/SKILL.md
@@ -2,7 +2,7 @@
 name: code-review
 argument-hint: [#PR]
 description: Multi-domain code review (agents + Conventional Comments → findings + verdict). Triggers: "code review" | "review changes" | "review PR #42" | "check my code" | "review my changes" | "review this PR" | "do a code review" | "review the diff" | "look at my code".
-version: 0.2.0
+version: 0.2.1
 allowed-tools: Bash, Read, Write, Glob, Grep, Task, Skill, ToolSearch
 ---
 
@@ -299,7 +299,7 @@ C(f) = min(diagnostic_certainty, fix_certainty)
 
 Q:
 - **Fix now (`/fix`)** — invoke `/fix` (auto-apply + 1b1 + spawn fixers; `/fix` Phase 8 offers rebase + label + merge)
-- **Merge as-is** — rebase + label + squash merge (below)
+- **Merge as-is** — rebase + label + auto-merge (below)
 - **Stop** — exit
 
 **If Merge as-is:**
@@ -308,7 +308,7 @@ Q:
    - count > 0 → `git rebase origin/${BASE}` + `git push --force-with-lease`
    - conflict → halt (¬label)
 2. Q: "Add `reviewed` label?" → Yes / No
-3. Yes → `gh api repos/:owner/:repo/issues/<#>/labels -f "labels[]=reviewed"` → squash merge on green CI
+3. Yes → `gh api repos/:owner/:repo/issues/<#>/labels -f "labels[]=reviewed"` → auto-merge merges (merge commit) on green CI. ¬auto-merge workflow in repo → `gh pr merge <#> --auto --merge`. ¬plain `gh pr merge` while any check is IN_PROGRESS/QUEUED — mid-CI merge cancels in-flight runs + skips gates.
 4. No → inform manual
 
 > `/code-review` ¬fixes code. Fixing = `/fix` skill.
@@ -333,9 +333,10 @@ Q:
 
 1. Fresh agents only — ¬implementation context
 2. ¬auto-merge, ¬approve PRs on GitHub
-3. ¬fix code — findings only. Fixing = `/fix` skill
-4. ∃ PR → must post comment (Phase 6)
-5. Human decides at Phase 8 — ¬proceed without Q
+3. Merge = merge commit only (¬squash — Release Convention); merge executes via the gate (label + auto-merge), never manually mid-CI
+4. ¬fix code — findings only. Fixing = `/fix` skill
+5. ∃ PR → must post comment (Phase 6)
+6. Human decides at Phase 8 — ¬proceed without Q
 
 ## Chain Position
 

--- a/plugins/dev-core/skills/fix/SKILL.md
+++ b/plugins/dev-core/skills/fix/SKILL.md
@@ -2,7 +2,7 @@
 name: fix
 argument-hint: '[#PR]'
 description: 'Apply review findings — auto-apply high-confidence, 1b1 for rest, then batch-apply. Triggers: "fix findings" | "fix review" | "apply fixes" | "fix these" | "apply review comments" | "apply the review" | "fix the review issues" | "address review feedback" | "fix PR comments".'
-version: 0.4.0
+version: 0.4.1
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch, Task, Skill, ToolSearch
 ---
 
@@ -292,7 +292,7 @@ _(omit section when |D| = 0; group by tag when |distinct tags| > 1 using **[tag]
 2. ∃ PR → must post follow-up comment (Phase 8)
 3. Fixer agents ¬have implementation context → spawn fresh
 4. Stage specific files only — ¬`git add -A` (risk of .env, secrets)
-5. ¬auto-merge — label `reviewed` only, human merges
+5. Merge via the gate: label `reviewed` → auto-merge merges (merge commit) on green. ¬manual `gh pr merge` while any check is IN_PROGRESS/QUEUED
 
 ## Chain Position
 

--- a/plugins/dev-core/skills/pr/SKILL.md
+++ b/plugins/dev-core/skills/pr/SKILL.md
@@ -2,7 +2,7 @@
 name: pr
 argument-hint: [--draft | --base <branch>]
 description: Create/update PRs with Conventional Commits title, issue linking & guard rails. Triggers: "create PR" | "open PR" | "submit PR" | "update PR" | "/pr --draft" | "open a pull request" | "make a PR" | "open pull request" | "submit a pull request" | "create a draft PR" | "raise a PR".
-version: 0.4.1
+version: 0.4.2
 allowed-tools: Bash, Read, Grep, ToolSearch
 ---
 
@@ -116,6 +116,8 @@ git push --force-with-lease origin ${BRANCH}
 
 Inform: "CI is running on the PR — use `/ci-watch` to monitor it live."
 
+Merge path = gate-driven: `reviewed` label + auto-merge (`gh pr merge --auto --merge`). ¬manual `gh pr merge` while any check is IN_PROGRESS/QUEUED — the gate decides, not the operator.
+
 ## PR Body Template
 
 ```markdown
@@ -172,6 +174,7 @@ Lifecycle notes: S-tier → Intent + Implementation + Verification only. ¬issue
 4. → DP(A) for all decisions (proceed despite warnings, edit)
 5. Always display PR URL after creation
 6. Rebase conflicts → abort + defer to user — ¬auto-resolve
+7. ¬manual `gh pr merge` while any check is IN_PROGRESS/QUEUED — manual merge mid-CI cancels in-flight runs (`concurrency.cancel-in-progress`) and skips gates. Nominal path: `reviewed` label → auto-merge (`--merge`) on green.
 
 ## Chain Position
 

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -2,7 +2,7 @@
 name: promote
 argument-hint: [--dry-run | --skip-preview | --finalize]
 description: Promote staging→main — pre-flight, version bump, changelog, PR & tag. Triggers: "promote staging" | "release" | "deploy" | "cut a release" | "--finalize" | "merge to main" | "promote to production" | "ship a release" | "tag and release" | "publish release".
-version: 0.4.0
+version: 0.4.1
 allowed-tools: Bash, Read, Grep, Write, Edit, ToolSearch
 ---
 
@@ -179,7 +179,7 @@ Promotion Summary
 1. Branch: `git branch chore/$VERSION-changelog staging`
 2. Push: `git push origin chore/$VERSION-changelog`
 3. PR: `gh pr create --base staging --head chore/$VERSION-changelog --title "chore(release): add $VERSION changelog"`
-4. Merge: `gh pr merge <N> --squash --delete-branch`
+4. Merge: `gh pr merge <N> --auto --merge --delete-branch` (merge commit — ¬squash, Release Convention; `--auto` waits for required checks)
 5. Sync: `git fetch origin staging && git reset --hard origin/staging`
 
 ## Step 7 — Create Promotion PR

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -280,7 +280,7 @@ Inform: "Release $VERSION finalized. Run `/cleanup` to clean branches."
 ## Safety Rules
 
 1. ¬force-push to μ ∨ σ
-2. ¬auto-merge — user merges after review
+2. Promotion PR: ¬auto-merge — user merges after review (merge commit). Changelog PR (Step 6b): `--auto --merge` via required checks
 3. Always show changelog before creating PR
 4. Always check CI before promoting
 5. Always warn about open PRs on σ


### PR DESCRIPTION
## Summary
Encodes the #579 lesson (P0 action 3 — daily review 2026-06-10) across every merge-touching dev-core skill:

- **pr**: new safety rule — never manual `gh pr merge` while any check is IN_PROGRESS/QUEUED (manual merge mid-CI cancels in-flight runs via `concurrency.cancel-in-progress` and skips gates). Nominal path: `reviewed` label → auto-merge `--merge` on green.
- **code-review Phase 8**: hardcoded squash merge (×2) → auto-merge with merge commit + the same mid-CI rule; new safety rule (merge commit only, via the gate).
- **promote Step 6b**: changelog PR `--squash` → `--auto --merge --delete-branch` (Release Convention: merge-commit only; `--auto` waits for required checks).
- **checkup cookbook**: ruleset remedy updated to `allowed_merge_methods: ["merge"]` — the old `["squash","rebase","merge"]` remedy pre-dated the Lot 1 server-side rollout and would have reintroduced the #273 squash class.

Versions: dev-core 0.7.1 → 0.7.2 (pr 0.4.2, code-review 0.2.1, promote 0.4.1).

## Test Plan
- [ ] `python3 tools/validate_plugins.py` green (passed locally)
- [ ] R2 skill-version gate green (plugin.json bumped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)