### PR TITLE
fix(checkup): iteration-2 review findings (follow-up #277)

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/checkup/SKILL.md
+++ b/plugins/dev-core/skills/checkup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: checkup
 description: 'Health check — verify dev-core config, GitHub project, labels, workflows, branch protection, secret scanning, CI hardening. Triggers: "checkup" | "health check" | "check setup" | "verify config" | "security baseline".'
-version: 0.8.0
+version: 0.8.1
 allowed-tools: Bash, Read, ToolSearch
 ---
 

--- a/plugins/dev-core/skills/checkup/__tests__/pull-request-target.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/pull-request-target.test.ts
@@ -127,6 +127,32 @@ describe('detectPullRequestTargetCheckout', () => {
     expect(detectPullRequestTargetCheckout(wf, 'wf.yml')).toEqual({ file: 'wf.yml', checkout: 'pr-head' })
   })
 
+  it('does not flag pr-head for unrelated PR expressions next to a base-ref git fetch', () => {
+    const wf = [
+      'on:',
+      '  pull_request_target:',
+      'jobs:',
+      '  build:',
+      '    steps:',
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions expression syntax — intentionally a plain string
+      '      - run: git fetch origin main && echo "${{ github.event.pull_request.title }}"',
+    ].join('\n')
+    expect(detectPullRequestTargetCheckout(wf, 'wf.yml')).toEqual({ file: 'wf.yml', checkout: 'none' })
+  })
+
+  it('flags pr-head when the head SHA itself is fetched in a run: step', () => {
+    const wf = [
+      'on:',
+      '  pull_request_target:',
+      'jobs:',
+      '  build:',
+      '    steps:',
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions expression syntax — intentionally a plain string
+      '      - run: git fetch origin ${{ github.event.pull_request.head.sha }}',
+    ].join('\n')
+    expect(detectPullRequestTargetCheckout(wf, 'wf.yml')).toEqual({ file: 'wf.yml', checkout: 'pr-head' })
+  })
+
   it('flags pr-head when PR code is fetched via a run: step, even without actions/checkout', () => {
     const wf = [
       'on:',

--- a/plugins/dev-core/skills/checkup/doctor-github.ts
+++ b/plugins/dev-core/skills/checkup/doctor-github.ts
@@ -237,6 +237,13 @@ export function checkRulesets(ghOk: boolean, owner: string, repo: string, meta: 
       } catch {}
     }
 
+    if (!detail) {
+      checks.push({
+        name: 'ruleset detail',
+        status: 'warn',
+        detail: 'could not fetch ruleset detail — cannot verify merge methods or branch targeting',
+      })
+    }
     if (detail) {
       const prRule = detail.rules?.find((rule) => rule.type === 'pull_request')
       const methods = prRule?.parameters?.allowed_merge_methods ?? []
@@ -252,6 +259,13 @@ export function checkRulesets(ghOk: boolean, owner: string, repo: string, meta: 
       // A ruleset pinned to refs/heads/main protects nothing on repos whose default
       // branch is staging — the ruleset reports "active" while every PR merges unchecked.
       const defaultBranch = meta?.defaultBranch ?? ''
+      if (!defaultBranch) {
+        checks.push({
+          name: 'Default branch targeted',
+          status: 'skip',
+          detail: meta ? 'default branch unknown' : 'repo meta unavailable — cannot verify ruleset coverage',
+        })
+      }
       if (defaultBranch) {
         const targets = detail.conditions?.ref_name?.include ?? []
         const coversDefault =
@@ -270,6 +284,12 @@ export function checkRulesets(ghOk: boolean, owner: string, repo: string, meta: 
         checks.push({ name: 'Default branch targeted', status, detail: detailMsg })
       }
     }
+  } else if (ruleset) {
+    checks.push({
+      name: 'ruleset detail',
+      status: 'warn',
+      detail: 'ruleset id missing or not numeric — cannot verify merge methods or branch targeting',
+    })
   }
 
   return { name: 'Rulesets', checks }
@@ -470,6 +490,13 @@ export function checkCIPermissions(meta: RepoMeta | null): Section {
     }
   }
 
+  if (!meta) {
+    checks.push({
+      name: 'repo visibility',
+      status: 'warn',
+      detail: 'could not fetch repo metadata — severity may be understated on private repos',
+    })
+  }
   const isPrivate = meta?.visibility === 'private'
 
   const issues: Array<{ file: string; job: string; permissions: string[] }> = []

--- a/plugins/dev-core/skills/checkup/doctor-local.ts
+++ b/plugins/dev-core/skills/checkup/doctor-local.ts
@@ -248,7 +248,9 @@ export function detectPullRequestTargetCheckout(content: string, filePath: strin
     /ref:\s*\$\{\{\s*github\.(event\.pull_request\.head\.(sha|ref)|head_ref)\s*\}\}/.test(content) ||
     /repository:\s*\$\{\{\s*github\.event\.pull_request\.head\.repo\.full_name\s*\}\}/.test(content) ||
     /ref:\s*refs\/pull\/[^\n]*\/merge/.test(content) ||
-    /git\s+(fetch|checkout)[^\n]*(pull\/\$\{\{|github\.event\.pull_request)/.test(content)
+    // code-fetching forms only: pull/${{N}}/head, refs/pull/*, or head.* fields —
+    // a bare github.event.pull_request.title/number next to an unrelated git fetch is not a PR-head checkout
+    /git\s+(fetch|checkout)[^\n]*(pull\/\$\{\{|refs\/pull\/|github\.event\.pull_request\.head)/.test(content)
   if (executesPrHead) return { file: filePath, checkout: 'pr-head' }
   if (content.includes('actions/checkout')) return { file: filePath, checkout: 'default' }
   return { file: filePath, checkout: 'none' }


### PR DESCRIPTION
## Summary
- Follow-up to #277, which auto-merged while the second review iteration was in flight. Applies the 4 findings from the iteration-2 re-review (all verified against the fix delta):
  - run-step PR-head detector tightened to code-fetching forms only (`pull/${{`, `refs/pull/`, `head.*`) — a bare `pull_request.title` next to an unrelated `git fetch` no longer produces a false pr-head fail
  - `checkRulesets`: explicit skip when repo meta is unavailable; warn when ruleset detail fetch fails or the id is not numeric (previously silent omissions reporting a false-clean picture)
  - `checkCIPermissions`: warn when meta is null — the severity downgrade on private repos is now visible
- dev-core 0.8.0 → 0.8.1

## Test Plan
- [x] +2 detector tests (false-positive guard, head.sha run-step fetch) — 27/27 green
- [x] lint + typecheck green, pre-push gates (trufflehog, version check) pass

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`