### PR TITLE
fix(dev-init): auto-merge lazy-sync + App-token generator parity (#281)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -58,6 +58,16 @@ jobs:
             exit 1
           fi
 
+      - name: Update branch (lazy sync for late joiners)
+        if: contains(github.event.pull_request.labels.*.name, 'reviewed')
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/update-branch" \
+            --method PUT -f expected_head_sha="$PR_HEAD_SHA" || true
+
       - name: Enable auto-merge (merge commit)
         run: gh pr merge "$PR_NUMBER" --auto --merge --repo "$GITHUB_REPOSITORY"
         env:

--- a/plugins/dev-init/skills/init/__tests__/workflows.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/workflows.test.ts
@@ -22,13 +22,16 @@ describe('generateAutoMergeYml', () => {
 
   it('emits the lazy-sync update-branch step gated by reviewed in the auto-merge job', () => {
     const yml = generateAutoMergeYml()
-    // The step must appear in the auto-merge job section (before update-behind-prs job)
-    const autoMergeJobSection = yml.split('update-behind-prs:')[0]
-    expect(autoMergeJobSection).toContain('Update branch (lazy sync for late joiners)')
-    expect(autoMergeJobSection).toContain("contains(github.event.pull_request.labels.*.name, 'reviewed')")
-    expect(autoMergeJobSection).toContain('update-branch')
-    expect(autoMergeJobSection).toContain('steps.app.outputs.token')
-    expect(autoMergeJobSection).toContain('|| true')
+    // Narrow to the lazy-sync step block only (from step name to next step name)
+    const lazySyncMatch = yml.match(/- name: Update branch \(lazy sync for late joiners\)[\s\S]*?(?=\n {6}- name:)/)
+    expect(lazySyncMatch).not.toBeNull()
+    const lazySyncStep = lazySyncMatch![0]
+    // The if: guard must appear INSIDE the step block itself (not just at job level)
+    expect(lazySyncStep).toContain("if: contains(github.event.pull_request.labels.*.name, 'reviewed')")
+    expect(lazySyncStep).toContain('update-branch')
+    // The step uses the app token
+    expect(lazySyncStep).toContain('steps.app.outputs.token')
+    expect(lazySyncStep).toContain('|| true')
   })
 
   it('lazy-sync step appears BEFORE enable auto-merge step', () => {
@@ -50,6 +53,14 @@ describe('generateAutoMergeYml', () => {
     const yml = generateAutoMergeYml()
     const updateBehindSection = yml.split('update-behind-prs:')[1]
     expect(updateBehindSection).toContain("github.event_name == 'push'")
+  })
+
+  it('update-behind-prs job includes the App token mint step', () => {
+    const yml = generateAutoMergeYml()
+    const updateBehindSection = yml.split('update-behind-prs:')[1]
+    expect(updateBehindSection).toContain('actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1')
+    expect(updateBehindSection).toContain('vars.ROXABI_CI_APP_ID')
+    expect(updateBehindSection).toContain('secrets.ROXABI_CI_APP_PRIVATE_KEY')
   })
 })
 

--- a/plugins/dev-init/skills/init/__tests__/workflows.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/workflows.test.ts
@@ -25,7 +25,7 @@ describe('generateAutoMergeYml', () => {
     // Narrow to the lazy-sync step block only (from step name to next step name)
     const lazySyncMatch = yml.match(/- name: Update branch \(lazy sync for late joiners\)[\s\S]*?(?=\n {6}- name:)/)
     expect(lazySyncMatch).not.toBeNull()
-    const lazySyncStep = lazySyncMatch![0]
+    const lazySyncStep = lazySyncMatch?.[0]
     // The if: guard must appear INSIDE the step block itself (not just at job level)
     expect(lazySyncStep).toContain("if: contains(github.event.pull_request.labels.*.name, 'reviewed')")
     expect(lazySyncStep).toContain('update-branch')

--- a/plugins/dev-init/skills/init/__tests__/workflows.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/workflows.test.ts
@@ -1,5 +1,57 @@
 import { describe, expect, it } from 'vitest'
-import { generateCiYml, generateDeployYml } from '../lib/workflows'
+import { generateAutoMergeYml, generateCiYml, generateDeployYml } from '../lib/workflows'
+
+describe('generateAutoMergeYml', () => {
+  it('emits the App token mint step (no secrets.PAT)', () => {
+    const yml = generateAutoMergeYml()
+    expect(yml).toContain('actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1')
+    expect(yml).toContain('vars.ROXABI_CI_APP_ID')
+    expect(yml).toContain('secrets.ROXABI_CI_APP_PRIVATE_KEY')
+    expect(yml).not.toContain('secrets.PAT')
+  })
+
+  it('uses steps.app.outputs.token (not PAT) for all GH_TOKEN references', () => {
+    const yml = generateAutoMergeYml()
+    // Every GH_TOKEN assignment must reference the App token
+    const ghTokenMatches = [...yml.matchAll(/GH_TOKEN:\s*\$\{\{[^}]+\}\}/g)].map((m) => m[0])
+    expect(ghTokenMatches.length).toBeGreaterThan(0)
+    for (const match of ghTokenMatches) {
+      expect(match).toContain('steps.app.outputs.token')
+    }
+  })
+
+  it('emits the lazy-sync update-branch step gated by reviewed in the auto-merge job', () => {
+    const yml = generateAutoMergeYml()
+    // The step must appear in the auto-merge job section (before update-behind-prs job)
+    const autoMergeJobSection = yml.split('update-behind-prs:')[0]
+    expect(autoMergeJobSection).toContain('Update branch (lazy sync for late joiners)')
+    expect(autoMergeJobSection).toContain("contains(github.event.pull_request.labels.*.name, 'reviewed')")
+    expect(autoMergeJobSection).toContain('update-branch')
+    expect(autoMergeJobSection).toContain('steps.app.outputs.token')
+    expect(autoMergeJobSection).toContain('|| true')
+  })
+
+  it('lazy-sync step appears BEFORE enable auto-merge step', () => {
+    const yml = generateAutoMergeYml()
+    const lazyIdx = yml.indexOf('Update branch (lazy sync for late joiners)')
+    const mergeIdx = yml.indexOf('Enable auto-merge (merge commit)')
+    expect(lazyIdx).toBeGreaterThan(-1)
+    expect(mergeIdx).toBeGreaterThan(-1)
+    expect(lazyIdx).toBeLessThan(mergeIdx)
+  })
+
+  it('update-behind-prs job still filters reviewed label (regression guard)', () => {
+    const yml = generateAutoMergeYml()
+    const updateBehindSection = yml.split('update-behind-prs:')[1]
+    expect(updateBehindSection).toContain('--label reviewed')
+  })
+
+  it('update-behind-prs job runs only on push (regression guard)', () => {
+    const yml = generateAutoMergeYml()
+    const updateBehindSection = yml.split('update-behind-prs:')[1]
+    expect(updateBehindSection).toContain("github.event_name == 'push'")
+  })
+})
 
 describe('generateCiYml', () => {
   it('generates bun + vitest CI', () => {

--- a/plugins/dev-init/skills/init/lib/workflows.ts
+++ b/plugins/dev-init/skills/init/lib/workflows.ts
@@ -4,6 +4,7 @@
  */
 
 import { run } from '../../shared/adapters/github-adapter'
+import { APP_MINT_STEP } from '../../shared/adapters/github-infra'
 
 export interface WorkflowOpts {
   stack: 'bun' | 'node' | 'python'
@@ -50,10 +51,12 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'reviewed')
     timeout-minutes: 5
     steps:
+${APP_MINT_STEP}
+
       - name: Block dependabot semver-major bumps
         if: github.event.pull_request.user.login == 'dependabot[bot]'
         env:
-          GH_TOKEN: \${{ secrets.PAT }}
+          GH_TOKEN: \${{ steps.app.outputs.token }}
           PR_NUMBER: \${{ github.event.pull_request.number }}
           PR_TITLE: \${{ github.event.pull_request.title }}
         run: |
@@ -64,10 +67,20 @@ jobs:
             exit 1
           fi
 
+      - name: Update branch (lazy sync for late joiners)
+        if: contains(github.event.pull_request.labels.*.name, 'reviewed')
+        env:
+          GH_TOKEN: \${{ steps.app.outputs.token }}
+          PR_NUMBER: \${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: \${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api "repos/\${{ github.repository }}/pulls/$PR_NUMBER/update-branch" \\
+            --method PUT -f expected_head_sha="$PR_HEAD_SHA" || true
+
       - name: Enable auto-merge (merge commit)
         run: gh pr merge "$PR_NUMBER" --auto --merge --repo "$GITHUB_REPOSITORY"
         env:
-          GH_TOKEN: \${{ secrets.PAT }}
+          GH_TOKEN: \${{ steps.app.outputs.token }}
           PR_NUMBER: \${{ github.event.pull_request.number }}
 
   update-behind-prs:
@@ -76,6 +89,8 @@ jobs:
     if: github.event_name == 'push'
     timeout-minutes: 5
     steps:
+${APP_MINT_STEP}
+
       - name: Update all reviewed PRs targeting this branch
         run: |
           BRANCH="\${GITHUB_REF_NAME}"
@@ -92,7 +107,7 @@ jobs:
               --method PUT -f expected_head_sha="$SHA" || true
           done
         env:
-          GH_TOKEN: \${{ secrets.PAT }}
+          GH_TOKEN: \${{ steps.app.outputs.token }}
 
   close-linked-issues:
     name: Close linked issues

--- a/plugins/dev-init/skills/init/lib/workflows.ts
+++ b/plugins/dev-init/skills/init/lib/workflows.ts
@@ -74,7 +74,7 @@ ${APP_MINT_STEP}
           PR_NUMBER: \${{ github.event.pull_request.number }}
           PR_HEAD_SHA: \${{ github.event.pull_request.head.sha }}
         run: |
-          gh api "repos/\${{ github.repository }}/pulls/$PR_NUMBER/update-branch" \\
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/update-branch" \\
             --method PUT -f expected_head_sha="$PR_HEAD_SHA" || true
 
       - name: Enable auto-merge (merge commit)


### PR DESCRIPTION
## Summary

- **Lazy sync (late joiners):** add `Update branch (lazy sync for late joiners)` step to the `auto-merge` job, BEFORE `Enable auto-merge`, gated by `reviewed` label, using `steps.app.outputs.token`, with `|| true` to swallow 422 (already up-to-date). PRs that receive `reviewed` between staging pushes no longer sit behind until the next push.
- **Generator App-token parity:** `generateAutoMergeYml()` now imports `APP_MINT_STEP` from `github-infra.ts`, injects it at the top of both jobs (`auto-merge` and `update-behind-prs`), and replaces all 3 `secrets.PAT` refs with `steps.app.outputs.token`. No new `secrets.PAT` introduced anywhere.
- **Test coverage:** 6 new tests for `generateAutoMergeYml` covering App token emission, no-PAT assertion, lazy-sync step presence/ordering, and regression guards on `update-behind-prs`.

Closes #281

## SC → Test matrix

| Scenario | Test |
|---|---|
| App mint step emitted (SHA-pinned, no PAT) | `emits the App token mint step (no secrets.PAT)` |
| All `GH_TOKEN` refs use `steps.app.outputs.token` | `uses steps.app.outputs.token (not PAT) for all GH_TOKEN references` |
| Lazy-sync step in auto-merge job, gated by `reviewed` | `emits the lazy-sync update-branch step gated by reviewed in the auto-merge job` |
| Lazy-sync step appears BEFORE enable-auto-merge | `lazy-sync step appears BEFORE enable auto-merge step` |
| `update-behind-prs` still filters `reviewed` label | `update-behind-prs job still filters reviewed label (regression guard)` |
| `update-behind-prs` runs only on `push` | `update-behind-prs job runs only on push (regression guard)` |

## Security

- Branch updates use `steps.app.outputs.token` (roxabi-ci App) — never `github.token`/`GITHUB_TOKEN`. Anti-recursion guarantee preserved.
- TruffleHog: 0 verified secrets, 0 unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)