### PR TITLE
docs(dev-core): GitHub App CI tokens — private repos need repo-level secrets

### DIFF
--- a/plugins/dev-core/skills/ci-setup/cookbooks/workflows.md
+++ b/plugins/dev-core/skills/ci-setup/cookbooks/workflows.md
@@ -46,6 +46,8 @@ Standard set: `ci.yml`, `auto-merge.yml`, `pr-title.yml` (+ `deploy-preview.yml`
      ```
    - D: `CI/CD workflows ✅ Created` + `PAT secret ✅ Set` + `allow_auto_merge ✅ Enabled` + `Auto-merge re-triggered on N PR(s) ✅` (or ⏭ if none).
 
+   > **GitHub App alternative (org pattern: `roxabi-ci`).** Workflows can authenticate via `actions/create-github-app-token` instead of a PAT — ephemeral 1 h job-scoped installation tokens. Org variables/secrets needed: `ROXABI_CI_APP_ID` (var) + `ROXABI_CI_APP_PRIVATE_KEY` (secret). **Private repos on a free-plan org:** org-level Actions secrets/variables do NOT propagate to private repositories — set them at repo level: `gh variable set ROXABI_CI_APP_ID --repo <owner>/<repo> --body <app-id>` / `gh secret set ROXABI_CI_APP_PRIVATE_KEY --repo <owner>/<repo> < key.pem`. Dependabot-triggered events additionally need a Dependabot secret: `gh secret set ROXABI_CI_APP_PRIVATE_KEY --repo <owner>/<repo> --app dependabot < key.pem`. (Migration of this repo's workflows: #284.)
+
 6. skip → D⏭("CI/CD workflows").
 
 ### Phase 1d — Fumadocs Vercel Deployment (Optional)

--- a/plugins/dev-core/skills/release-setup/cookbooks/release-automation.md
+++ b/plugins/dev-core/skills/release-setup/cookbooks/release-automation.md
@@ -111,6 +111,8 @@ Configure automated versioning and changelog generation.
    ```
    `mkdir -p .github/workflows` first. Use `secrets.PAT` (set during `/init` Phase 3) so the release PR can trigger `ci.yml` — the default `GITHUB_TOKEN` can't fan out to other workflows. Existing file + ¬F → skip with D⏭. `.github/workflows/release-please.yml` already present, but no config → restore config and keep workflow.
 
+   > **GitHub App alternative (org pattern: `roxabi-ci`):** replace `secrets.PAT` with a minted `actions/create-github-app-token` step (`app-id: ${{ vars.ROXABI_CI_APP_ID }}`, `private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}`). **Private repos on a free-plan org:** org-level secrets/variables do NOT reach private repos — set `ROXABI_CI_APP_ID` (var) and `ROXABI_CI_APP_PRIVATE_KEY` (secret) at repo level. Dependabot jobs also need `gh secret set ROXABI_CI_APP_PRIVATE_KEY --repo <owner>/<repo> --app dependabot < key.pem`. Generator parity tracked in #281.
+
 7. **Idempotent repair under F** — if any of these are already present but drift from the convention, patch in place:
    - Workflow missing `target-branch: main` action input → inject it.
    - Config `.` package missing `component` / `package-name` / `tag-separator: "/"` → add them.


### PR DESCRIPTION
Documents the roxabi-ci GitHub App auth pattern for scaffolded workflows and the free-plan caveat: org-level Actions secrets/variables don't reach private repos → repo-level ROXABI_CI_APP_ID / ROXABI_CI_APP_PRIVATE_KEY (+ Dependabot secret when needed). Complements #281 (generator fix). Org-wide workflow migration done in the #284 wave.