### PR TITLE
feat(cleanup): end-of-session sweep — stuck labels + orphan runs

### DIFF
--- a/plugins/dev-core/skills/cleanup/SKILL.md
+++ b/plugins/dev-core/skills/cleanup/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: cleanup
-argument-hint: [--branches | --worktrees | --all]
-description: Clean git branches/worktrees/remotes after merge-status verification. Triggers: "cleanup" | "clean branches" | "cleanup worktrees" | "remove stale branches".
-version: 0.3.0
+argument-hint: [--branches | --worktrees | --all | --report-only]
+description: Clean git branches/worktrees/remotes after merge-status verification; sweep stuck pipeline labels and orphan CI runs. Triggers: "cleanup" | "clean branches" | "cleanup worktrees" | "remove stale branches".
+version: 0.4.0
 allowed-tools: Bash, Read, EnterWorktree, ExitWorktree, ToolSearch
 ---
 
@@ -10,17 +10,36 @@ allowed-tools: Bash, Read, EnterWorktree, ExitWorktree, ToolSearch
 
 Let: β := branch | ω := worktree | π := open PR | Π := protected branch (main/master/staging) | safe(β) ⟺ fully_merged(β) ∧ ¬π(β) | merged(β) := regular_merge(β) ∨ squash_merge(β)
 
-Safely clean local β, ω, and remote branches with **mandatory merge-status verification** before any deletion.
+Safely clean local β, ω, and remote branches with **mandatory merge-status verification** before any deletion. End-of-session sweep also strips stuck pipeline labels from closed PRs and cancels long-queued CI runs.
+
+## Entry: parse $ARGUMENTS
+
+At skill entry, before any other action:
+
+```
+REPORT_ONLY=false
+YES=false
+for arg in $ARGUMENTS; do
+  case "$arg" in
+    --report-only) REPORT_ONLY=true ;;
+    --yes)         YES=true ;;
+  esac
+done
+```
+
+`REPORT_ONLY=true` ⇒ **zero mutations** throughout all steps (cron-safe).  
+`YES=true` ⇒ skip confirmation prompts for destructive actions (implies user already consented).  
+If both set: `REPORT_ONLY` wins — no mutations.
 
 ## Instructions
 
 ### 1. Gather State
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/pr/gather-state.sh
+bash ${CLAUDE_PLUGIN_ROOT}/skills/cleanup/gather-state.sh
 ```
 
-Emits: `current`, branch list with tracking info, worktree list, open PRs.
+Emits: `current`, branch list with tracking info, worktree list, open PRs, closed PRs with pipeline labels, and queued/stuck CI runs.
 
 ### 2. Analyze Each Branch
 
@@ -133,7 +152,104 @@ Remote Branch Cleanup
 git push origin --delete <branch>
 ```
 
-### 7. Final Report
+### 7. Sweep: stuck pipeline labels on closed/merged PRs
+
+Pipeline labels should be removed when a PR is closed or merged. This step identifies and strips them.
+
+#### Pipeline label list
+
+<!-- sync manually when plugins/dev-core/skills/shared/adapters/config-helpers.ts changes -->
+```
+PRIORITY_LABELS : P0-critical  P1-high  P2-medium  P3-low
+SIZE_LABELS     : size:S  size:F-lite  size:F-full
+LANE_LABELS     : graph:lane/a1  graph:lane/a2  graph:lane/a3
+                  graph:lane/b
+                  graph:lane/c1  graph:lane/c2  graph:lane/c3
+                  graph:lane/d  graph:lane/e  graph:lane/f
+                  graph:lane/g  graph:lane/h  graph:lane/i
+                  graph:lane/j  graph:lane/k  graph:lane/l
+                  graph:lane/m  graph:lane/n  graph:lane/o
+                  graph:lane/standalone
+STATUS_LABELS   : status:Backlog  status:Analysis  status:Specs
+                  "status:In Progress"  status:Review  status:Done
+PIPELINE_OTHER  : reviewed
+```
+
+All of the above are "pipeline labels" — they should not remain on closed/merged PRs.
+
+#### 7a. Find candidates (from gather-state.sh `---closed-prs-with-labels---` section)
+
+The script emits at most 20 closed PRs. For each, check which labels from the pipeline label list are present.
+
+#### 7b. Present findings
+
+```
+Stuck Labels on Closed PRs
+══════════════════════════
+
+  PR    │ Title (truncated)          │ Labels to remove
+  #123  │ feat: add auth module       │ status:In Progress, P2-medium
+  #117  │ fix: broken build           │ reviewed, status:Review
+  (none found)
+```
+
+If `REPORT_ONLY=true` → print table and **stop this step** (zero mutations).
+
+#### 7c. Confirm and strip
+
+→ DP(C)
+- Default: strip all listed labels from all listed PRs
+- "Skip / Keep labels as-is" always available
+
+If `YES=true` → proceed without prompt.
+
+For each confirmed PR + label:
+
+```bash
+gh pr edit <number> --remove-label "<label>"
+```
+
+Gracefully handle `gh` permission errors — report which labels could not be removed and continue.
+
+### 8. Sweep: queued/stuck CI runs
+
+#### 8a. Find candidates (from gather-state.sh `---queued-runs---` section)
+
+The script emits at most 30 runs filtered to `queued` or `in_progress` status. Consider a run "stuck" if:
+- status = `queued` and created ≥ 30 min ago, OR
+- status = `in_progress` and created ≥ 60 min ago (use run's `createdAt` field)
+
+#### 8b. Present findings
+
+```
+Queued / Stuck CI Runs
+══════════════════════
+
+  Run ID    │ Workflow              │ Branch              │ Status      │ Age
+  12345678  │ ci.yml                │ feat/old-branch     │ queued      │ 2h 15m
+  12345679  │ release.yml           │ main                │ in_progress │ 75m
+  (none found)
+```
+
+If `REPORT_ONLY=true` → print table and **stop this step** (zero mutations).
+
+#### 8c. Confirm and cancel
+
+→ DP(C)
+- Present stuck runs as candidates; runs on protected branches (main/master/staging) shown as informational — NEVER auto-cancel
+- "Skip / Cancel none" always available
+
+If `YES=true` → proceed without prompt (still skips protected branches).
+
+For each confirmed run:
+
+```bash
+gh run cancel <run-id> 2>/dev/null || echo "⚠️  Cannot cancel run <run-id> (permission denied or already completed)"
+```
+
+Always degrade gracefully — permission errors are non-fatal; report and continue.
+
+### 9. Final Report
 
 ```
 Cleanup Complete
@@ -149,16 +265,28 @@ Cleanup Complete
     ✅ Deleted remote: origin/docs/28-coding-standards
     ⏭ Skipped remote: origin/feat/33-i18n (active PR #42)
 
+  Labels:
+    ✅ Stripped: #123 — status:In Progress, P2-medium
+    ⏭ Skipped: #117 (user chose to keep)
+
+  CI Runs:
+    ✅ Cancelled: run 12345678 (feat/old-branch, queued 2h 15m)
+    ⏭ Skipped: run 12345679 (main — protected branch)
+
   Remaining branches: main, feat/33-i18n, experiment/test
 ```
+
+If `REPORT_ONLY=true`, prefix the header with `[report-only — no mutations performed]`.
 
 ## Options
 
 | Flag | Description |
 |------|-------------|
-| (none) / `--all` | Analyze both branches and worktrees |
+| (none) / `--all` | Analyze branches, worktrees, labels, and runs |
 | `--branches` | Only analyze branches |
 | `--worktrees` | Only analyze worktrees |
+| `--report-only` | Gather and print findings; perform zero mutations (cron-safe) |
+| `--yes` | Skip confirmation prompts for all destructive actions |
 
 ## Safety Rules
 
@@ -171,6 +299,9 @@ Cleanup Complete
 7. **ALWAYS remove worktree before deleting its branch**
 8. **NEVER delete remote branches automatically** — always require explicit confirmation per branch
 9. **ALWAYS scan all remote branches** for stale merged branches, not just locally deleted ones
+10. **`--report-only` = zero mutations** — no label edits, no run cancels, no branch deletes
+11. **NEVER auto-cancel runs on protected branches** (main/master/staging) — show as info only
+12. **Degrade gracefully on `gh` permission errors** — report failure and continue; never abort entire sweep
 
 ## Edge Cases
 
@@ -196,7 +327,8 @@ Cleanup Complete
 ## Exit
 
 - **Success via `/dev`:** stale branches/worktrees removed → return control silently. ¬write summary. `/dev` re-scans, all steps done/skipped, shows completion banner.
-- **Success standalone:** print summary (branches deleted, worktrees pruned). Stop.
+- **Success standalone:** print summary (branches deleted, worktrees pruned, labels stripped, runs cancelled). Stop.
+- **`--report-only`:** print findings report, no mutations. Exit 0.
 - **Failure:** return error. `/dev` presents Retry | Skip | Abort.
 
 $ARGUMENTS

--- a/plugins/dev-core/skills/cleanup/SKILL.md
+++ b/plugins/dev-core/skills/cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cleanup
-argument-hint: [--branches | --worktrees | --all | --report-only]
+argument-hint: [--all | --report-only | --yes]
 description: Clean git branches/worktrees/remotes after merge-status verification; sweep stuck pipeline labels and orphan CI runs. Triggers: "cleanup" | "clean branches" | "cleanup worktrees" | "remove stale branches".
 version: 0.4.0
 allowed-tools: Bash, Read, EnterWorktree, ExitWorktree, ToolSearch
@@ -36,7 +36,7 @@ If both set: `REPORT_ONLY` wins — no mutations.
 ### 1. Gather State
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/cleanup/gather-state.sh
+bash ${CLAUDE_SKILL_DIR}/gather-state.sh
 ```
 
 Emits: `current`, branch list with tracking info, worktree list, open PRs, closed PRs with pipeline labels, and queued/stuck CI runs.
@@ -75,6 +75,8 @@ Legend: 🗑 = safe to delete, ⚠️ = needs attention, 🔒 = protected
 ```
 
 ### 4. Ask for Confirmation
+
+If `REPORT_ONLY=true` → skip this confirmation **and** Step 5 (zero deletions); Step 3's table is the report. Continue to Step 6.
 
 → DP(C)
 - Present only safe(β) items as default selections
@@ -143,6 +145,8 @@ Remote Branch Cleanup
 ```
 
 #### 6d. Ask for confirmation
+
+If `REPORT_ONLY=true` → skip this confirmation **and** Step 6e (zero remote deletions); Step 6c's table is the report. Continue to Step 7.
 
 → DP(C) present merged remote β with ¬π as safe; show unmerged separately; **NEVER auto-delete remote β**; always include "Skip / Keep all remote branches".
 
@@ -283,8 +287,6 @@ If `REPORT_ONLY=true`, prefix the header with `[report-only — no mutations per
 | Flag | Description |
 |------|-------------|
 | (none) / `--all` | Analyze branches, worktrees, labels, and runs |
-| `--branches` | Only analyze branches |
-| `--worktrees` | Only analyze worktrees |
 | `--report-only` | Gather and print findings; perform zero mutations (cron-safe) |
 | `--yes` | Skip confirmation prompts for all destructive actions |
 

--- a/plugins/dev-core/skills/cleanup/gather-state.sh
+++ b/plugins/dev-core/skills/cleanup/gather-state.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Usage: gather-state.sh
-# Outputs current branch, all branches with tracking info, worktrees, and open PRs.
+# Outputs current branch, all branches with tracking info, worktrees, open PRs,
+# closed PRs with stuck pipeline labels, and queued/stuck CI runs.
 set -euo pipefail
 
 echo "---current---"
@@ -14,3 +15,22 @@ git worktree list 2>/dev/null || echo "worktrees=none"
 
 echo "---open-prs---"
 gh pr list --state open 2>/dev/null || echo "open_prs=none"
+
+echo "---closed-prs-with-labels---"
+# Bounded: at most 20 closed PRs. Lists number, title, and labels.
+# The caller filters by the pipeline label list defined in SKILL.md.
+gh pr list \
+  --state closed \
+  --limit 20 \
+  --json number,title,labels \
+  --jq '.[] | select((.labels | length) > 0) | {number, title, labels: [.labels[].name]}' \
+  2>/dev/null || echo "closed_prs=none"
+
+echo "---queued-runs---"
+# Bounded: at most 30 runs, queued or in_progress only.
+# Caller applies age threshold: queued ≥ 30 min, in_progress ≥ 60 min.
+gh run list \
+  --limit 30 \
+  --json databaseId,name,workflowName,headBranch,status,createdAt \
+  --jq '.[] | select(.status == "queued" or .status == "in_progress")' \
+  2>/dev/null || echo "queued_runs=none"


### PR DESCRIPTION
## Summary

- **Step 7**: sweep pipeline labels (`P0-critical`, `status:*`, `size:*`, `graph:lane/*`, `reviewed`, etc.) from closed/merged PRs — report → confirm → strip with `gh pr edit --remove-label`
- **Step 8**: sweep queued/stuck CI runs — age thresholds (queued ≥30min, in_progress ≥60min), protected branches (main/master/staging) shown as info only, never auto-cancelled
- **`$ARGUMENTS` parsing block**: `--report-only` = zero mutations (cron-safe), `--yes` = skip prompts; `--report-only` wins if both set
- **Full pipeline label list** enumerated inline in SKILL.md from `config-helpers.ts` SSoT (with `<!-- sync manually -->` note, since SKILL.md is a prompt and cannot import TS)
- **`gather-state.sh` extended**: two new bounded sections — `---closed-prs-with-labels---` (`--limit 20`) and `---queued-runs---` (`--limit 30`, filtered to `queued|in_progress`)
- **Pre-existing path bug fixed**: `skills/pr/gather-state.sh` → `skills/cleanup/gather-state.sh`
- Safety rules 10–12 added; Options table, Exit section, Final Report updated

## Acceptance criteria → evidence

| AC | Evidence |
|----|----------|
| `--report-only` triggers zero mutations | `REPORT_ONLY` flag checked before every `gh pr edit` / `gh run cancel` / `git branch -d` / `git push --delete`; Steps 7b/8b/Final Report print `[report-only — no mutations performed]` prefix |
| Queries bounded | `gh pr list --state closed --limit 20` + `gh run list --limit 30` in gather-state.sh |
| Label list matches config-helpers.ts | SKILL.md §7 enumerates all values from `PRIORITY_LABEL_MAP`, `SIZE_LABEL_MAP`, `LANE_LABEL_MAP`, `STATUS_LABEL_MAP` + `reviewed` |
| Protected branches never auto-cancelled | Step 8b: "runs on protected branches shown as informational — NEVER auto-cancel"; Safety Rule 11 |
| Graceful degradation on permission errors | Step 7 + Step 8: `|| echo "⚠️ Cannot …"` on every `gh` mutation call |
| Report-then-act | Steps 7b/8b: present table first, confirm (or `--yes`), then act |
| `--yes` skips prompts | `YES=true` checked at Steps 7c and 8c before DP(C) |
| No local process/watcher logic | Zero watcher/process-registry additions — git/gh-only |
| gather-state.sh syntax valid | `bash -n gather-state.sh` → syntax OK |

## Test plan

- [ ] `bash -n plugins/dev-core/skills/cleanup/gather-state.sh` → `syntax OK` (run locally)
- [ ] `bun run test` passes (no TS changes → all existing tests green)
- [ ] CI green on this PR
- [ ] Manual smoke: `/cleanup --report-only` in a session with closed PRs bearing pipeline labels → prints table, zero mutations
- [ ] Manual smoke: `/cleanup --yes` → strips labels + cancels stuck runs without prompts

Closes #282