### PR TITLE
feat(dev-core): executed falsification gate — prove tests fail when feature breaks (#280)

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/agents/tester.md
+++ b/plugins/dev-core/agents/tester.md
@@ -49,7 +49,7 @@ Generate + maintain + validate tests. Testing Trophy: integration = largest laye
 - Shim test passes even if shim re-exports stale inline copy instead of delegating
 - Protocol method removed → no conformance test catches the divergence
 
-**Correct pattern:** negative test fails when the guard is removed. Verify by mentally deleting the guard — if the test still passes, it is tautological and must be flagged.
+**Correct pattern:** negative test fails when the guard is removed. The implement orchestrator (or domain agent owning source) MUST execute the falsification gate (#280): `git stash` source → run test → assert FAIL → `git stash pop` → assert green → record evidence `broke {source} → test failed with {error}`. ¬mental-only check — executed evidence line is required. A test without a recorded evidence line is treated as unproven (Status `⏳ not run`), not `✓ proven`. Tautological result (stash → still passes) → flag as merge blocker; do NOT record as `✓ proven`.
 
 ## Coverage Rules (CRITICAL)
 

--- a/plugins/dev-core/skills/implement/SKILL.md
+++ b/plugins/dev-core/skills/implement/SKILL.md
@@ -230,6 +230,33 @@ For τ=F (F-lite or F-full):
 - `✗ failed` — test ran red (set by #280 gate; note: `broke X → test failed with Y`)
 - `⚠ NO TEST — {reason}` — no test; reason ∈ enum
 
+### Step 6b — Falsification Gate (#280)
+
+Runs immediately after SC→Test Matrix is built. Scope: unit + fast-integration tests only. e2e tests are **exempt** — annotate each e2e row `⚠ NO FALSIFY — e2e` in the evidence log and leave Status unchanged.
+
+∀ new/modified test mapped in the matrix (¬e2e):
+
+1. **Stash source** (¬test files): `git stash -- $(git diff HEAD --name-only | grep -v '\.test\.' | grep -v '\.spec\.')` — stash implementation only.
+2. **Run the test**: `{commands.test} {test_file}`.
+3. **Assert FAIL**: if exit 0 → test is **tautological** (passes without the implementation) → blocking gap. Do NOT pop stash. Report: `TAUTOLOGICAL: {file} :: {test name} — passed with implementation stashed`. ¬proceed to `/pr` until test is fixed.
+4. **Pop stash**: `git stash pop`.
+5. **Assert GREEN**: re-run `{commands.test} {test_file}` → exit 0. If ✗ → stash pop corrupted state → escalate to lead.
+6. **Record evidence**: one line per test:
+   ```
+   broke {source file} → test failed with {error/assertion message}
+   ```
+7. **Update Status**: set matrix row to `✓ proven` (green + falsified) or `✗ failed` (red on green run).
+
+**After all tests falsified**: append evidence block to summary output:
+
+```
+## Falsification Evidence
+broke {source A} → test failed with {error A}
+broke {source B} → test failed with {error B}
+```
+
+¬stash residue in working tree after gate completes — verify with `git status`.
+
 **Matrix format (fixed columns — parseable):**
 
 ````markdown

--- a/plugins/dev-core/skills/implement/SKILL.md
+++ b/plugins/dev-core/skills/implement/SKILL.md
@@ -234,12 +234,20 @@ For τ=F (F-lite or F-full):
 
 Runs immediately after SC→Test Matrix is built. Scope: unit + fast-integration tests only. e2e tests are **exempt** — annotate each e2e row `⚠ NO FALSIFY — e2e` in the evidence log and leave Status unchanged.
 
+**Precondition:** the implement agent must `git add` all newly created source files before the gate runs — the Write tool does NOT auto-stage, and unstaged new files are invisible to `git diff HEAD`.
+
 ∀ new/modified test mapped in the matrix (¬e2e):
 
-1. **Stash source** (¬test files): `git stash -- $(git diff HEAD --name-only | grep -v '\.test\.' | grep -v '\.spec\.')` — stash implementation only.
+1. **Stash source** (¬test files):
+   ```bash
+   SRC=$(  { git diff HEAD --name-only; git ls-files --others --exclude-standard; } \
+           | grep -v '\.test\.' | grep -v '\.spec\.' )
+   git stash -- $SRC
+   ```
+   This enumerates both tracked-dirty AND untracked source files, then excludes test/spec files.
 2. **Run the test**: `{commands.test} {test_file}`.
-3. **Assert FAIL**: if exit 0 → test is **tautological** (passes without the implementation) → blocking gap. Do NOT pop stash. Report: `TAUTOLOGICAL: {file} :: {test name} — passed with implementation stashed`. ¬proceed to `/pr` until test is fixed.
-4. **Pop stash**: `git stash pop`.
+3. **Assert FAIL**: if exit 0 → test is **tautological** (passes without the implementation) → blocking gap. Do NOT pop stash. Restore worktree: `git stash pop`. Report: `TAUTOLOGICAL: {file} :: {test name} — passed with implementation stashed`. ¬proceed to `/pr` until test is rewritten.
+4. **Pop stash** (success path only): `git stash pop`.
 5. **Assert GREEN**: re-run `{commands.test} {test_file}` → exit 0. If ✗ → stash pop corrupted state → escalate to lead.
 6. **Record evidence**: one line per test:
    ```
@@ -255,7 +263,7 @@ broke {source A} → test failed with {error A}
 broke {source B} → test failed with {error B}
 ```
 
-¬stash residue in working tree after gate completes — verify with `git status`.
+**Success path only:** ¬stash residue in working tree after gate completes — verify with `git status`. (On the tautological-blocking path the run halts before `/pr`; stash is popped as part of stopping, so no diff residue reaches the PR.)
 
 **Matrix format (fixed columns — parseable):**
 

--- a/plugins/dev-core/skills/test/SKILL.md
+++ b/plugins/dev-core/skills/test/SKILL.md
@@ -120,6 +120,26 @@ it('should return user by id', () => {
 ∀ approved τ: write via Write tool → `{commands.test} {test_file_path}` → report pass/fail.
 ∃ failures ⇒ → DP(A) show failing test + error → propose fix → re-run.
 
+## Step 8 — Falsification Gate (standalone `/test`)
+
+Applies to: unit + fast-integration tests only. Triggered after Step 7 green run. Owned by the calling agent (the agent that owns source drives the stash — ¬tester).
+
+**e2e exemption:** tests generated via `--e2e` → annotate each as `NO FALSIFY — e2e`. Stop. ¬run stash cycle.
+
+∀ new/modified test written in this session:
+
+1. **Stash source** (¬test files): `git stash -- $(git diff HEAD --name-only | grep -v '\.test\.' | grep -v '\.spec\.')`.
+2. **Run the test**: `{commands.test} {test_file_path}`.
+3. **Assert FAIL**: exit 0 → tautological → → DP(A) **Fix test** | **Flag and skip** (¬silently pass). Tautological = merge blocker.
+4. **Pop stash**: `git stash pop`.
+5. **Assert GREEN**: re-run → exit 0.
+6. **Record evidence** (one line per test):
+   ```
+   broke {source file} → test failed with {error/assertion message}
+   ```
+
+Evidence lines feed the #279 matrix `Status` column: `✓ proven`. Tautological test → `✗ failed` (the test itself is the failure). Append evidence block to output before reporting done.
+
 ## E2E Mode (`--e2e`)
 
 Check Playwright:

--- a/plugins/dev-core/skills/test/SKILL.md
+++ b/plugins/dev-core/skills/test/SKILL.md
@@ -122,23 +122,31 @@ it('should return user by id', () => {
 
 ## Step 8 — Falsification Gate (standalone `/test`)
 
-Applies to: unit + fast-integration tests only. Triggered after Step 7 green run. Owned by the calling agent (the agent that owns source drives the stash — ¬tester).
+Applies to: unit + fast-integration tests only. Triggered after Step 7 green run. **Ownership:** when invoked by `/implement`, the implement orchestrator drives the stash (¬tester). When invoked standalone (no implement orchestrator), `/test` owns the stash cycle itself — the tester agent still only writes tests; the stash is driven by the `/test` flow.
 
-**e2e exemption:** tests generated via `--e2e` → annotate each as `NO FALSIFY — e2e`. Stop. ¬run stash cycle.
+**e2e exemption:** tests generated via `--e2e` → annotate each as `⚠ NO FALSIFY — e2e`. Stop. ¬run stash cycle.
+
+**Precondition:** all newly created source files must be `git add`-ed before the gate runs — the Write tool does NOT auto-stage new files, and unstaged new files are invisible to `git diff HEAD`.
 
 ∀ new/modified test written in this session:
 
-1. **Stash source** (¬test files): `git stash -- $(git diff HEAD --name-only | grep -v '\.test\.' | grep -v '\.spec\.')`.
+1. **Stash source** (¬test files):
+   ```bash
+   SRC=$(  { git diff HEAD --name-only; git ls-files --others --exclude-standard; } \
+           | grep -v '\.test\.' | grep -v '\.spec\.' )
+   git stash -- $SRC
+   ```
+   This enumerates both tracked-dirty AND untracked source files, then excludes test/spec files.
 2. **Run the test**: `{commands.test} {test_file_path}`.
-3. **Assert FAIL**: exit 0 → tautological → → DP(A) **Fix test** | **Flag and skip** (¬silently pass). Tautological = merge blocker.
-4. **Pop stash**: `git stash pop`.
+3. **Assert FAIL**: exit 0 → tautological → tautological = merge blocker. Do NOT pop stash. Restore worktree: `git stash pop`. DP(A) **Rewrite test** | **Flag and block** (¬silently pass). ¬assign a matrix Status — no Status update until the test is rewritten and re-run.
+4. **Pop stash** (success path only): `git stash pop`.
 5. **Assert GREEN**: re-run → exit 0.
 6. **Record evidence** (one line per test):
    ```
    broke {source file} → test failed with {error/assertion message}
    ```
 
-Evidence lines feed the #279 matrix `Status` column: `✓ proven`. Tautological test → `✗ failed` (the test itself is the failure). Append evidence block to output before reporting done.
+Evidence lines feed the #279 matrix `Status` column: `✓ proven`. Append evidence block to output before reporting done.
 
 ## E2E Mode (`--e2e`)
 


### PR DESCRIPTION
## Summary

- Upgrades the Negative-Test Rule from a mental check to an executed falsification gate across 3 files
- `implement/SKILL.md`: adds Step 6b (gate runs immediately after SC→Test Matrix; stash → FAIL → pop → green → evidence)
- `test/SKILL.md`: adds Step 8 (standalone `/test` gate; owned by calling agent; e2e exempt)
- `agents/tester.md`: replaces "mentally deleting the guard" with the mandatory executed protocol; unproven test = `⏳ not run`, tautological = merge blocker
- `plugin.json`: version bump 0.8.1 → 0.8.2 (triggered by check-skill-version hook)

Closes #280

## SC→Test Matrix

| SC | Test file | Test name | Status |
|----|-----------|-----------|--------|
| implement Step 6b: stash source → assert FAIL | — | — | ⚠ NO TEST — prompt-logic-only |
| implement Step 6b: pop stash → assert GREEN | — | — | ⚠ NO TEST — prompt-logic-only |
| implement Step 6b: tautological → blocking gap reported | — | — | ⚠ NO TEST — prompt-logic-only |
| implement Step 6b: evidence line appended to summary | — | — | ⚠ NO TEST — prompt-logic-only |
| implement Step 6b: e2e rows annotated NO FALSIFY | — | — | ⚠ NO TEST — prompt-logic-only |
| test Step 8: gate owned by calling agent (¬tester) | — | — | ⚠ NO TEST — prompt-logic-only |
| test Step 8: e2e → annotate NO FALSIFY, stop | — | — | ⚠ NO TEST — prompt-logic-only |
| test Step 8: tautological → DP(A) Fix \| Flag, ¬silently pass | — | — | ⚠ NO TEST — prompt-logic-only |
| tester.md: ¬mental-only — evidence line required | — | — | ⚠ NO TEST — prompt-logic-only |
| tester.md: no evidence line → Status ⏳ not run | — | — | ⚠ NO TEST — prompt-logic-only |
| tester.md: tautological → merge blocker, ¬✓ proven | — | — | ⚠ NO TEST — prompt-logic-only |

All rows `⚠ NO TEST — prompt-logic-only`: gate logic lives in LLM-executed SKILL.md instructions; no executable test harness can assert that an agent follows a process step.

## Test plan

- [x] `bun run test` — 492 tests passing (33 files)
- [x] `tools/validate_plugins.py` — all checks pass
- [x] lefthook pre-commit: detectLocalPath-guard, license-check, trufflehog, typecheck, conventional-commits — all green
- [x] lefthook pre-push: check-no-claude-comments, test, trufflehog, check-skill-version — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)