### PR TITLE
feat(checkup): dead-gate detector — flag CI gates that never run (#278)

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
@@ -296,7 +296,7 @@ describe('checkDeadGates (integration via subprocess)', () => {
         '  "api repos/TestOrg/test-repo/branches/staging") echo "{}"; exit 0 ;;',
         '  "api repos/TestOrg/test-repo/branches/main") echo "{}"; exit 0 ;;',
         // push run count: return 0 (no push runs landed)
-        '  "run list"*"--event" "push"*"--json" "databaseId"*) echo "0"; exit 0 ;;',
+        '  "run list"*"--event"*"push"*"--json"*"databaseId"*) echo "0"; exit 0 ;;',
         // merge commit count: ≥5 merges
         '  "api repos/TestOrg/test-repo/commits"*) echo "7"; exit 0 ;;',
         '  "label list"*) echo "[]"; exit 0 ;;',
@@ -322,8 +322,10 @@ describe('checkDeadGates (integration via subprocess)', () => {
     expect(result.stdout).toContain('Dead Gates')
   })
 
-  it('AC-4 + AC-5: flags push-gate dead gate in JSON output', () => {
-    // Write a push-triggered workflow with unsafe token
+  it('AC-4: flags push-gate dead gate in JSON output (push-gate history sentinel)', () => {
+    // Write a push-triggered workflow using a safe App token so that token taxonomy passes —
+    // only the push-gate history sub-check (0 push runs + ≥5 merges) can produce a fail.
+    // This isolates AC-4: a regression in push-gate logic stays visible even if token taxonomy passes.
     const wfDir = path.join(tmpDir, '.github', 'workflows')
     fs.mkdirSync(wfDir, { recursive: true })
     fs.writeFileSync(
@@ -337,21 +339,32 @@ describe('checkDeadGates (integration via subprocess)', () => {
         '  build:',
         '    runs-on: ubuntu-latest',
         '    steps:',
+        '      - name: Mint app token',
+        '        id: app',
+        '        uses: actions/create-github-app-token@v1',
+        '        with:',
+        '          app-id: ${{ vars.APP_ID }}',
+        '          private-key: ${{ secrets.APP_PRIVATE_KEY }}',
         '      - name: Push',
         '        run: git push',
         '        env:',
-        '          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}',
+        '          GH_TOKEN: ${{ steps.app.outputs.token }}',
       ].join('\n'),
     )
 
     const result = runDoctor(tmpDir, ['--json'])
-    const parsed = JSON.parse(result.stdout) as Array<{ name: string; checks: Array<{ status: string }> }>
+    const parsed = JSON.parse(result.stdout) as Array<{
+      name: string
+      checks: Array<{ name?: string; status: string; detail?: string }>
+    }>
 
     const deadGatesSection = parsed.find((s) => s.name === 'Dead Gates')
     expect(deadGatesSection).toBeDefined()
-    // Should have at least one fail (token taxonomy)
-    const hasFail = deadGatesSection?.checks.some((c) => c.status === 'fail')
-    expect(hasFail).toBe(true)
+    // Must have a push-gate history fail with the canonical sentinel phrase
+    const pushGateFail = deadGatesSection?.checks.find(
+      (c) => c.status === 'fail' && c.detail?.includes('never actually runs on pushes'),
+    )
+    expect(pushGateFail).toBeDefined()
   })
 
   it('AC-3: does not flag App token in push-triggered workflow', () => {
@@ -384,15 +397,17 @@ describe('checkDeadGates (integration via subprocess)', () => {
     const result = runDoctor(tmpDir, ['--json'])
     const parsed = JSON.parse(result.stdout) as Array<{
       name: string
-      checks: Array<{ status: string; detail?: string }>
+      checks: Array<{ name?: string; status: string; detail?: string }>
     }>
 
     const deadGatesSection = parsed.find((s) => s.name === 'Dead Gates')
     expect(deadGatesSection).toBeDefined()
 
-    // Token taxonomy check must NOT contain a 'dead' fail about this workflow
-    const tokenFails = deadGatesSection?.checks.filter((c) => c.status === 'fail' && c.detail?.includes('DEAD GATE'))
-    expect(tokenFails).toHaveLength(0)
+    // Token taxonomy check (name === 'token taxonomy') must NOT flag this workflow as a dead gate.
+    // Scope to the taxonomy check only — push-gate history checks use the same phrase but are separate.
+    const tokenTaxonomyCheck = deadGatesSection?.checks.find((c) => c.name === 'token taxonomy')
+    expect(tokenTaxonomyCheck).toBeDefined()
+    expect(tokenTaxonomyCheck?.status).not.toBe('fail')
   })
 
   it('AC-1 (read-only): doctor does not mutate repo or run state', () => {

--- a/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
@@ -191,6 +191,64 @@ describe('detectUnsafeTokenInTriggeredWorkflow', () => {
     })
   })
 
+  describe('AC-3b (review #296): job-level env + no safe-token masking', () => {
+    it('flags github.token declared at JOB-LEVEL env (not in a step)', () => {
+      const content = [
+        'name: Release',
+        'on:',
+        '  push:',
+        '    branches: [main]',
+        'jobs:',
+        '  publish:',
+        '    runs-on: ubuntu-latest',
+        '    env:',
+        '      GH_TOKEN: ${{ github.token }}',
+        '    steps:',
+        '      - run: gh release create',
+      ].join('\n')
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'release.yml')
+      const dead = issues.filter((i) => i.kind === 'dead')
+      expect(dead).toHaveLength(1)
+      expect(dead[0].step).toBe('(job-level env)')
+    })
+
+    it('flags a dead token even when a safe App token is present in the same step (no masking)', () => {
+      const content = [
+        'name: Auto Merge',
+        'on:',
+        '  push:',
+        '    branches: [staging]',
+        'jobs:',
+        '  merge:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Mixed',
+        '        run: gh pr merge',
+        '        env:',
+        '          APP: ${{ steps.app.outputs.token }}',
+        '          GH_TOKEN: ${{ github.token }}',
+      ].join('\n')
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'auto-merge.yml')
+      expect(issues.filter((i) => i.kind === 'dead')).toHaveLength(1)
+    })
+
+    it('flags secrets.PAT at job-level env as pat-warn', () => {
+      const content = [
+        'name: Sync',
+        'on: push',
+        'jobs:',
+        '  sync:',
+        '    runs-on: ubuntu-latest',
+        '    env:',
+        '      GH_TOKEN: ${{ secrets.PAT }}',
+        '    steps:',
+        '      - run: git push',
+      ].join('\n')
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'sync.yml')
+      expect(issues.filter((i) => i.kind === 'pat-warn')).toHaveLength(1)
+    })
+  })
+
   describe('edge cases', () => {
     it('does not flag push-triggered workflows with no token usage at all', () => {
       const content = [

--- a/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
@@ -1,0 +1,410 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { detectUnsafeTokenInTriggeredWorkflow } from '../doctor-github'
+
+/**
+ * Dead Gate detector — acceptance tests.
+ *
+ * AC-1: github.token / secrets.GITHUB_TOKEN in push-triggered steps → flagged as 'dead'
+ * AC-2: secrets.PAT in push-triggered steps → flagged as 'pat-warn' (not 'dead')
+ * AC-3: App token via actions/create-github-app-token → steps.<id>.outputs.token → NOT flagged
+ * AC-4: Push-gate merge-relative history: 0 push runs + ≥N merges → fail (integration via subprocess)
+ * AC-5: findings appear in 'Dead Gates' Section
+ */
+
+// ── Unit tests: detectUnsafeTokenInTriggeredWorkflow ──────────────────────────
+
+describe('detectUnsafeTokenInTriggeredWorkflow', () => {
+  describe('AC-1: github.token / GITHUB_TOKEN → flagged as dead', () => {
+    it('flags github.token in env of push-triggered step', () => {
+      const content = [
+        'name: Auto Merge',
+        'on:',
+        '  push:',
+        '    branches: [staging]',
+        'jobs:',
+        '  merge:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Trigger merge',
+        '        uses: some/action@v1',
+        '        with:',
+        '          token: ${{ github.token }}',
+      ].join('\n')
+
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'auto-merge.yml')
+
+      expect(issues).toHaveLength(1)
+      expect(issues[0].kind).toBe('dead')
+      expect(issues[0].token).toContain('github.token')
+      expect(issues[0].file).toBe('auto-merge.yml')
+      expect(issues[0].job).toBe('merge')
+    })
+
+    it('flags secrets.GITHUB_TOKEN in env of push-triggered step', () => {
+      const content = [
+        'name: CI',
+        'on:',
+        '  push:',
+        '    branches: [main]',
+        'jobs:',
+        '  build:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Push changes',
+        '        run: git push',
+        '        env:',
+        '          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}',
+      ].join('\n')
+
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'ci.yml')
+
+      expect(issues).toHaveLength(1)
+      expect(issues[0].kind).toBe('dead')
+      expect(issues[0].token).toContain('secrets.GITHUB_TOKEN')
+    })
+
+    it('flags github.token in compact on: [push] form', () => {
+      const content = [
+        'name: CI',
+        'on: [push, pull_request]',
+        'jobs:',
+        '  build:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Deploy',
+        '        run: deploy.sh',
+        '        env:',
+        '          TOKEN: ${{ github.token }}',
+      ].join('\n')
+
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'ci.yml')
+
+      expect(issues.some((i) => i.kind === 'dead')).toBe(true)
+    })
+
+    it('flags github.token in workflow_run-triggered step (bot trigger)', () => {
+      const content = [
+        'name: Bot Workflow',
+        'on:',
+        '  workflow_run:',
+        '    workflows: [CI]',
+        '    types: [completed]',
+        'jobs:',
+        '  bot:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Comment',
+        '        uses: some-action@v1',
+        '        with:',
+        '          token: ${{ github.token }}',
+      ].join('\n')
+
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'bot.yml')
+
+      expect(issues.some((i) => i.kind === 'dead')).toBe(true)
+    })
+  })
+
+  describe('AC-2: secrets.PAT → warn (not dead)', () => {
+    it('flags secrets.PAT as pat-warn, not dead', () => {
+      const content = [
+        'name: Auto Merge',
+        'on:',
+        '  push:',
+        '    branches: [staging]',
+        'jobs:',
+        '  merge:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Trigger',
+        '        uses: some/action@v1',
+        '        with:',
+        '          token: ${{ secrets.PAT }}',
+      ].join('\n')
+
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'auto-merge.yml')
+
+      expect(issues).toHaveLength(1)
+      expect(issues[0].kind).toBe('pat-warn')
+      // Must NOT be classified as dead
+      expect(issues.some((i) => i.kind === 'dead')).toBe(false)
+    })
+  })
+
+  describe('AC-3: App token via actions/create-github-app-token → NOT flagged', () => {
+    it('does not flag steps.<id>.outputs.token (App token pattern)', () => {
+      const content = [
+        'name: Auto Merge',
+        'on:',
+        '  push:',
+        '    branches: [staging]',
+        'jobs:',
+        '  merge:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Mint app token (roxabi-ci)',
+        '        id: app',
+        '        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1',
+        '        with:',
+        '          app-id: ${{ vars.ROXABI_CI_APP_ID }}',
+        '          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}',
+        '      - name: Trigger merge',
+        '        uses: some/action@v1',
+        '        with:',
+        '          token: ${{ steps.app.outputs.token }}',
+      ].join('\n')
+
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'auto-merge.yml')
+
+      // Zero issues — App token is the canonical safe pattern
+      expect(issues).toHaveLength(0)
+    })
+
+    it('does not false-positive on steps.<custom-id>.outputs.token', () => {
+      const content = [
+        'name: CI',
+        'on:',
+        '  push:',
+        '    branches: [main]',
+        'jobs:',
+        '  build:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Mint token',
+        '        id: roxabi-ci',
+        '        uses: actions/create-github-app-token@v3',
+        '        with:',
+        '          app-id: ${{ vars.APP_ID }}',
+        '          private-key: ${{ secrets.PRIVATE_KEY }}',
+        '      - name: Push',
+        '        run: git push',
+        '        env:',
+        '          GH_TOKEN: ${{ steps.roxabi-ci.outputs.token }}',
+      ].join('\n')
+
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'ci.yml')
+
+      expect(issues.filter((i) => i.kind === 'dead')).toHaveLength(0)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('does not flag push-triggered workflows with no token usage at all', () => {
+      const content = [
+        'name: CI',
+        'on: push',
+        'jobs:',
+        '  build:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - uses: actions/checkout@v4',
+        '      - run: bun test',
+      ].join('\n')
+
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'ci.yml')
+
+      expect(issues).toHaveLength(0)
+    })
+
+    it('does not flag non-push-triggered workflows using github.token (pull_request only)', () => {
+      const content = [
+        'name: PR Lint',
+        'on:',
+        '  pull_request:',
+        '    types: [opened, synchronize]',
+        'jobs:',
+        '  lint:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Comment',
+        '        uses: some/action@v1',
+        '        with:',
+        '          token: ${{ github.token }}',
+      ].join('\n')
+
+      const issues = detectUnsafeTokenInTriggeredWorkflow(content, 'pr-lint.yml')
+
+      // pull_request events ARE re-triggered — only push/bot-triggered is the dead-gate
+      expect(issues).toHaveLength(0)
+    })
+
+    it('returns empty array for empty content', () => {
+      const issues = detectUnsafeTokenInTriggeredWorkflow('', 'empty.yml')
+      expect(issues).toHaveLength(0)
+    })
+  })
+})
+
+// ── Integration tests: checkDeadGates section via subprocess ─────────────────
+
+const bunBin = Bun.spawnSync(['which', 'bun'], { stdout: 'pipe' })
+const bunBinPath = new TextDecoder().decode(bunBin.stdout).trim()
+const bunBinDir = path.dirname(bunBinPath)
+
+function makeFakeExec(tmpDir: string, name: string, script: string) {
+  const p = path.join(tmpDir, name)
+  fs.writeFileSync(p, `#!/bin/sh\n${script}\n`, { mode: 0o755 })
+  return p
+}
+
+function runDoctor(tmpDir: string, args: string[] = []) {
+  const doctorPath = path.resolve(__dirname, '../doctor.ts')
+  const proc = Bun.spawnSync([bunBinPath, 'run', doctorPath, ...args], {
+    cwd: tmpDir,
+    env: {
+      HOME: os.homedir(),
+      PATH: `${tmpDir}:${bunBinDir}:${process.env.PATH ?? ''}`,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  return {
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+    exitCode: proc.exitCode,
+  }
+}
+
+describe('checkDeadGates (integration via subprocess)', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dead-gate-test-'))
+
+    // Fake git: returns known remote
+    makeFakeExec(
+      tmpDir,
+      'git',
+      ['if [ "$1" = "remote" ]; then echo "git@github.com:TestOrg/test-repo.git"; exit 0; fi', 'exit 0'].join('\n'),
+    )
+
+    // Fake gh: authenticated, repo exists + is old enough, 0 push runs, N merges
+    makeFakeExec(
+      tmpDir,
+      'gh',
+      [
+        'case "$*" in',
+        '  "--version") echo "gh version 2.40.0"; exit 0 ;;',
+        '  "auth status") exit 0 ;;',
+        '  "auth token") echo "ghp_test"; exit 0 ;;',
+        // repo view: return old creation date so grace window passes
+        '  "repo view"*"createdAt"*) echo "2020-01-01T00:00:00Z"; exit 0 ;;',
+        // branches staging/main: exist
+        '  "api repos/TestOrg/test-repo/branches/staging") echo "{}"; exit 0 ;;',
+        '  "api repos/TestOrg/test-repo/branches/main") echo "{}"; exit 0 ;;',
+        // push run count: return 0 (no push runs landed)
+        '  "run list"*"--event" "push"*"--json" "databaseId"*) echo "0"; exit 0 ;;',
+        // merge commit count: ≥5 merges
+        '  "api repos/TestOrg/test-repo/commits"*) echo "7"; exit 0 ;;',
+        '  "label list"*) echo "[]"; exit 0 ;;',
+        '  "api"*) echo "{}"; exit 0 ;;',
+        '  *) exit 0 ;;',
+        'esac',
+      ].join('\n'),
+    )
+
+    // .env for GITHUB_REPO
+    fs.writeFileSync(
+      path.join(tmpDir, '.env'),
+      'GITHUB_REPO=TestOrg/test-repo\nGH_PROJECT_ID=PVT_123\nSTATUS_FIELD_ID=F1\nSIZE_FIELD_ID=F2\nPRIORITY_FIELD_ID=F3\n',
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('AC-5: Dead Gates section appears in output', () => {
+    const result = runDoctor(tmpDir)
+    expect(result.stdout).toContain('Dead Gates')
+  })
+
+  it('AC-4 + AC-5: flags push-gate dead gate in JSON output', () => {
+    // Write a push-triggered workflow with unsafe token
+    const wfDir = path.join(tmpDir, '.github', 'workflows')
+    fs.mkdirSync(wfDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(wfDir, 'ci.yml'),
+      [
+        'name: CI',
+        'on:',
+        '  push:',
+        '    branches: [staging]',
+        'jobs:',
+        '  build:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Push',
+        '        run: git push',
+        '        env:',
+        '          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}',
+      ].join('\n'),
+    )
+
+    const result = runDoctor(tmpDir, ['--json'])
+    const parsed = JSON.parse(result.stdout) as Array<{ name: string; checks: Array<{ status: string }> }>
+
+    const deadGatesSection = parsed.find((s) => s.name === 'Dead Gates')
+    expect(deadGatesSection).toBeDefined()
+    // Should have at least one fail (token taxonomy)
+    const hasFail = deadGatesSection?.checks.some((c) => c.status === 'fail')
+    expect(hasFail).toBe(true)
+  })
+
+  it('AC-3: does not flag App token in push-triggered workflow', () => {
+    const wfDir = path.join(tmpDir, '.github', 'workflows')
+    fs.mkdirSync(wfDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(wfDir, 'auto-merge.yml'),
+      [
+        'name: Auto Merge',
+        'on:',
+        '  push:',
+        '    branches: [staging]',
+        'jobs:',
+        '  merge:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Mint app token',
+        '        id: app',
+        '        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1',
+        '        with:',
+        '          app-id: ${{ vars.ROXABI_CI_APP_ID }}',
+        '          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}',
+        '      - name: Merge',
+        '        uses: some/action@v1',
+        '        with:',
+        '          token: ${{ steps.app.outputs.token }}',
+      ].join('\n'),
+    )
+
+    const result = runDoctor(tmpDir, ['--json'])
+    const parsed = JSON.parse(result.stdout) as Array<{
+      name: string
+      checks: Array<{ status: string; detail?: string }>
+    }>
+
+    const deadGatesSection = parsed.find((s) => s.name === 'Dead Gates')
+    expect(deadGatesSection).toBeDefined()
+
+    // Token taxonomy check must NOT contain a 'dead' fail about this workflow
+    const tokenFails = deadGatesSection?.checks.filter((c) => c.status === 'fail' && c.detail?.includes('DEAD GATE'))
+    expect(tokenFails).toHaveLength(0)
+  })
+
+  it('AC-1 (read-only): doctor does not mutate repo or run state', () => {
+    // Read-only: running doctor twice produces the same output
+    const result1 = runDoctor(tmpDir, ['--json'])
+    const result2 = runDoctor(tmpDir, ['--json'])
+
+    // Both runs parse successfully
+    expect(() => JSON.parse(result1.stdout)).not.toThrow()
+    expect(() => JSON.parse(result2.stdout)).not.toThrow()
+
+    // Outputs are identical (no state written between runs)
+    expect(result1.stdout).toBe(result2.stdout)
+  })
+})

--- a/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
@@ -425,6 +425,63 @@ describe('checkDeadGates (integration via subprocess)', () => {
     expect(pushGateFail).toBeDefined()
   })
 
+  it('SC3 grace window: a recently-added workflow is NOT flagged as a dead push-gate', () => {
+    // Override gh so the workflow's created_at is recent (< GRACE_DAYS). Even with an OLD
+    // repo + 0 push runs + ≥5 merges, a brand-new workflow has 0 runs because it is new,
+    // not dead — the per-workflow grace window must skip it.
+    makeFakeExec(
+      tmpDir,
+      'gh',
+      [
+        'case "$*" in',
+        '  "--version") echo "gh version 2.40.0"; exit 0 ;;',
+        '  "auth status") exit 0 ;;',
+        '  "auth token") echo "ghp_test"; exit 0 ;;',
+        '  "repo view"*"createdAt"*) echo "2020-01-01T00:00:00Z"; exit 0 ;;',
+        '  "api repos/TestOrg/test-repo/branches/staging") echo "{}"; exit 0 ;;',
+        '  "api repos/TestOrg/test-repo/branches/main") echo "{}"; exit 0 ;;',
+        '  "run list"*"--event"*"push"*"--json"*"databaseId"*) echo "0"; exit 0 ;;',
+        '  "api repos/TestOrg/test-repo/actions/workflows/"*) date -u -d "2 days ago" +%Y-%m-%dT%H:%M:%SZ; exit 0 ;;',
+        '  "api repos/TestOrg/test-repo/commits"*) echo "7"; exit 0 ;;',
+        '  "label list"*) echo "[]"; exit 0 ;;',
+        '  "api"*) echo "{}"; exit 0 ;;',
+        '  *) exit 0 ;;',
+        'esac',
+      ].join('\n'),
+    )
+    const wfDir = path.join(tmpDir, '.github', 'workflows')
+    fs.mkdirSync(wfDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(wfDir, 'ci.yml'),
+      [
+        'name: CI',
+        'on:',
+        '  push:',
+        '    branches: [staging]',
+        'jobs:',
+        '  build:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - name: Push',
+        '        run: git push',
+        '        env:',
+        '          GH_TOKEN: ${{ steps.app.outputs.token }}',
+      ].join('\n'),
+    )
+
+    const result = runDoctor(tmpDir, ['--json'])
+    const parsed = JSON.parse(result.stdout) as Array<{
+      name: string
+      checks: Array<{ name?: string; status: string; detail?: string }>
+    }>
+    const deadGatesSection = parsed.find((s) => s.name === 'Dead Gates')
+    expect(deadGatesSection).toBeDefined()
+    const pushGateFail = deadGatesSection?.checks.find(
+      (c) => c.status === 'fail' && c.detail?.includes('never actually runs on pushes'),
+    )
+    expect(pushGateFail).toBeUndefined()
+  })
+
   it('AC-3: does not flag App token in push-triggered workflow', () => {
     const wfDir = path.join(tmpDir, '.github', 'workflows')
     fs.mkdirSync(wfDir, { recursive: true })

--- a/plugins/dev-core/skills/checkup/cookbooks/devcore-checks.md
+++ b/plugins/dev-core/skills/checkup/cookbooks/devcore-checks.md
@@ -30,6 +30,7 @@
 | secret scanning / push protection disabled | `printf '%s' '{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}' \| gh api repos/<owner>/<repo> --method PATCH --input -` — free on public repos (printf: POSIX-safe, `<<<` is bash-only) |
 | Actions default permissions ≠ read | `gh api repos/<owner>/<repo>/actions/permissions/workflow --method PUT -f default_workflow_permissions=read -F can_approve_pull_request_reviews=false` |
 | `pull_request_target` checks out PR head | Switch trigger to `pull_request`, or drop the PR-head `ref:` from checkout — never run PR-authored code with secrets in scope |
+| `github.token` / `secrets.GITHUB_TOKEN` in push-triggered step | Replace with App token via `actions/create-github-app-token` → `${{ steps.app.outputs.token }}` — `GITHUB_TOKEN` pushes are silently dropped by GitHub Actions and never re-trigger `push` workflows (dead gate) |
 | `trufflehog` not in `.pre-commit-config.yaml` | Add the trufflehog repo/hook to `.pre-commit-config.yaml` (mirror an existing Roxabi Python repo) |
 | `trufflehog` not in CI | Add `secret-scan.yml` workflow — `/ci-setup` Phase 1b |
 | no hook manager at all | Run `/init` Phase 10d (lefthook) or add `.pre-commit-config.yaml` |

--- a/plugins/dev-core/skills/checkup/doctor-github.ts
+++ b/plugins/dev-core/skills/checkup/doctor-github.ts
@@ -674,13 +674,33 @@ export function detectUnsafeTokenInTriggeredWorkflow(
 const PUSH_GATE_MERGE_THRESHOLD = 5
 const GRACE_DAYS = 14
 
-function repoAgeOk(owner: string, repo: string): boolean {
-  const result = spawnSync(['gh', 'repo', 'view', `${owner}/${repo}`, '--json', 'createdAt', '--jq', '.createdAt'])
-  if (!result.ok || !result.stdout.trim()) return true // assume ok if can't check
+// Returns the age in days of the ISO timestamp in `result.stdout`, or Infinity when
+// it cannot be determined (fail-open: an unknown age never triggers a false dead-gate).
+function ageInDays(result: { ok: boolean; stdout: string }): number {
+  if (!result.ok || !result.stdout.trim()) return Number.POSITIVE_INFINITY
   const created = new Date(result.stdout.trim())
-  const ageMs = Date.now() - created.getTime()
-  const ageDays = ageMs / (1000 * 60 * 60 * 24)
-  return ageDays >= GRACE_DAYS
+  if (Number.isNaN(created.getTime())) return Number.POSITIVE_INFINITY
+  return (Date.now() - created.getTime()) / (1000 * 60 * 60 * 24)
+}
+
+export function repoAgeOk(owner: string, repo: string): boolean {
+  return (
+    ageInDays(spawnSync(['gh', 'repo', 'view', `${owner}/${repo}`, '--json', 'createdAt', '--jq', '.createdAt'])) >=
+    GRACE_DAYS
+  )
+}
+
+/**
+ * Grace window for a single workflow: a workflow file added recently to an OLD repo
+ * legitimately has 0 push runs yet — that is not a dead gate. Exported so #288
+ * (per-job dormancy) can reuse the same grace logic without duplicating it.
+ */
+export function workflowAgeOk(owner: string, repo: string, workflow: string): boolean {
+  return (
+    ageInDays(
+      spawnSync(['gh', 'api', `repos/${owner}/${repo}/actions/workflows/${workflow}`, '--jq', '.created_at']),
+    ) >= GRACE_DAYS
+  )
 }
 
 function countPushRuns(owner: string, repo: string, workflow: string, branch: string): number {
@@ -720,7 +740,9 @@ function countMergeCommits(owner: string, repo: string, branch: string, n: numbe
     '-f',
     `sha=${branch}`,
     '-f',
-    `per_page=${n * 3}`,
+    // Widen the lookback (≥100, the API page max) so sparse-merge repos — many direct
+    // commits between merges — can still reach the N-merge anchor (avoids false negatives).
+    `per_page=${Math.max(100, n * 4)}`,
   ])
   if (!result.ok) return -1
   const count = parseInt(result.stdout.trim(), 10)
@@ -818,6 +840,10 @@ export function checkDeadGates(ghOk: boolean, owner: string, repo: string): Sect
 
       const mergeCount = countMergeCommits(owner, repo, branch, PUSH_GATE_MERGE_THRESHOLD)
       if (mergeCount === -1 || mergeCount < PUSH_GATE_MERGE_THRESHOLD) continue
+
+      // Grace window on the WORKFLOW itself: a recently-added workflow (even on an old
+      // repo) has 0 push runs because it is new, not dead — don't false-flag it.
+      if (!workflowAgeOk(owner, repo, wf)) continue
 
       checks.push({
         name: `${wf}:${branch}:push-gate`,

--- a/plugins/dev-core/skills/checkup/doctor-github.ts
+++ b/plugins/dev-core/skills/checkup/doctor-github.ts
@@ -486,6 +486,332 @@ export function detectMissingContentsRead(
   return issues
 }
 
+// ---------------------------------------------------------------------------
+// Dead Gate detector
+// ---------------------------------------------------------------------------
+
+/**
+ * Unsafe token patterns in CI workflows — triggers a DEAD GATE finding.
+ *
+ * Anti-recursion rule: pushes made via `github.token` / `secrets.GITHUB_TOKEN`
+ * are silently dropped by GitHub Actions; the push workflow never re-triggers.
+ * This is a dead gate — CI appears wired but never actually runs on automation
+ * pushes.
+ *
+ * Safe patterns (must NOT false-positive):
+ *   - `secrets.PAT`  — legacy PAT, causes a warn not a fail
+ *   - `steps.<id>.outputs.token`  — App token via actions/create-github-app-token
+ */
+export function detectUnsafeTokenInTriggeredWorkflow(
+  content: string,
+  filePath: string,
+): Array<{ file: string; job: string; step: string; kind: 'dead' | 'pat-warn'; token: string }> {
+  const lines = content.split('\n')
+  const issues: Array<{ file: string; job: string; step: string; kind: 'dead' | 'pat-warn'; token: string }> = []
+
+  // --- 1. Determine if this workflow is push-triggered ---
+  // We look at the `on:` section at root level.
+  let isPushTriggered = false
+  let isBotTriggered = false // workflow_run, workflow_dispatch used by bots
+  let inOnBlock = false
+  let onIndent = -1
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    // Detect `on:` root key
+    if (/^on:\s*$/.test(line)) {
+      inOnBlock = true
+      onIndent = 0
+      continue
+    }
+    // Compact form: `on: [push, pull_request]` or `on: push`
+    if (/^on:\s+\S/.test(line)) {
+      const val = line.replace(/^on:\s+/, '').trim()
+      if (val.includes('push')) isPushTriggered = true
+      if (val.includes('workflow_run') || val.includes('workflow_dispatch')) isBotTriggered = true
+      break
+    }
+
+    if (inOnBlock) {
+      // End of on block when we hit another root-level key
+      if (/^\S/.test(line) && line.trim() && !line.trim().startsWith('#')) {
+        inOnBlock = false
+        break
+      }
+      const m = line.match(/^ {2}([a-zA-Z0-9_-]+):\s*/)
+      if (m) {
+        if (m[1] === 'push') isPushTriggered = true
+        if (m[1] === 'workflow_run' || m[1] === 'workflow_dispatch') isBotTriggered = true
+      }
+    }
+  }
+
+  // Only scan push-triggered workflows (or bot-triggered that use push semantics)
+  if (!isPushTriggered && !isBotTriggered) return issues
+
+  // --- 2. Detect steps using unsafe tokens ---
+  // We scan for env vars or `with:` fields containing the dangerous expressions.
+  // Safe: steps.<id>.outputs.token (App token)
+  // Dead: github.token, secrets.GITHUB_TOKEN
+  // Warn: secrets.PAT
+
+  const DEAD_PATTERNS = [/\$\{\{\s*github\.token\s*\}\}/, /\$\{\{\s*secrets\.GITHUB_TOKEN\s*\}\}/]
+  const PAT_PATTERN = /\$\{\{\s*secrets\.PAT\s*\}\}/
+  const SAFE_PATTERN = /\$\{\{\s*steps\.[a-zA-Z0-9_-]+\.outputs\.token\s*\}\}/
+
+  // Walk jobs section
+  let jobsSectionLine = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (/^jobs:\s*$/.test(lines[i])) {
+      jobsSectionLine = i
+      break
+    }
+  }
+  if (jobsSectionLine === -1) return issues
+
+  // Find job headers (2-space indent)
+  const jobHeaders: Array<{ name: string; start: number }> = []
+  for (let i = jobsSectionLine + 1; i < lines.length; i++) {
+    const m = lines[i].match(/^ {2}([a-zA-Z0-9][a-zA-Z0-9_-]*):\s*$/)
+    if (m) {
+      jobHeaders.push({ name: m[1], start: i })
+    } else if (/^\S/.test(lines[i]) && lines[i].trim() && !lines[i].trimStart().startsWith('#')) {
+      break
+    }
+  }
+
+  for (let j = 0; j < jobHeaders.length; j++) {
+    const { name: jobName, start } = jobHeaders[j]
+    const end = j + 1 < jobHeaders.length ? jobHeaders[j + 1].start : lines.length
+    const jobLines = lines.slice(start + 1, end)
+
+    // Find step names and step bodies
+    const stepHeaders: Array<{ name: string; start: number }> = []
+    for (let i = 0; i < jobLines.length; i++) {
+      const m = jobLines[i].match(/^ {6}- name:\s+(.+)$/)
+      if (m) {
+        stepHeaders.push({ name: m[1].trim(), start: i })
+      } else if (/^ {6}- uses:/.test(jobLines[i]) || /^ {6}- run:/.test(jobLines[i])) {
+        // Unnamed step
+        stepHeaders.push({ name: `(unnamed step ${stepHeaders.length + 1})`, start: i })
+      }
+    }
+
+    // Scan each step body for token usage
+    for (let s = 0; s < stepHeaders.length; s++) {
+      const stepStart = stepHeaders[s].start
+      const stepEnd = s + 1 < stepHeaders.length ? stepHeaders[s + 1].start : jobLines.length
+      const stepBody = jobLines.slice(stepStart, stepEnd).join('\n')
+
+      // Skip if it uses a safe App token — this step is the mint step itself or consumes app output
+      if (SAFE_PATTERN.test(stepBody)) continue
+
+      for (const pat of DEAD_PATTERNS) {
+        if (pat.test(stepBody)) {
+          const tokenMatch = stepBody.match(pat)
+          issues.push({
+            file: filePath,
+            job: jobName,
+            step: stepHeaders[s].name,
+            kind: 'dead',
+            token: tokenMatch ? tokenMatch[0] : 'github.token/GITHUB_TOKEN',
+          })
+          break // one finding per step
+        }
+      }
+
+      if (PAT_PATTERN.test(stepBody)) {
+        issues.push({
+          file: filePath,
+          job: jobName,
+          step: stepHeaders[s].name,
+          kind: 'pat-warn',
+          token: 'secrets.PAT',
+        })
+      }
+    }
+  }
+
+  return issues
+}
+
+/**
+ * Push-gate merge-relative history check.
+ *
+ * For each workflow targeting push on staging/main: fetch the last N+slack
+ * runs and compare how many were push-event vs how many merge commits landed.
+ * If 0 push runs while ≥N merges landed → DEAD GATE.
+ *
+ * Grace window: skip workflows/repos younger than GRACE_DAYS.
+ */
+const PUSH_GATE_MERGE_THRESHOLD = 5
+const GRACE_DAYS = 14
+
+function repoAgeOk(owner: string, repo: string): boolean {
+  const result = spawnSync(['gh', 'repo', 'view', `${owner}/${repo}`, '--json', 'createdAt', '--jq', '.createdAt'])
+  if (!result.ok || !result.stdout.trim()) return true // assume ok if can't check
+  const created = new Date(result.stdout.trim())
+  const ageMs = Date.now() - created.getTime()
+  const ageDays = ageMs / (1000 * 60 * 60 * 24)
+  return ageDays >= GRACE_DAYS
+}
+
+function countPushRuns(owner: string, repo: string, workflow: string, branch: string): number {
+  const result = spawnSync([
+    'gh',
+    'run',
+    'list',
+    '--repo',
+    `${owner}/${repo}`,
+    '--workflow',
+    workflow,
+    '--branch',
+    branch,
+    '--event',
+    'push',
+    '--limit',
+    '20',
+    '--json',
+    'databaseId',
+    '--jq',
+    'length',
+  ])
+  if (!result.ok) return -1
+  const n = parseInt(result.stdout.trim(), 10)
+  return Number.isNaN(n) ? -1 : n
+}
+
+function countMergeCommits(owner: string, repo: string, branch: string, n: number): number {
+  const result = spawnSync([
+    'gh',
+    'api',
+    `repos/${owner}/${repo}/commits`,
+    '--jq',
+    `[.[] | select(.commit.message | startswith("Merge"))] | length`,
+    '-X',
+    'GET',
+    '-f',
+    `sha=${branch}`,
+    '-f',
+    `per_page=${n * 3}`,
+  ])
+  if (!result.ok) return -1
+  const count = parseInt(result.stdout.trim(), 10)
+  return Number.isNaN(count) ? -1 : count
+}
+
+export function checkDeadGates(ghOk: boolean, owner: string, repo: string): Section {
+  const sectionName = 'Dead Gates'
+  const skip = (detail: string): Section => ({
+    name: sectionName,
+    checks: [{ name: 'token taxonomy + push-gate', status: 'skip' as Status, detail }],
+  })
+
+  if (!owner || !repo) return skip('repo not detected')
+
+  const checks: Check[] = []
+
+  // --- A. Token taxonomy (static YAML scan) ---
+  const wfDir = '.github/workflows'
+  const wfFiles: string[] = []
+  if (existsSync(wfDir)) {
+    for (const f of readdirSync(wfDir) as string[]) {
+      if (f.endsWith('.yml') || f.endsWith('.yaml')) {
+        wfFiles.push(`${wfDir}/${f}`)
+      }
+    }
+  }
+
+  if (wfFiles.length === 0) {
+    checks.push({ name: 'token taxonomy', status: 'skip', detail: 'no local workflow files found' })
+  } else {
+    const tokenIssues: Array<{ file: string; job: string; step: string; kind: 'dead' | 'pat-warn'; token: string }> = []
+    for (const filePath of wfFiles) {
+      let content: string
+      try {
+        content = readFileSync(filePath, 'utf8') as string
+      } catch {
+        checks.push({ name: filePath, status: 'warn', detail: 'could not read file — skipped' })
+        continue
+      }
+      tokenIssues.push(...detectUnsafeTokenInTriggeredWorkflow(content, filePath))
+    }
+
+    if (tokenIssues.length === 0) {
+      checks.push({
+        name: 'token taxonomy',
+        status: 'pass',
+        detail: `${wfFiles.length} workflow(s) checked — no unsafe token usage in push-triggered steps`,
+      })
+    } else {
+      for (const issue of tokenIssues) {
+        const fileName = issue.file.replace('.github/workflows/', '')
+        if (issue.kind === 'dead') {
+          checks.push({
+            name: `${fileName}:${issue.job}:${issue.step}`,
+            status: 'fail',
+            detail: `push/bot-triggered step uses ${issue.token} — DEAD GATE (GitHub drops pushes from GITHUB_TOKEN; workflow never re-triggers). Use App token or secrets.PAT.`,
+          })
+        } else {
+          checks.push({
+            name: `${fileName}:${issue.job}:${issue.step}`,
+            status: 'warn',
+            detail: `step uses secrets.PAT — legacy token (retiring org-wide). Migrate to App token (actions/create-github-app-token).`,
+          })
+        }
+      }
+    }
+  }
+
+  // --- B. Push-gate merge-relative history ---
+  if (!ghOk) {
+    checks.push({ name: 'push-gate history', status: 'skip', detail: 'gh CLI not available' })
+    return { name: sectionName, checks }
+  }
+  if (!repoAgeOk(owner, repo)) {
+    checks.push({
+      name: 'push-gate history',
+      status: 'skip',
+      detail: `repo younger than ${GRACE_DAYS} days — insufficient history`,
+    })
+    return { name: sectionName, checks }
+  }
+
+  // Only check protected branches (staging/main)
+  for (const branch of PROTECTED_BRANCHES) {
+    // Check if branch exists
+    const branchCheck = spawnSync(['gh', 'api', `repos/${owner}/${repo}/branches/${branch}`])
+    if (!branchCheck.ok) continue
+
+    // Check each standard workflow for push-gate health
+    for (const wf of STANDARD_WORKFLOWS) {
+      const pushCount = countPushRuns(owner, repo, wf, branch)
+      if (pushCount === -1) continue // workflow may not exist — skip
+      if (pushCount > 0) continue // at least some push runs landed — gate is alive
+
+      const mergeCount = countMergeCommits(owner, repo, branch, PUSH_GATE_MERGE_THRESHOLD)
+      if (mergeCount === -1 || mergeCount < PUSH_GATE_MERGE_THRESHOLD) continue
+
+      checks.push({
+        name: `${wf}:${branch}:push-gate`,
+        status: 'fail',
+        detail: `0 push-event runs on ${branch} while ≥${PUSH_GATE_MERGE_THRESHOLD} merge commits landed — workflow is a DEAD GATE (never actually runs on pushes to ${branch}).`,
+      })
+    }
+  }
+
+  if (checks.length === 0) {
+    checks.push({
+      name: 'push-gate history',
+      status: 'pass',
+      detail: 'no dead push-gates detected',
+    })
+  }
+
+  return { name: sectionName, checks }
+}
+
 export function checkCIPermissions(meta: RepoMeta | null): Section {
   const checks: Check[] = []
 

--- a/plugins/dev-core/skills/checkup/doctor-github.ts
+++ b/plugins/dev-core/skills/checkup/doctor-github.ts
@@ -558,7 +558,6 @@ export function detectUnsafeTokenInTriggeredWorkflow(
 
   const DEAD_PATTERNS = [/\$\{\{\s*github\.token\s*\}\}/, /\$\{\{\s*secrets\.GITHUB_TOKEN\s*\}\}/]
   const PAT_PATTERN = /\$\{\{\s*secrets\.PAT\s*\}\}/
-  const SAFE_PATTERN = /\$\{\{\s*steps\.[a-zA-Z0-9_-]+\.outputs\.token\s*\}\}/
 
   // Walk jobs section
   let jobsSectionLine = -1
@@ -598,6 +597,30 @@ export function detectUnsafeTokenInTriggeredWorkflow(
       }
     }
 
+    // Scan job-level config (the preamble before the first step) — e.g. a job-level
+    // `env:` token applies to every step, so a dead token there is a dead gate too.
+    const firstStepStart = stepHeaders.length > 0 ? stepHeaders[0].start : jobLines.length
+    const preamble = jobLines
+      .slice(0, firstStepStart)
+      .filter((l) => !l.trimStart().startsWith('#'))
+      .join('\n')
+    for (const pat of DEAD_PATTERNS) {
+      if (pat.test(preamble)) {
+        const tokenMatch = preamble.match(pat)
+        issues.push({
+          file: filePath,
+          job: jobName,
+          step: '(job-level env)',
+          kind: 'dead',
+          token: tokenMatch ? tokenMatch[0] : 'github.token/GITHUB_TOKEN',
+        })
+        break
+      }
+    }
+    if (PAT_PATTERN.test(preamble)) {
+      issues.push({ file: filePath, job: jobName, step: '(job-level env)', kind: 'pat-warn', token: 'secrets.PAT' })
+    }
+
     // Scan each step body for token usage
     for (let s = 0; s < stepHeaders.length; s++) {
       const stepStart = stepHeaders[s].start
@@ -607,9 +630,9 @@ export function detectUnsafeTokenInTriggeredWorkflow(
       const activeLines = stepLines.filter((l) => !l.trimStart().startsWith('#'))
       const stepBody = activeLines.join('\n')
 
-      // Skip if it uses a safe App token — this step is the mint step itself or consumes app output
-      if (SAFE_PATTERN.test(stepBody)) continue
-
+      // A step using only the safe App token (steps.<id>.outputs.token) matches none
+      // of the DEAD/PAT patterns below, so it is not flagged. We do NOT early-continue
+      // on a safe token: a step that ALSO references a dead token must still be flagged.
       for (const pat of DEAD_PATTERNS) {
         if (pat.test(stepBody)) {
           const tokenMatch = stepBody.match(pat)

--- a/plugins/dev-core/skills/checkup/doctor-github.ts
+++ b/plugins/dev-core/skills/checkup/doctor-github.ts
@@ -602,7 +602,10 @@ export function detectUnsafeTokenInTriggeredWorkflow(
     for (let s = 0; s < stepHeaders.length; s++) {
       const stepStart = stepHeaders[s].start
       const stepEnd = s + 1 < stepHeaders.length ? stepHeaders[s + 1].start : jobLines.length
-      const stepBody = jobLines.slice(stepStart, stepEnd).join('\n')
+      const stepLines = jobLines.slice(stepStart, stepEnd)
+      // Strip comment lines before pattern matching to avoid false positives on commented-out tokens
+      const activeLines = stepLines.filter((l) => !l.trimStart().startsWith('#'))
+      const stepBody = activeLines.join('\n')
 
       // Skip if it uses a safe App token — this step is the mint step itself or consumes app output
       if (SAFE_PATTERN.test(stepBody)) continue

--- a/plugins/dev-core/skills/checkup/doctor.ts
+++ b/plugins/dev-core/skills/checkup/doctor.ts
@@ -9,6 +9,7 @@ import { checkPrereqs } from '../shared/prereqs'
 import {
   checkBranchProtection,
   checkCIPermissions,
+  checkDeadGates,
   checkDefaultWorkflowPermissions,
   checkGitHubConfig,
   checkRulesets,
@@ -55,6 +56,7 @@ const sections: Section[] = [
   checkVercel(),
   checkCIPermissions(meta),
   checkPullRequestTarget(),
+  checkDeadGates(ghOk, owner, repo),
 ]
 
 if (jsonFlag) {


### PR DESCRIPTION
## Summary

Adds a **dead-gate detector** to `dev-core:checkup` — surfaces CI gates that exist and look green on PRs but never actually run where it matters (the #579/#589 class). Read-only.

Two sub-checks (per-job dormancy is split out to **#288**, blocked-by this):

1. **Token taxonomy** — `detectUnsafeTokenInTriggeredWorkflow()` static-YAML scan of push-/bot-triggered steps:
   - `github.token` / `secrets.GITHUB_TOKEN` → **DEAD GATE** (anti-recursion: pushes never re-trigger CI)
   - `secrets.PAT` → **warn** (valid legacy, migrate to roxabi-ci App)
   - `actions/create-github-app-token` → `steps.*.outputs.token` → **canonical-valid**, never flagged
2. **Push-gate merge-relative history** — flags a push-triggered workflow with **0 push-event runs while ≥N merge-commits landed** (N=5 default), anchored to real branch activity (not a bare "0 of last 5").

Iterates `STANDARD_WORKFLOWS` (not `REQUIRED_SECRETS` keys) so `ci.yml`/`pr-title.yml` are covered. Renders a `Dead Gates` section in `doctor` output.

Closes #278

## SC → Test matrix

| SC | Test(s) | Status |
|---|---|---|
| SC1: `github.token`/`GITHUB_TOKEN` flagged; `secrets.PAT` & App `outputs.token` NOT flagged (no FP in mixed fleet) | `detectUnsafeTokenInTriggeredWorkflow :: AC-1 (env push / GITHUB_TOKEN / on:[push] / workflow_run)`, `AC-2 :: secrets.PAT as pat-warn`, `AC-3 :: does not flag steps.*.outputs.token (App)` + `checkDeadGates :: AC-3 App token not flagged` | ✓ proven |
| SC2: push-triggered workflow with 0 push-runs while ≥N merges landed is reported | `checkDeadGates (subprocess) :: AC-4 + AC-5: flags push-gate dead gate in JSON output` | ✓ proven |
| SC3: grace window — workflows younger than the window are skipped | grace-window guard implemented in `checkDeadGates` via repo `createdAt`; no dedicated unit test | ⚠ NO TEST — infra-not-wired |
| SC4: read-only — never mutates repo or run state | `checkDeadGates (subprocess) :: AC-1 (read-only): doctor does not mutate repo or run state` | ✓ proven |
| SC5: findings render in a `Dead Gates` Section | `checkDeadGates (subprocess) :: AC-5: Dead Gates section appears in output` | ✓ proven |

14/14 tests in `dead-gate.test.ts` green · full suite 506 passed / 4 skipped · typecheck clean · biome clean.

## Notes

- **Recovered run:** the first implementation agent completed the code + tests but hit a context-overflow before committing; a second agent fixed the 6 then-failing token-scanner assertions (the static scanner wasn't matching tokens); the lead finalized gates + commit + PR.
- **Version bump coordination:** bumps `dev-core` `0.8.1 → 0.8.2`, same as #295 (#280). Identical 3-way change → clean auto-merge; whichever of #278/#295 lands second needs no manual rebase on the version line.
- Does **not** add `detectDormantJobs()` (per-job dormancy) — that is #288, which extends `checkDeadGates()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
