### PR TITLE
feat(promote): hotfix-density pre-flight gauge

### DIFF
--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -56,13 +56,14 @@ Steps: pre-flight → version → changelog → commit → preview → create-pr
 bash ${CLAUDE_SKILL_DIR}/preflight.sh
 ```
 
-Emits: `commits_ahead`, `status`, commit log, diff stat, open PRs on staging, CI check results.
+Emits: `commits_ahead`, `status`, commit log, diff stat, open PRs on staging, CI check results, `hotfix_density`.
 
 | Check | Condition | Action |
 |-------|-----------|--------|
 | No commits | `commits_ahead=0` | **REFUSE.** Stop. |
 | Open PRs on σ | open_prs section non-empty | **WARN** + Q: **Continue** \| **Wait** |
 | CI status | ci section | **WARN** if ¬passing |
+| Hotfix density | `hotfix_density` section | **WARN** if gauge=warn (20–40%); **recommend pause** + `/checkup` if gauge=pause (>40%); advisory-only — never hard-block |
 
 ## Step 1b — Pin-swap Phase
 

--- a/plugins/dev-core/skills/promote/__tests__/hotfix-density.test.ts
+++ b/plugins/dev-core/skills/promote/__tests__/hotfix-density.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
-  THRESHOLD_GREEN,
-  THRESHOLD_PAUSE,
-  THRESHOLD_WARN,
   classifyDensity,
   computeHotfixDensity,
+  type Deps,
   fetchHotfixPrShas,
   formatResult,
+  type HotfixDensityResult,
   isHotfix,
   listCommitsSince,
   resolveAnchor,
-  type Deps,
-  type HotfixDensityResult,
+  THRESHOLD_GREEN,
+  THRESHOLD_PAUSE,
+  THRESHOLD_WARN,
 } from '../lib/hotfix-density'
 
 // ─── Threshold constants ───────────────────────────────────────────────────────
@@ -111,9 +111,7 @@ describe('isHotfix', () => {
 
 // ─── resolveAnchor ────────────────────────────────────────────────────────────
 
-function makeRunDeps(
-  responses: Record<string, string | Error>,
-): Pick<Deps, 'run'> {
+function makeRunDeps(responses: Record<string, string | Error>): Pick<Deps, 'run'> {
   return {
     run: vi.fn(async (cmd: string[]) => {
       const key = cmd.join(' ')
@@ -150,8 +148,7 @@ describe('resolveAnchor', () => {
 
   it('returns first matching tag when multiple tags present', async () => {
     const deps = makeRunDeps({
-      'git tag --list':
-        'dev-core/v2.0.0 2026-06-01T10:00:00+02:00\ndev-core/v1.9.0 2026-05-01T10:00:00+02:00\n',
+      'git tag --list': 'dev-core/v2.0.0 2026-06-01T10:00:00+02:00\ndev-core/v1.9.0 2026-05-01T10:00:00+02:00\n',
     })
     const result = await resolveAnchor(undefined, deps)
     expect(result.anchorSource).toBe('tag')
@@ -272,12 +269,7 @@ describe('fetchHotfixPrShas', () => {
 
 // ─── computeHotfixDensity — integration paths ─────────────────────────────────
 
-function makeDepsForIntegration(opts: {
-  tags?: string
-  promoLog?: string
-  commits?: string
-  prShas?: string
-}): Deps {
+function makeDepsForIntegration(opts: { tags?: string; promoLog?: string; commits?: string; prShas?: string }): Deps {
   return {
     run: vi.fn(async (cmd: string[]) => {
       const joined = cmd.join(' ')
@@ -381,10 +373,7 @@ describe('computeHotfixDensity', () => {
     const deps = makeDepsForIntegration({
       tags: 'v1.0.0 2026-05-01T10:00:00+02:00\n',
       // feat commit but PR has hotfix label
-      commits: [
-        'prsha1\tfeat: should be classified hotfix via label',
-        'sha02\tfeat: normal feature',
-      ].join('\n'),
+      commits: ['prsha1\tfeat: should be classified hotfix via label', 'sha02\tfeat: normal feature'].join('\n'),
       prShas: 'prsha1',
     })
     const result = await computeHotfixDensity(undefined, deps)

--- a/plugins/dev-core/skills/promote/__tests__/hotfix-density.test.ts
+++ b/plugins/dev-core/skills/promote/__tests__/hotfix-density.test.ts
@@ -1,0 +1,498 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  THRESHOLD_GREEN,
+  THRESHOLD_PAUSE,
+  THRESHOLD_WARN,
+  classifyDensity,
+  computeHotfixDensity,
+  fetchHotfixPrShas,
+  formatResult,
+  isHotfix,
+  listCommitsSince,
+  resolveAnchor,
+  type Deps,
+  type HotfixDensityResult,
+} from '../lib/hotfix-density'
+
+// ─── Threshold constants ───────────────────────────────────────────────────────
+
+describe('threshold constants', () => {
+  it('exports correct green threshold', () => {
+    expect(THRESHOLD_GREEN).toBe(0.2)
+  })
+
+  it('exports correct warn threshold', () => {
+    expect(THRESHOLD_WARN).toBe(0.4)
+  })
+
+  it('exports correct pause threshold equal to warn', () => {
+    expect(THRESHOLD_PAUSE).toBe(THRESHOLD_WARN)
+  })
+})
+
+// ─── classifyDensity ──────────────────────────────────────────────────────────
+
+describe('classifyDensity', () => {
+  it('returns green for 0', () => {
+    expect(classifyDensity(0)).toBe('green')
+  })
+
+  it('returns green for density just below THRESHOLD_GREEN', () => {
+    expect(classifyDensity(0.19)).toBe('green')
+  })
+
+  it('returns warn at exactly THRESHOLD_GREEN (boundary)', () => {
+    expect(classifyDensity(0.2)).toBe('warn')
+  })
+
+  it('returns warn for mid-range density', () => {
+    expect(classifyDensity(0.3)).toBe('warn')
+  })
+
+  it('returns warn for density just below THRESHOLD_WARN', () => {
+    expect(classifyDensity(0.39)).toBe('warn')
+  })
+
+  it('returns pause at exactly THRESHOLD_WARN (boundary)', () => {
+    expect(classifyDensity(0.4)).toBe('pause')
+  })
+
+  it('returns pause for density above THRESHOLD_WARN', () => {
+    expect(classifyDensity(0.6)).toBe('pause')
+  })
+
+  it('returns pause for density = 1.0', () => {
+    expect(classifyDensity(1.0)).toBe('pause')
+  })
+})
+
+// ─── isHotfix ─────────────────────────────────────────────────────────────────
+
+describe('isHotfix', () => {
+  it('returns true for fix: prefix (lowercase)', () => {
+    expect(isHotfix('abc', 'fix: correct null check', new Set())).toBe(true)
+  })
+
+  it('returns true for Fix: prefix (case-insensitive)', () => {
+    expect(isHotfix('abc', 'Fix: something', new Set())).toBe(true)
+  })
+
+  it('returns true for FIX: prefix (uppercase)', () => {
+    expect(isHotfix('abc', 'FIX: uppercase', new Set())).toBe(true)
+  })
+
+  it('returns false for feat: prefix', () => {
+    expect(isHotfix('abc', 'feat: add feature', new Set())).toBe(false)
+  })
+
+  it('returns false for chore: prefix', () => {
+    expect(isHotfix('abc', 'chore: update deps', new Set())).toBe(false)
+  })
+
+  it('returns false for title containing fix but not at start', () => {
+    expect(isHotfix('abc', 'feat: prefix fix in middle', new Set())).toBe(false)
+  })
+
+  it('returns true if sha is in hotfixPrShas set', () => {
+    const shas = new Set(['sha123'])
+    expect(isHotfix('sha123', 'feat: any title', shas)).toBe(true)
+  })
+
+  it('returns false if sha not in hotfixPrShas and title is not fix:', () => {
+    const shas = new Set(['other-sha'])
+    expect(isHotfix('sha999', 'docs: update readme', shas)).toBe(false)
+  })
+
+  it('returns true for union: both fix: and in set', () => {
+    const shas = new Set(['sha123'])
+    expect(isHotfix('sha123', 'fix: also in set', shas)).toBe(true)
+  })
+})
+
+// ─── resolveAnchor ────────────────────────────────────────────────────────────
+
+function makeRunDeps(
+  responses: Record<string, string | Error>,
+): Pick<Deps, 'run'> {
+  return {
+    run: vi.fn(async (cmd: string[]) => {
+      const key = cmd.join(' ')
+      // Find the first key that the joined command contains
+      for (const [pattern, response] of Object.entries(responses)) {
+        if (key.includes(pattern)) {
+          if (response instanceof Error) throw response
+          return response
+        }
+      }
+      throw new Error(`Unexpected command: ${key}`)
+    }),
+  }
+}
+
+describe('resolveAnchor', () => {
+  it('returns tag source when a version tag is present', async () => {
+    const deps = makeRunDeps({
+      'git tag --list': 'dev-core/v1.2.3 2026-05-01T10:00:00+02:00\n',
+    })
+    const result = await resolveAnchor(undefined, deps)
+    expect(result.anchorSource).toBe('tag')
+    expect(result.anchorDate).toContain('2026-05-01')
+    expect(result.anchorWarn).toBeUndefined()
+  })
+
+  it('returns tag source for bare vX.Y.Z tag', async () => {
+    const deps = makeRunDeps({
+      'git tag --list': 'v0.5.0 2026-04-10T08:00:00+02:00\n',
+    })
+    const result = await resolveAnchor(undefined, deps)
+    expect(result.anchorSource).toBe('tag')
+  })
+
+  it('returns first matching tag when multiple tags present', async () => {
+    const deps = makeRunDeps({
+      'git tag --list':
+        'dev-core/v2.0.0 2026-06-01T10:00:00+02:00\ndev-core/v1.9.0 2026-05-01T10:00:00+02:00\n',
+    })
+    const result = await resolveAnchor(undefined, deps)
+    expect(result.anchorSource).toBe('tag')
+    expect(result.anchorDate).toContain('2026-06-01')
+  })
+
+  it('falls through to promotion-merge when no tags found', async () => {
+    const deps = makeRunDeps({
+      'git tag --list': '',
+      'git log': 'abc1234 2026-05-10 12:00:00 +0200',
+    })
+    const result = await resolveAnchor(undefined, deps)
+    expect(result.anchorSource).toBe('promotion-merge')
+    expect(result.anchorDate).toContain('2026-05-10')
+    expect(result.anchorWarn).toBeUndefined()
+  })
+
+  it('falls through to fallback-30d when both tag and promotion-merge fail', async () => {
+    const deps = makeRunDeps({
+      'git tag --list': '',
+      'git log': '',
+    })
+    const result = await resolveAnchor(undefined, deps)
+    expect(result.anchorSource).toBe('fallback-30d')
+    expect(result.anchorWarn).toBeTruthy()
+    // anchorDate should be approximately 30 days ago
+    const now = Date.now()
+    const anchor = new Date(result.anchorDate).getTime()
+    const diffDays = (now - anchor) / (1000 * 60 * 60 * 24)
+    expect(diffDays).toBeGreaterThan(29)
+    expect(diffDays).toBeLessThan(31)
+  })
+
+  it('falls through to fallback-30d when git commands throw', async () => {
+    const deps = {
+      run: vi.fn().mockRejectedValue(new Error('git not found')),
+    }
+    const result = await resolveAnchor(undefined, deps)
+    expect(result.anchorSource).toBe('fallback-30d')
+    expect(result.anchorWarn).toBeTruthy()
+  })
+})
+
+// ─── listCommitsSince ────────────────────────────────────────────────────────
+
+describe('listCommitsSince', () => {
+  it('parses commit lines into sha+title objects', async () => {
+    const deps = makeRunDeps({
+      'git log': 'abc1234\tfeat: add feature\ndef5678\tfix: patch null\n',
+    })
+    const commits = await listCommitsSince('2026-05-01', undefined, deps)
+    expect(commits).toHaveLength(2)
+    expect(commits[0]).toEqual({ sha: 'abc1234', title: 'feat: add feature' })
+    expect(commits[1]).toEqual({ sha: 'def5678', title: 'fix: patch null' })
+  })
+
+  it('returns empty array for empty git output', async () => {
+    const deps = makeRunDeps({
+      'git log': '',
+    })
+    const commits = await listCommitsSince('2026-05-01', undefined, deps)
+    expect(commits).toHaveLength(0)
+  })
+
+  it('returns empty array when git throws', async () => {
+    const deps = { run: vi.fn().mockRejectedValue(new Error('no repo')) }
+    const commits = await listCommitsSince('2026-05-01', undefined, deps)
+    expect(commits).toHaveLength(0)
+  })
+
+  it('handles line without tab gracefully', async () => {
+    const deps = makeRunDeps({
+      'git log': 'abc1234\n',
+    })
+    const commits = await listCommitsSince('2026-05-01', undefined, deps)
+    expect(commits).toHaveLength(1)
+    expect(commits[0]).toEqual({ sha: 'abc1234', title: '' })
+  })
+})
+
+// ─── fetchHotfixPrShas ───────────────────────────────────────────────────────
+
+describe('fetchHotfixPrShas', () => {
+  it('returns a set of SHAs from gh output', async () => {
+    const deps = makeRunDeps({
+      'gh pr list': 'sha111\nsha222\nsha333\n',
+    })
+    const shas = await fetchHotfixPrShas('2026-05-01', deps)
+    expect(shas.has('sha111')).toBe(true)
+    expect(shas.has('sha222')).toBe(true)
+    expect(shas.has('sha333')).toBe(true)
+    expect(shas.size).toBe(3)
+  })
+
+  it('returns empty set for empty gh output', async () => {
+    const deps = makeRunDeps({
+      'gh pr list': '',
+    })
+    const shas = await fetchHotfixPrShas('2026-05-01', deps)
+    expect(shas.size).toBe(0)
+  })
+
+  it('returns empty set when gh throws (graceful degradation)', async () => {
+    const deps = { run: vi.fn().mockRejectedValue(new Error('no auth')) }
+    const shas = await fetchHotfixPrShas('2026-05-01', deps)
+    expect(shas.size).toBe(0)
+  })
+
+  it('uses only the first 10 chars of anchorDate for --search date filter', async () => {
+    const runMock = vi.fn().mockResolvedValue('')
+    const deps = { run: runMock }
+    await fetchHotfixPrShas('2026-05-01T10:00:00Z', deps)
+    const callArgs: string[] = runMock.mock.calls[0][0]
+    const searchArg = callArgs[callArgs.indexOf('--search') + 1]
+    expect(searchArg).toContain('merged:>=2026-05-01')
+  })
+})
+
+// ─── computeHotfixDensity — integration paths ─────────────────────────────────
+
+function makeDepsForIntegration(opts: {
+  tags?: string
+  promoLog?: string
+  commits?: string
+  prShas?: string
+}): Deps {
+  return {
+    run: vi.fn(async (cmd: string[]) => {
+      const joined = cmd.join(' ')
+      if (joined.includes('git tag --list')) return opts.tags ?? ''
+      if (joined.includes('git log') && joined.includes('main') && joined.includes('merges')) {
+        return opts.promoLog ?? ''
+      }
+      if (joined.includes('git log') && joined.includes('main..staging')) return opts.commits ?? ''
+      if (joined.includes('gh pr list')) return opts.prShas ?? ''
+      throw new Error(`Unexpected cmd: ${joined}`)
+    }),
+  }
+}
+
+describe('computeHotfixDensity', () => {
+  it('returns green result for zero commits', async () => {
+    const deps = makeDepsForIntegration({
+      tags: 'dev-core/v1.0.0 2026-05-01T10:00:00+02:00\n',
+      commits: '',
+    })
+    const result = await computeHotfixDensity(undefined, deps)
+    expect(result.total).toBe(0)
+    expect(result.hotfixCount).toBe(0)
+    expect(result.density).toBe(0)
+    expect(result.gauge).toBe('green')
+    expect(result.anchorSource).toBe('tag')
+  })
+
+  it('returns green gauge for <20% hotfix density', async () => {
+    const deps = makeDepsForIntegration({
+      tags: 'v1.0.0 2026-05-01T10:00:00+02:00\n',
+      // 1 fix out of 10 = 10%
+      commits: [
+        'sha01\tfix: one fix',
+        'sha02\tfeat: feature a',
+        'sha03\tfeat: feature b',
+        'sha04\tfeat: feature c',
+        'sha05\tfeat: feature d',
+        'sha06\tfeat: feature e',
+        'sha07\tchore: cleanup',
+        'sha08\tdocs: update readme',
+        'sha09\trefactor: small refactor',
+        'sha10\ttest: add tests',
+      ].join('\n'),
+      prShas: '',
+    })
+    const result = await computeHotfixDensity(undefined, deps)
+    expect(result.total).toBe(10)
+    expect(result.hotfixCount).toBe(1)
+    expect(result.density).toBeCloseTo(0.1)
+    expect(result.gauge).toBe('green')
+  })
+
+  it('returns warn gauge for 20–40% hotfix density', async () => {
+    const deps = makeDepsForIntegration({
+      tags: 'v1.0.0 2026-05-01T10:00:00+02:00\n',
+      // 3 fix out of 10 = 30%
+      commits: [
+        'sha01\tfix: first',
+        'sha02\tfix: second',
+        'sha03\tfix: third',
+        'sha04\tfeat: a',
+        'sha05\tfeat: b',
+        'sha06\tfeat: c',
+        'sha07\tchore: d',
+        'sha08\tdocs: e',
+        'sha09\trefactor: f',
+        'sha10\ttest: g',
+      ].join('\n'),
+      prShas: '',
+    })
+    const result = await computeHotfixDensity(undefined, deps)
+    expect(result.hotfixCount).toBe(3)
+    expect(result.gauge).toBe('warn')
+  })
+
+  it('returns pause gauge for >40% hotfix density', async () => {
+    const deps = makeDepsForIntegration({
+      tags: 'v1.0.0 2026-05-01T10:00:00+02:00\n',
+      // 5 fix out of 10 = 50%
+      commits: [
+        'sha01\tfix: a',
+        'sha02\tfix: b',
+        'sha03\tfix: c',
+        'sha04\tfix: d',
+        'sha05\tfix: e',
+        'sha06\tfeat: f',
+        'sha07\tfeat: g',
+        'sha08\tchore: h',
+        'sha09\tdocs: i',
+        'sha10\ttest: j',
+      ].join('\n'),
+      prShas: '',
+    })
+    const result = await computeHotfixDensity(undefined, deps)
+    expect(result.hotfixCount).toBe(5)
+    expect(result.gauge).toBe('pause')
+  })
+
+  it('classifies hotfix from PR label (sha in hotfixPrShas)', async () => {
+    const deps = makeDepsForIntegration({
+      tags: 'v1.0.0 2026-05-01T10:00:00+02:00\n',
+      // feat commit but PR has hotfix label
+      commits: [
+        'prsha1\tfeat: should be classified hotfix via label',
+        'sha02\tfeat: normal feature',
+      ].join('\n'),
+      prShas: 'prsha1',
+    })
+    const result = await computeHotfixDensity(undefined, deps)
+    expect(result.hotfixCount).toBe(1)
+    expect(result.total).toBe(2)
+    expect(result.density).toBeCloseTo(0.5)
+    expect(result.gauge).toBe('pause')
+  })
+
+  it('uses fallback-30d when no tags or promotion merge, emits anchorWarn', async () => {
+    const deps = makeDepsForIntegration({
+      tags: '',
+      promoLog: '',
+      commits: 'sha01\tfeat: something\n',
+      prShas: '',
+    })
+    const result = await computeHotfixDensity(undefined, deps)
+    expect(result.anchorSource).toBe('fallback-30d')
+    expect(result.anchorWarn).toBeTruthy()
+  })
+
+  it('uses promotion-merge when no tags but promo commit found', async () => {
+    const deps = makeDepsForIntegration({
+      tags: '',
+      promoLog: 'abcdef 2026-05-15 09:00:00 +0200',
+      commits: '',
+    })
+    const result = await computeHotfixDensity(undefined, deps)
+    expect(result.anchorSource).toBe('promotion-merge')
+    expect(result.anchorWarn).toBeUndefined()
+  })
+})
+
+// ─── formatResult ─────────────────────────────────────────────────────────────
+
+describe('formatResult', () => {
+  const baseResult: HotfixDensityResult = {
+    total: 10,
+    hotfixCount: 1,
+    density: 0.1,
+    gauge: 'green',
+    anchorDate: '2026-05-01T10:00:00Z',
+    anchorSource: 'tag',
+  }
+
+  it('formats green result with OK signal', () => {
+    const out = formatResult(baseResult)
+    expect(out).toContain('1/10')
+    expect(out).toContain('10%')
+    expect(out).toContain('OK')
+  })
+
+  it('formats warn result with WARN signal', () => {
+    const result: HotfixDensityResult = {
+      ...baseResult,
+      hotfixCount: 3,
+      density: 0.3,
+      gauge: 'warn',
+    }
+    const out = formatResult(result)
+    expect(out).toContain('3/10')
+    expect(out).toContain('30%')
+    expect(out).toContain('WARN')
+    expect(out).toContain('/checkup')
+  })
+
+  it('formats pause result with PAUSE recommended signal', () => {
+    const result: HotfixDensityResult = {
+      ...baseResult,
+      hotfixCount: 5,
+      density: 0.5,
+      gauge: 'pause',
+    }
+    const out = formatResult(result)
+    expect(out).toContain('5/10')
+    expect(out).toContain('50%')
+    expect(out).toContain('PAUSE')
+    expect(out).toContain('/checkup')
+  })
+
+  it('appends anchorWarn note when present', () => {
+    const result: HotfixDensityResult = {
+      ...baseResult,
+      anchorSource: 'fallback-30d',
+      anchorWarn: 'No release tag found — using 30-day window',
+    }
+    const out = formatResult(result)
+    expect(out).toContain('note:')
+    expect(out).toContain('30-day window')
+  })
+
+  it('does not append note when anchorWarn absent', () => {
+    const out = formatResult(baseResult)
+    expect(out).not.toContain('note:')
+  })
+
+  it('formats zero commits result', () => {
+    const result: HotfixDensityResult = {
+      total: 0,
+      hotfixCount: 0,
+      density: 0,
+      gauge: 'green',
+      anchorDate: '2026-05-01',
+      anchorSource: 'tag',
+    }
+    const out = formatResult(result)
+    expect(out).toContain('0/0')
+    expect(out).toContain('0%')
+    expect(out).toContain('OK')
+  })
+})

--- a/plugins/dev-core/skills/promote/lib/hotfix-density.ts
+++ b/plugins/dev-core/skills/promote/lib/hotfix-density.ts
@@ -1,0 +1,307 @@
+/**
+ * hotfix-density.ts — hotfix-density pre-flight gauge for /promote
+ *
+ * Measures the ratio of hotfix-class commits in staging since the last
+ * promotion anchor and emits an advisory signal (never a hard gate).
+ *
+ * A commit is hotfix-class if:
+ *   • its title matches /^fix:/i  (Conventional Commit), OR
+ *   • its merged PR carries the `hotfix` label (batched API query)
+ *
+ * Designed for pure-logic testability: all I/O is injected via Deps interface.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type Gauge = 'green' | 'warn' | 'pause'
+
+export interface HotfixDensityResult {
+  /** Total commits in the window */
+  total: number
+  /** Commits classified as hotfix-class */
+  hotfixCount: number
+  /** hotfixCount / total (0 if total === 0) */
+  density: number
+  /** Advisory signal */
+  gauge: Gauge
+  /** ISO date string of the window anchor (tag date, promotion merge date, or 30d fallback) */
+  anchorDate: string
+  /** How the anchor was determined */
+  anchorSource: 'tag' | 'promotion-merge' | 'fallback-30d'
+  /** Present when anchorSource === 'fallback-30d' */
+  anchorWarn?: string
+}
+
+// ─── Dependencies (injected for testability) ──────────────────────────────────
+
+export interface Deps {
+  /** Run a shell command, return trimmed stdout. Throws on non-zero exit. */
+  run: (cmd: string[], cwd?: string) => Promise<string>
+}
+
+// ─── Thresholds (SSoT — referenced by SKILL.md) ───────────────────────────────
+
+/** Density below this → green */
+export const THRESHOLD_GREEN = 0.2
+/** Density below this (and >= THRESHOLD_GREEN) → warn */
+export const THRESHOLD_WARN = 0.4
+/** Density at or above THRESHOLD_WARN → recommend pause */
+export const THRESHOLD_PAUSE = THRESHOLD_WARN
+
+// ─── Gauge classification ─────────────────────────────────────────────────────
+
+/**
+ * Classify a density ratio into a gauge level.
+ *
+ * < THRESHOLD_GREEN  → green
+ * < THRESHOLD_WARN   → warn
+ * >= THRESHOLD_WARN  → pause
+ */
+export function classifyDensity(density: number): Gauge {
+  if (density < THRESHOLD_GREEN) return 'green'
+  if (density < THRESHOLD_WARN) return 'warn'
+  return 'pause'
+}
+
+// ─── Window anchor resolution ─────────────────────────────────────────────────
+
+/**
+ * Determine the window anchor date for counting commits.
+ *
+ * Priority:
+ *   1. Last `<component>/vX.Y.Z` tag in the repo
+ *   2. Last promotion merge-commit (merge commit whose title matches
+ *      "chore: promote staging to main")
+ *   3. 30-calendar-day fallback (emits anchorWarn)
+ *
+ * Returns anchorDate (ISO string) and anchorSource.
+ */
+export async function resolveAnchor(
+  cwd: string | undefined,
+  deps: Pick<Deps, 'run'>,
+): Promise<{ anchorDate: string; anchorSource: HotfixDensityResult['anchorSource']; anchorWarn?: string }> {
+  // 1. Last <component>/vX.Y.Z tag
+  try {
+    const tagOut = await deps.run(
+      ['git', 'tag', '--list', '--sort=-creatordate', '--format=%(refname:short) %(creatordate:iso-strict)'],
+      cwd,
+    )
+    if (tagOut) {
+      for (const line of tagOut.split('\n').filter(Boolean)) {
+        const [tagName, ...dateParts] = line.trim().split(' ')
+        // Match <component>/vX.Y.Z or vX.Y.Z
+        if (/^(?:.+\/)?v\d+\.\d+\.\d+/.test(tagName)) {
+          const anchorDate = dateParts.join(' ')
+          if (anchorDate) {
+            return { anchorDate, anchorSource: 'tag' }
+          }
+        }
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  // 2. Last promotion merge-commit
+  try {
+    const logOut = await deps.run(
+      [
+        'git',
+        'log',
+        'main',
+        '--merges',
+        '--oneline',
+        '--format=%H %ai',
+        '--grep=chore: promote staging to main',
+        '-1',
+      ],
+      cwd,
+    )
+    if (logOut) {
+      const parts = logOut.trim().split(' ')
+      // Format: <sha> <date> <time> <tz>
+      if (parts.length >= 3) {
+        const anchorDate = parts.slice(1).join(' ')
+        return { anchorDate, anchorSource: 'promotion-merge' }
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  // 3. 30-day fallback
+  const fallbackDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+  return {
+    anchorDate: fallbackDate,
+    anchorSource: 'fallback-30d',
+    anchorWarn: 'No release tag or promotion merge found — using 30-day window (may be inaccurate)',
+  }
+}
+
+// ─── Commit listing ───────────────────────────────────────────────────────────
+
+/**
+ * List all commits on staging since anchorDate (exclusive).
+ * Returns an array of { sha, title } objects.
+ */
+export async function listCommitsSince(
+  anchorDate: string,
+  cwd: string | undefined,
+  deps: Pick<Deps, 'run'>,
+): Promise<Array<{ sha: string; title: string }>> {
+  let out: string
+  try {
+    out = await deps.run(
+      ['git', 'log', 'main..staging', `--after=${anchorDate}`, '--format=%H\t%s'],
+      cwd,
+    )
+  } catch {
+    return []
+  }
+
+  if (!out.trim()) return []
+
+  return out
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const tab = line.indexOf('\t')
+      if (tab === -1) return { sha: line.trim(), title: '' }
+      return { sha: line.slice(0, tab).trim(), title: line.slice(tab + 1).trim() }
+    })
+}
+
+// ─── Hotfix label query ───────────────────────────────────────────────────────
+
+/**
+ * Fetch SHAs of merged PRs with the `hotfix` label since anchorDate.
+ * Uses a single batched gh query (no per-commit API calls).
+ *
+ * Returns a Set of commit SHAs (merge commits on main) for matching PRs.
+ */
+export async function fetchHotfixPrShas(
+  anchorDate: string,
+  deps: Pick<Deps, 'run'>,
+): Promise<Set<string>> {
+  let out: string
+  try {
+    out = await deps.run([
+      'gh',
+      'pr',
+      'list',
+      '--state',
+      'merged',
+      '--search',
+      `label:hotfix merged:>=${anchorDate.slice(0, 10)}`,
+      '--json',
+      'mergeCommit',
+      '--jq',
+      '.[].mergeCommit.oid',
+    ])
+  } catch {
+    // gh may fail (no auth, network, etc.) — degrade gracefully
+    return new Set()
+  }
+
+  const shas = new Set<string>()
+  for (const line of out.split('\n').filter(Boolean)) {
+    shas.add(line.trim())
+  }
+  return shas
+}
+
+// ─── Hotfix classification ────────────────────────────────────────────────────
+
+/**
+ * Classify a commit as hotfix-class.
+ *
+ * Union rule: hotfix if title matches /^fix:/i OR sha in hotfixPrShas.
+ */
+export function isHotfix(sha: string, title: string, hotfixPrShas: Set<string>): boolean {
+  return /^fix:/i.test(title) || hotfixPrShas.has(sha)
+}
+
+// ─── Main entry point ─────────────────────────────────────────────────────────
+
+/**
+ * Compute the hotfix-density pre-flight result.
+ *
+ * @param cwd  Optional working directory (defaults to process.cwd())
+ */
+export async function computeHotfixDensity(
+  cwd: string | undefined,
+  deps: Deps,
+): Promise<HotfixDensityResult> {
+  const { anchorDate, anchorSource, anchorWarn } = await resolveAnchor(cwd, deps)
+
+  const commits = await listCommitsSince(anchorDate, cwd, deps)
+  const total = commits.length
+
+  if (total === 0) {
+    return {
+      total: 0,
+      hotfixCount: 0,
+      density: 0,
+      gauge: 'green',
+      anchorDate,
+      anchorSource,
+      ...(anchorWarn ? { anchorWarn } : {}),
+    }
+  }
+
+  const hotfixPrShas = await fetchHotfixPrShas(anchorDate, deps)
+
+  let hotfixCount = 0
+  for (const { sha, title } of commits) {
+    if (isHotfix(sha, title, hotfixPrShas)) hotfixCount++
+  }
+
+  const density = hotfixCount / total
+  const gauge = classifyDensity(density)
+
+  return {
+    total,
+    hotfixCount,
+    density,
+    gauge,
+    anchorDate,
+    anchorSource,
+    ...(anchorWarn ? { anchorWarn } : {}),
+  }
+}
+
+// ─── Output formatting ────────────────────────────────────────────────────────
+
+/**
+ * Format a HotfixDensityResult as a human-readable pre-flight report line.
+ *
+ * Example outputs:
+ *   hotfix-density: 2/10 (20%) — WARN: elevated hotfix rate; consider /checkup
+ *   hotfix-density: 1/10 (10%) — OK
+ *   hotfix-density: 5/10 (50%) — PAUSE recommended: >40% hotfix rate; run /checkup
+ */
+export function formatResult(result: HotfixDensityResult): string {
+  const pct = (result.density * 100).toFixed(0)
+  const ratio = `${result.hotfixCount}/${result.total}`
+
+  let signal: string
+  switch (result.gauge) {
+    case 'green':
+      signal = 'OK'
+      break
+    case 'warn':
+      signal = 'WARN: elevated hotfix rate; consider /checkup'
+      break
+    case 'pause':
+      signal = 'PAUSE recommended: >40% hotfix rate; run /checkup'
+      break
+  }
+
+  let line = `hotfix-density: ${ratio} (${pct}%) — ${signal}`
+
+  if (result.anchorWarn) {
+    line += `\n  note: ${result.anchorWarn}`
+  }
+
+  return line
+}

--- a/plugins/dev-core/skills/promote/lib/hotfix-density.ts
+++ b/plugins/dev-core/skills/promote/lib/hotfix-density.ts
@@ -105,7 +105,7 @@ export async function resolveAnchor(
   // 2. Last promotion merge-commit
   try {
     const logOut = await deps.run(
-      ['git', 'log', 'main', '--merges', '--oneline', '--format=%H %ai', '--grep=chore: promote staging to main', '-1'],
+      ['git', 'log', 'main', '--merges', '--format=%H %ai', '--grep=chore: promote staging to main', '-1'],
       cwd,
     )
     if (logOut) {
@@ -275,7 +275,7 @@ export function formatResult(result: HotfixDensityResult): string {
       signal = 'WARN: elevated hotfix rate; consider /checkup'
       break
     case 'pause':
-      signal = 'PAUSE recommended: >40% hotfix rate; run /checkup'
+      signal = `PAUSE recommended: >${(THRESHOLD_WARN * 100).toFixed(0)}% hotfix rate; run /checkup`
       break
   }
 
@@ -286,4 +286,23 @@ export function formatResult(result: HotfixDensityResult): string {
   }
 
   return line
+}
+
+// ─── Composition root ─────────────────────────────────────────────────────────
+// Invoked by promote/preflight.sh via `bun run .../lib/hotfix-density.ts`.
+// Guarded by import.meta.main so test imports (vitest) never execute the IO path.
+
+if (import.meta.main) {
+  const { execFile } = await import('node:child_process')
+  const { promisify } = await import('node:util')
+  const execFileAsync = promisify(execFile)
+  const deps: Deps = {
+    run: async (cmd, cwd) => {
+      const [bin, ...args] = cmd
+      const { stdout } = await execFileAsync(bin, args, { cwd: cwd ?? process.cwd() })
+      return stdout.trim()
+    },
+  }
+  const result = await computeHotfixDensity(process.cwd(), deps)
+  console.log(formatResult(result))
 }

--- a/plugins/dev-core/skills/promote/lib/hotfix-density.ts
+++ b/plugins/dev-core/skills/promote/lib/hotfix-density.ts
@@ -105,16 +105,7 @@ export async function resolveAnchor(
   // 2. Last promotion merge-commit
   try {
     const logOut = await deps.run(
-      [
-        'git',
-        'log',
-        'main',
-        '--merges',
-        '--oneline',
-        '--format=%H %ai',
-        '--grep=chore: promote staging to main',
-        '-1',
-      ],
+      ['git', 'log', 'main', '--merges', '--oneline', '--format=%H %ai', '--grep=chore: promote staging to main', '-1'],
       cwd,
     )
     if (logOut) {
@@ -151,10 +142,7 @@ export async function listCommitsSince(
 ): Promise<Array<{ sha: string; title: string }>> {
   let out: string
   try {
-    out = await deps.run(
-      ['git', 'log', 'main..staging', `--after=${anchorDate}`, '--format=%H\t%s'],
-      cwd,
-    )
+    out = await deps.run(['git', 'log', 'main..staging', `--after=${anchorDate}`, '--format=%H\t%s'], cwd)
   } catch {
     return []
   }
@@ -179,10 +167,7 @@ export async function listCommitsSince(
  *
  * Returns a Set of commit SHAs (merge commits on main) for matching PRs.
  */
-export async function fetchHotfixPrShas(
-  anchorDate: string,
-  deps: Pick<Deps, 'run'>,
-): Promise<Set<string>> {
+export async function fetchHotfixPrShas(anchorDate: string, deps: Pick<Deps, 'run'>): Promise<Set<string>> {
   let out: string
   try {
     out = await deps.run([
@@ -228,10 +213,7 @@ export function isHotfix(sha: string, title: string, hotfixPrShas: Set<string>):
  *
  * @param cwd  Optional working directory (defaults to process.cwd())
  */
-export async function computeHotfixDensity(
-  cwd: string | undefined,
-  deps: Deps,
-): Promise<HotfixDensityResult> {
+export async function computeHotfixDensity(cwd: string | undefined, deps: Deps): Promise<HotfixDensityResult> {
   const { anchorDate, anchorSource, anchorWarn } = await resolveAnchor(cwd, deps)
 
   const commits = await listCommitsSince(anchorDate, cwd, deps)

--- a/plugins/dev-core/skills/promote/preflight.sh
+++ b/plugins/dev-core/skills/promote/preflight.sh
@@ -37,3 +37,22 @@ echo "---ci---"
 gh api repos/:owner/:repo/commits/staging/check-runs \
   --jq '[.check_runs[] | {name, conclusion}] | group_by(.conclusion) | map({conclusion: .[0].conclusion, count: length})' \
   2>/dev/null || echo "ci=unknown"
+
+echo "---hotfix_density---"
+# Advisory-only: compute hotfix density since last tag/promotion-merge/30d fallback.
+# Never exits non-zero; failures emit a structured error line.
+node --input-type=module <<'EOF' 2>/dev/null || echo "hotfix_density=error"
+import { computeHotfixDensity, formatResult } from '${CLAUDE_SKILL_DIR}/lib/hotfix-density.js'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+const execFileAsync = promisify(execFile)
+const deps = {
+  run: async (cmd, cwd) => {
+    const [bin, ...args] = cmd
+    const { stdout } = await execFileAsync(bin, args, { cwd: cwd ?? process.cwd() })
+    return stdout.trim()
+  },
+}
+const result = await computeHotfixDensity(process.cwd(), deps)
+console.log(formatResult(result))
+EOF

--- a/plugins/dev-core/skills/promote/preflight.sh
+++ b/plugins/dev-core/skills/promote/preflight.sh
@@ -41,18 +41,8 @@ gh api repos/:owner/:repo/commits/staging/check-runs \
 echo "---hotfix_density---"
 # Advisory-only: compute hotfix density since last tag/promotion-merge/30d fallback.
 # Never exits non-zero; failures emit a structured error line.
-node --input-type=module <<'EOF' 2>/dev/null || echo "hotfix_density=error"
-import { computeHotfixDensity, formatResult } from '${CLAUDE_SKILL_DIR}/lib/hotfix-density.js'
-import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
-const execFileAsync = promisify(execFile)
-const deps = {
-  run: async (cmd, cwd) => {
-    const [bin, ...args] = cmd
-    const { stdout } = await execFileAsync(bin, args, { cwd: cwd ?? process.cwd() })
-    return stdout.trim()
-  },
-}
-const result = await computeHotfixDensity(process.cwd(), deps)
-console.log(formatResult(result))
-EOF
+# BASH_SOURCE resolves to the real skill-dir path at runtime (cache or marketplace);
+# bun runs the .ts source directly (no build step) — its import.meta.main block wires
+# the git/gh IO deps and prints the formatted line.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bun run "${SCRIPT_DIR}/lib/hotfix-density.ts" 2>/dev/null || echo "hotfix_density=error"


### PR DESCRIPTION
## Summary

Implements the hotfix-density pre-flight check for `/promote` as specified in #283.

- Measures ratio of hotfix-class commits in staging since the last release tag / promotion merge / 30-day fallback
- Emits `green` / `warn` / `pause` advisory signal — never hard-blocks
- Single batched `gh pr list` query (no per-commit API calls)
- All I/O injected via `Deps` interface for pure-logic testability

## Files changed

| File | Type | Description |
|------|------|-------------|
| `plugins/dev-core/skills/promote/lib/hotfix-density.ts` | NEW | IO-injected implementation; exported threshold SSoT constants |
| `plugins/dev-core/skills/promote/__tests__/hotfix-density.test.ts` | NEW | 47 unit tests |
| `plugins/dev-core/skills/promote/preflight.sh` | UPDATED | `---hotfix_density---` section after `---ci---`; advisory, degrades gracefully |
| `plugins/dev-core/skills/promote/SKILL.md` | UPDATED | Pre-flight table row + `hotfix_density` in emits line |

## Acceptance criteria → evidence

| AC | Evidence |
|----|----------|
| Window anchor: last tag → promotion-merge → 30d fallback with warn | `resolveAnchor` — 3-priority logic; `resolveAnchor` tests (6) cover all three paths |
| Classify union: `/^fix:/i` OR `hotfix` PR label | `isHotfix` — regex union + set lookup; 9 tests including case-insensitive fix:/Fix:/FIX: |
| Batched API: single `gh pr list` call, never per-commit | `fetchHotfixPrShas` — one `gh pr list --search 'label:hotfix merged:>=...'`; 4 tests |
| Thresholds: <20% green, 20–40% warn, >40% pause | `THRESHOLD_GREEN=0.2`, `THRESHOLD_WARN=0.4`, `THRESHOLD_PAUSE=THRESHOLD_WARN`; 8 boundary tests |
| Advisory-only: never hard-block | `preflight.sh` uses `\|\| echo "hotfix_density=error"`; section never exits non-zero |
| Squash caveat | `anchorWarn` field in fallback-30d path; `formatResult` emits `note:` line |
| 47 tests pass | `bun run test -- plugins/dev-core/skills/promote/__tests__/hotfix-density.test.ts` → Tests 47 passed (47) in 91ms |
| Stays within listed files only | Exactly 4 files changed — the 4 specified in the issue |

## Test plan

- [ ] `bun run test -- plugins/dev-core/skills/promote/__tests__/hotfix-density.test.ts` → 47 passed
- [ ] Verify `preflight.sh` `---hotfix_density---` section present and advisory (no `exit 1` path)
- [ ] Verify `SKILL.md` pre-flight table has Hotfix density row with correct thresholds
- [ ] Verify exported constants: `THRESHOLD_GREEN=0.2`, `THRESHOLD_WARN=0.4`, `THRESHOLD_PAUSE=0.4`
- [ ] Manual: run `/promote --dry-run` on a repo with some fix: commits, confirm density line in output

Closes #283

---
Generated with [Claude Code](https://claude.com/claude-code)