### PR TITLE
ci: replace shared org PAT with roxabi-ci GitHub App tokens

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -35,10 +35,19 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'reviewed')
     timeout-minutes: 5
     steps:
+      # roxabi-ci App token (ephemeral, 1 h) — merges PRs touching workflow files and
+      # re-triggers CI on the resulting push, which GITHUB_TOKEN cannot do.
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - name: Block dependabot semver-major bumps
         if: github.event.pull_request.user.login == 'dependabot[bot]'
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -52,7 +61,7 @@ jobs:
       - name: Enable auto-merge (merge commit)
         run: gh pr merge "$PR_NUMBER" --auto --merge --repo "$GITHUB_REPOSITORY"
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
   update-behind-prs:
@@ -61,6 +70,13 @@ jobs:
     if: github.event_name == 'push'
     timeout-minutes: 5
     steps:
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - name: Update all reviewed PRs targeting this branch
         run: |
           BRANCH="${GITHUB_REF_NAME}"
@@ -77,7 +93,7 @@ jobs:
               --method PUT -f expected_head_sha="$SHA" || true
           done
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
 
   close-linked-issues:
     name: Close linked issues

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,16 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # roxabi-ci App token (ephemeral, 1 h) — release-please pushes must re-trigger CI,
+      # which GITHUB_TOKEN cannot do.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        id: app
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.app.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace the long-lived org-wide `secrets.PAT` with ephemeral installation tokens minted by the `roxabi-ci` GitHub App (`actions/create-github-app-token` v3.2.0, SHA-pinned) in `release-please.yml` and `auto-merge.yml` (jobs `auto-merge` + `update-behind-prs`; `close-linked-issues` already uses the native `GITHUB_TOKEN`).
- Pilot repo for the org-wide PAT→App migration: tokens are job-scoped, expire after 1 h, carry only the App's 7 permissions, and their pushes still re-trigger CI (the property the PAT provided). The org-side `PAT` secret stays in place until every repo is migrated.

## Test Plan
- [ ] CI green on this PR (YAML-only change; both files parse)
- [ ] `reviewed` label on this PR → `auto-merge` job mints the App token (validates org var/secret wiring) and enables auto-merge as `roxabi-ci[bot]`
- [ ] After merge: `update-behind-prs` job runs on the staging push with the App token
- [ ] Next promote: release-please PR opened by `roxabi-ci[bot]`, CI re-triggered by its push

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`