### PR TITLE
feat(checkup): add per-job CI dormancy detector (#288)

### DIFF
--- a/artifacts/frames/288-conditional-job-skip-rate-frame.mdx
+++ b/artifacts/frames/288-conditional-job-skip-rate-frame.mdx
@@ -1,0 +1,86 @@
+---
+title: "checkup: conditional-job skip-rate detector (dead-gate per-job dormancy, #579 class)"
+issue: 288
+status: approved
+tier: F-lite
+date: 2026-06-12
+---
+
+## Problem
+
+`dev-core:checkup` gained a dead-gate detector in #278 (`checkDeadGates()` in `doctor-github.ts`):
+it confirms a workflow file *runs on push* and its token is safe. But detection stops at the
+**workflow** level. A gate can be alive as a file yet contain a **job** that never executes — a
+`paths:` filter that never matches, an `if:` that is permanently false, an empty matrix leg, a
+silently-skipped required check. #278 sees the workflow run, reports the gate healthy, and the
+dormant job is invisible.
+
+This is the exact signature of #579: the e2e suite existed, its workflow ran, the e2e **job** was
+filtered out every time, and 4 regressions shipped under a green check. Workflow-level liveness is
+necessary but not sufficient; a required status check that never actually runs is a merge gate that
+proves nothing.
+
+This frame adds a **per-job dormancy pass** (`detectDormantJobs()`) that cross-references static job
+wiring against per-job run history to flag jobs that were eligible to run but executed 0 times across
+the observation window — escalating when the dormant job is also a required status check.
+
+## Who
+
+- **Primary:** Roxabi maintainers running `/checkup` (manual + cron) on the plugins repo — they get a
+  new finding class under the existing `Dead Gates` section, sub-grouped by job.
+- **Secondary:** any downstream consumer of `dev-core:checkup` on a repo with conditional CI jobs
+  (path filters, matrix, `if:` guards) — the most common place a real #579 hides.
+
+## Constraints
+
+- **Read-only** — static YAML parse + `gh run` history queries only; no execution, no mutation. Cron-safe.
+- **Reuse #278, do not duplicate** — `STANDARD_WORKFLOWS` iteration + the exported grace-window helpers
+  (`repoAgeOk` / `workflowAgeOk`) + the merge-relative anchoring already live in `doctor-github.ts`.
+  `detectDormantJobs()` lands *after* `checkDeadGates()` + `detectUnsafeTokenInTriggeredWorkflow()`.
+- **Eligibility-aware** — a job whose `paths:` simply weren't touched in-window is NOT dormant; only a
+  job that was eligible (its workflow ran, its filter could have matched) yet never executed counts.
+- **Grace window** — jobs younger than the window are skipped (same anchoring as #278); no flag on a
+  brand-new or genuinely-rare-path job.
+- **Surface** — renders in the same `Dead Gates` section, sub-grouped by job; no new top-level section.
+- **F-lite footprint** — single file extended (`doctor-github.ts`) + test cases in the existing
+  `__tests__/dead-gate.test.ts`. No new module, no schema change.
+
+## Out of Scope
+
+- **Workflow-level dormancy** — owned by #278 (`checkDeadGates`); this pass assumes the workflow runs.
+- **Token / push-gate sub-checks** — already shipped in #278.
+- **Executing or "fixing" jobs** — detection only; remediation is the maintainer's call.
+- **Non-standard workflows** — limited to `STANDARD_WORKFLOWS` iteration #278 already established.
+- **Deep `if:` expression evaluation** — we infer dormancy from *observed run history*, not by
+  statically proving an `if:` is always false (history is the ground truth; static parse only
+  enumerates the jobs + their eligibility inputs).
+
+## Premise Validity
+
+**Success in 6 months:** `/checkup` on a repo with a conditional CI job that never runs (path filter
+that never matches, permanently-false `if:`, empty matrix leg) flags that job as dormant under
+`Dead Gates`, sub-grouped by job — and escalates it when the job is also a required status check.
+At least one real dormant-job instance is surfaced on the plugins repo's own CI (or a deliberate
+fixture proves the path end-to-end).
+
+**Failure in 6 months:** a second #579 ships — a required-check job stays dormant and a regression
+merges under a green check while `/checkup` runs and reports nothing — OR the detector is so noisy
+(false-flagging genuinely-rare-path jobs) that maintainers mute the `Dead Gates` section, which is
+boolean-observable: section muted/ignored, or a #579-class incident recurs, within 6 months.
+
+**Simplest alternative:** ship nothing further; rely on #278's workflow-level liveness check.
+**Why not simplest:** #278 is structurally blind to job-level dormancy — it confirms the *file* ran,
+not that each *job* ran. The #579 incident occurred with a workflow that ran fine; only the job was
+dead. The simplest version cannot see the exact failure mode that motivated the parent issue.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (checkup CI doctor), extends one existing function in
+one file plus its test file; no new architecture, no cross-plugin surface.
+
+Signals observed:
+- `size:F-lite` label on the issue.
+- Single file extended (`doctor-github.ts`) + existing test file (`dead-gate.test.ts`).
+- Reuses established #278 scaffolding (`STANDARD_WORKFLOWS`, grace-window helpers) — no new patterns.
+- One genuine unknown (per-job run-history shape from `gh run view --json jobs` + eligibility
+  modeling) → spec-worthy, but bounded; not multi-domain.

--- a/artifacts/plans/288-conditional-job-skip-rate-plan.mdx
+++ b/artifacts/plans/288-conditional-job-skip-rate-plan.mdx
@@ -1,0 +1,237 @@
+---
+title: "Plan: conditional-job skip-rate detector (per-job dormancy)"
+issue: 288
+spec: artifacts/specs/288-conditional-job-skip-rate-spec.mdx
+complexity: 5/10
+tier: F-lite
+generated: 2026-06-12
+---
+
+## Summary
+
+Extend `checkDeadGates()` in `plugins/dev-core/skills/checkup/doctor-github.ts` with sub-check **C**
+(per-job dormancy): a pure static job parser + a pure verdict function + pure history/required-context
+aggregators wrapped by thin `gh` fetchers, orchestrated by `detectDormantJobs()` and rendered into the
+existing `Dead Gates` section. Single source file + co-located tests in `__tests__/dead-gate.test.ts`.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph yaml[".github/workflows/*.yml"]
+    WF["workflow YAML (read by checkDeadGates)"]
+  end
+  subgraph src["doctor-github.ts"]
+    N1["parseWorkflowJobs(content) → ParsedJob[]"]
+    AGG["aggregateJobStats(runs, jobs) → Map<job,JobRunStats> (pure)"]
+    N2["fetchJobHistory(owner,repo,wf,branch,jobs,limit)"]
+    PRC["parseRequiredContexts(classic,ruleset) → Set (pure)"]
+    N3["fetchRequiredContexts(owner,repo,branch)"]
+    N6["classifyDormancy(job,stats,isRequired,minRuns) → DormancyVerdict (pure)"]
+    N4["detectDormantJobs(ghOk,owner,repo) → Check[]"]
+    N5["checkDeadGates() — Section C append"]
+  end
+  GH["gh run list / gh run view --json jobs,conclusion --repo o/r"]
+  PROT["gh api required_status_checks + rules/branches (--repo o/r)"]
+
+  WF --> N1 --> N4
+  GH --> N2 --> AGG --> N4
+  PROT --> N3 --> PRC --> N4
+  N4 -->|per job| N6 --> N4
+  N4 -->|"Check[] (fail/warn only)"| N5
+  N5 --> OUT["Dead Gates section → formatText / --json"]
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+  subgraph DG["doctor-github.ts"]
+    P1[parseWorkflowJobs]
+    P2[aggregateJobStats]
+    P3[parseRequiredContexts]
+    F1[fetchJobHistory]
+    F2[fetchRequiredContexts]
+    V1[classifyDormancy]
+    O1[detectDormantJobs]
+    C1[checkDeadGates]
+    F1 --> P2
+    F2 --> P3
+    O1 --> P1
+    O1 --> F1
+    O1 --> F2
+    O1 --> V1
+    C1 --> O1
+  end
+  subgraph T["__tests__/dead-gate.test.ts"]
+    UT["unit: parseWorkflowJobs · classifyDormancy · aggregateJobStats · parseRequiredContexts"]
+    IT["integration (subprocess): Dead Gates per-job dormancy"]
+  end
+  P1 -.-> UT
+  V1 -.-> UT
+  P2 -.-> UT
+  P3 -.-> UT
+  C1 -.-> IT
+```
+
+## Agents
+
+| Agent instance | Tasks | Files | Subjects |
+|---|---|---|---|
+| backend-dev-A | T1, T2, T3, T4, T5 | `doctor-github.ts` (+ co-located unit tests in `dead-gate.test.ts`) | parser, verdict, history, required-checks, orchestrator |
+| tester-A | T6, T7 | `dead-gate.test.ts` | integration, coverage |
+
+## Wave Structure
+
+1 wave (sequential chain — all source in one file; parallel split would conflict). ~7 chained tasks.
+Elapsed ≈ sequential (no parallelism gain possible on a single file); 2 named instances for impl/test split.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 1 (backend-dev-A) | T1→T2→T3→T4→T5 |
+| 2 | Wave 1 done | 1 (tester-A) | T6→T7 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 parseWorkflowJobs + tests | 1 | judgmental | 5 | — |
+| T2 classifyDormancy + tests | 1 | judgmental | 5 | — |
+| T3 aggregateJobStats + tests | 1 | judgmental | 6 | — |
+| T4 required-contexts + fetchers + tests | 2 | judgmental | 6 | — |
+| T5 detectDormantJobs + wire | 1 | judgmental | 5 | — |
+| T6 integration test | 1 | judgmental | 5 | — |
+| T7 coverage audit + QG | 1 | bounded | 3 | — |
+
+**Total estimated ops: ~35**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1–T5 | 27 | parser, verdict, history, required-checks, orchestrator (5) | **OVERRIDE — no split**: all tasks target the single file `doctor-github.ts`; parallel split conflicts, sequential handoff loses file context. Per skill's "shared file → merge into single agent". Ops 27 < 50. |
+| tester-A | T6–T7 | 8 | integration, coverage (2) | — |
+
+## Consistency Report
+
+Covered: 11/11 success criteria.
+
+| Criterion | Task(s) |
+|---|---|
+| AC-6 (wiring warn) | T2, T6 |
+| AC-7 (required fail) | T2, T6 |
+| AC-8 (conditional unflagged) | T2 |
+| AC-9 (grace window) | T2, T5, T6 |
+| AC-10 (renders sub-grouped, read-only) | T5, T6 |
+| AC-11 (required-context union + 404) | T4 |
+| Parser (ParsedJob fields, `( )`-name) | T1 |
+| Eligibility semantics | T3 |
+| Clean-state pass | T6 |
+| `--repo` correctness | T4, T7 |
+| lint + typecheck + test green | T7 (RED-GATE) |
+
+Untraced tasks: none. Exemptions: none.
+
+## Micro-Tasks
+
+### Slice S1 — parseWorkflowJobs (parser)
+
+**T1** · backend-dev-A · subject: parser · difficulty 3 · ~5 min · spec trace: Parser AC / N1 / S1
+- **File:** `plugins/dev-core/skills/checkup/doctor-github.ts` (+ `__tests__/dead-gate.test.ts`)
+- **Do:** add `export interface ParsedJob { id; displayName; hasIf; matrixEmpty; needs }` and
+  `export function parseWorkflowJobs(content: string): ParsedJob[]` — walk `jobs:` (2-space headers,
+  reuse the header-scan idiom from `detectUnsafeTokenInTriggeredWorkflow`); per job detect `if:`,
+  `strategy.matrix` static-empty (`matrix: {}`/`[]`/an axis `[]`), `needs:` (scalar or list),
+  `name:` → displayName (fallback id). Add unit tests incl. a job whose `name:` contains ` (`.
+- **Verify:** `bun test dead-gate -t parseWorkflowJobs` → green
+- **Phase:** RED→GREEN (co-located)
+
+### Slice S2 — classifyDormancy (verdict)
+
+**T2** · backend-dev-A · subject: verdict · difficulty 3 · ~5 min · trace: AC-6/7/8/9 / N6 / S2 · blockedBy T1
+- **Do:** add `DORMANCY_MIN_RUNS = 5`, `DORMANCY_RUN_LIMIT = 10`; `export type DormancyVerdict`
+  (`alive | dormant_required | dormant_wiring | conditional_ok`); `export function classifyDormancy(job, stats, isRequired, minRuns): DormancyVerdict`
+  implementing the pinned ladder (considered<min→alive; executed>0→alive; required→dormant_required;
+  matrixEmpty||!hasIf→dormant_wiring; else conditional_ok). Unit-test the full matrix incl.
+  `{considered:10,executed:0,skipped:8}` + hasIf + !required → conditional_ok, and same + required → dormant_required.
+- **Verify:** `bun test dead-gate -t classifyDormancy` → green
+
+### Slice S3 — history + required-context aggregation
+
+**T3** · backend-dev-A · subject: history · difficulty 4 · ~6 min · trace: Eligibility AC / N2 / S3 · blockedBy T2
+- **Do:** add `JobRunStats { considered; executed; skipped }` + a `RunRecord` shape
+  (`{ runConclusion; jobs: {name; conclusion}[] }`); pure
+  `export function aggregateJobStats(runs: RunRecord[], jobs: ParsedJob[]): Map<string, JobRunStats>` —
+  exclude run-level `skipped`/`cancelled`; per static job match history by `name === displayName ||
+  name.startsWith(displayName + ' (')`; considered = retained runs where job present; executed =
+  present∧conclusion≠skipped; skipped = present∧conclusion===skipped. Unit-test eligibility semantics
+  + anchored matrix-leg (incl. `Build (debug)` not collapsing).
+- **Verify:** `bun test dead-gate -t aggregateJobStats` → green
+
+**T4** · backend-dev-A · subject: required-checks · difficulty 4 · ~6 min · trace: AC-11, `--repo` AC / N2,N3 / S3 · blockedBy T3
+- **Do:** pure `export function parseRequiredContexts(classicJson: string, rulesetJson: string): Set<string>`
+  — union classic `.required_status_checks.contexts[]` + `.checks[].context` + ruleset
+  `required_status_checks` rule contexts; tolerate empty/invalid (404→`''`)→∅. Thin gh wrappers
+  `fetchJobHistory(owner,repo,wf,branch,jobs,limit)` (uses `aggregateJobStats`; **`--repo owner/repo`**
+  on `gh run list` AND `gh run view --json jobs,conclusion`; inline comment re matrix-leg display
+  convention fragility) + `fetchRequiredContexts(owner,repo,branch)` (uses `parseRequiredContexts`,
+  memo by caller). Unit-test `parseRequiredContexts`: each source, union, 404→∅.
+- **Verify:** `bun test dead-gate -t parseRequiredContexts` → green
+
+### Slice S4 — orchestrate + wire
+
+**T5** · backend-dev-A · subject: orchestrator · difficulty 4 · ~5 min · trace: AC-10 / N4,N5 / S4 · blockedBy T4
+- **Do:** `export function detectDormantJobs(ghOk, owner, repo): Check[]` — guard `!ghOk`/`!repoAgeOk`→[];
+  ∀ branch∈PROTECTED_BRANCHES (exists) × wf∈STANDARD_WORKFLOWS with `countPushRuns>0` ∧ `workflowAgeOk`:
+  read file→parseWorkflowJobs; required=fetchRequiredContexts(memo/branch); stats=fetchJobHistory;
+  ∀ job→classifyDormancy→push Check ONLY for dormant_required(`fail`)/dormant_wiring(`warn`), named
+  `"<wf>:<branch>:<job> dormancy"`. Wire into `checkDeadGates`: `checks.push(...detectDormantJobs(ghOk, owner, repo))`
+  AFTER sub-check B, BEFORE the `checks.length === 0` pass fallback.
+- **Verify:** `bun run typecheck` clean ∧ `bun test dead-gate` green
+
+**T6** · tester-A · subject: integration · difficulty 3 · ~5 min · trace: AC-10, clean-state / S4 · blockedBy T5
+- **Do:** add subprocess integration tests in the existing `checkDeadGates (integration via subprocess)`
+  describe block: (a) a fixture workflow with a never-running job renders a `… dormancy` check
+  sub-grouped by job; (b) clean state → single `pass` covering B+C; (c) read-only guard (no mutation /
+  no run state change), mirroring the existing AC-1 read-only test.
+- **Verify:** `bun test dead-gate` → green
+
+**T7** · tester-A · subject: coverage · difficulty 2 · ~3 min · trace: QG / RED-GATE · blockedBy T6
+- **Do:** audit the suite against AC-6…AC-11 + parser/eligibility/clean-state/`--repo`; add any missing
+  case; confirm `--repo` present in N2. Run full QG.
+- **Verify (RED-GATE):** `bun run lint && bun run typecheck && bun test` → all green
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — start, backend-dev-A (sequential chain)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | parser |
+| T2 | backend-dev-A | T1 | verdict |
+| T3 | backend-dev-A | T2 | history |
+| T4 | backend-dev-A | T3 | required-checks |
+| T5 | backend-dev-A | T4 | orchestrator |
+
+### Wave 2 — after Wave 1, tester-A (sequential chain)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | tester-A | T5 | integration |
+| T7 | tester-A | T6 | coverage |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 11 — parser
+- T2: 12 — verdict
+- T3: 13 — history
+- T4: 14 — required-checks
+- T5: 15 — orchestrator
+- T6: 16 — integration
+- T7: 17 — coverage

--- a/artifacts/specs/288-conditional-job-skip-rate-spec.mdx
+++ b/artifacts/specs/288-conditional-job-skip-rate-spec.mdx
@@ -1,0 +1,226 @@
+---
+title: "checkup: conditional-job skip-rate detector (per-job dormancy)"
+issue: 288
+status: approved
+tier: F-lite
+date: 2026-06-12
+promoted_from: artifacts/frames/288-conditional-job-skip-rate-frame.mdx
+---
+
+## Context
+
+Source: [frame](../frames/288-conditional-job-skip-rate-frame.mdx) (analyze skipped — F-lite).
+
+#278 shipped `checkDeadGates()` in `plugins/dev-core/skills/checkup/doctor-github.ts` with two
+sub-checks: **(A)** token taxonomy (static YAML scan via `detectUnsafeTokenInTriggeredWorkflow`)
+and **(B)** push-gate merge-relative history. Both operate at the **workflow** level. This spec adds
+sub-check **(C)**: a **per-job dormancy** pass that flags a job which was eligible to run (its
+workflow ran) yet executed **0 times** across the observation window — the #579 signature, where a
+required e2e job was filtered out every run and 4 regressions shipped under a green check.
+
+Reuses (do not duplicate): `STANDARD_WORKFLOWS`, `PROTECTED_BRANCHES`, `DEFAULT_RULESET`
+(from `github-infra`), the grace-window helpers `workflowAgeOk`/`repoAgeOk`, `ageInDays`, and the
+`spawnSync`/`Check`/`Section`/`Status` primitives from `doctor-shared`.
+
+> Expert-review-driven refinements (panel 2026-06-12): eligibility semantics pinned (run-level skip
+> exclusion + `skipped` never counts as executed + absent-job exclusion), matrix-leg matching
+> anchored on static job names, required-context resolution unions classic `contexts[]` +
+> `checks[].context` + **ruleset** contexts, and `--repo owner/repo` made explicit on all `gh` calls.
+> Probe note: on roxabi-plugins the required `ci` check lives in **classic protection** (`contexts`
+> *and* `checks` both list `ci`); its `staging` ruleset carries **no** `required_status_checks` rule
+> (merge-method + thread-resolution only). So AC-7 escalation is live here via the classic source; the
+> ruleset union is defensive coverage for repos that register required checks via rulesets.
+
+## Goal
+
+`/checkup` flags any CI **job** that never runs across ≥N eligible workflow runs, escalating to a
+failure when that job is also a required status check (a merge gate that proves nothing), while not
+false-flagging genuinely-conditional jobs whose paths simply weren't exercised in-window.
+
+## Users
+
+- **Primary:** Roxabi maintainers running `/checkup` (manual + cron) — receive a new per-job finding
+  group under the existing `Dead Gates` section.
+- **Secondary:** any `dev-core:checkup` consumer with conditional CI jobs (`if:`, matrix, path-gated
+  via `dorny/paths-filter` + `if:`).
+
+## Expected Behavior
+
+For each protected branch × each standard workflow that **is alive at the workflow level** (has push
+runs — a dormant job only matters inside a workflow that actually runs):
+
+1. **Static parse** (`parseWorkflowJobs`) enumerates each job: its YAML key (`id`), display name
+   (`name:` or `id`), whether it carries a job-level `if:`, whether its `strategy.matrix` is
+   statically empty, and its `needs:` list. No execution — pure string parse, like
+   `detectUnsafeTokenInTriggeredWorkflow`.
+2. **Run-history cross-ref** (`fetchJobHistory`) samples the last `DORMANCY_RUN_LIMIT` push runs
+   (`gh run list --repo <owner>/<repo> --event push`) and, per run, reads
+   `gh run view <id> --repo <owner>/<repo> --json jobs,conclusion`. **Eligibility semantics (pinned):**
+   - A run whose **run-level** `conclusion` is `skipped` or `cancelled` is **excluded** — the whole
+     workflow was a no-op (path filter / concurrency cancel), so its jobs prove nothing. (This is the
+     robust guard for workflow-level `on.push.paths` gating: a never-matched path produces no run, and
+     a phantom skipped-run is excluded here — no separate `workflowPathsGated` flag, which would
+     false-negative a genuinely-broken single job.)
+   - `considered` counts only retained runs **in which the job entry appears** (a job added mid-window
+     is absent from older runs → those runs do not inflate `considered`).
+   - `executed` counts retained runs where the job's `conclusion` is **not** `skipped` (i.e.
+     `success`/`failure`/`cancelled`/`timed_out`/`action_required`).
+   - `skipped` counts retained runs where the job `conclusion == 'skipped'` (`if:` evaluated false /
+     `needs` upstream skipped). **`skipped` is never counted as `executed`** — a job that skips every
+     run has `executed == 0`.
+   - Matrix legs (history name `"<job> (<leg>)"`) aggregate under their base job by **anchored prefix
+     match**: a history entry belongs to static job J iff `historyName === J.displayName` **or**
+     `historyName.startsWith(J.displayName + ' (')`. Anchoring on the known static display name avoids
+     misattributing a job whose own name contains ` (` (e.g. `Build (debug)`).
+3. **Required-check lookup** (`fetchRequiredContexts`, memoized per branch) unions three sources so
+   the escalation path is live regardless of how the repo enforces checks:
+   - classic protection `required_status_checks.contexts[]`,
+   - classic protection `required_status_checks.checks[].context` (modern Checks-API registration),
+   - **ruleset** `required_status_checks` rule contexts (`gh api .../rules/branches/<branch>`).
+   Any endpoint 404 / absent rule → contributes nothing (fail-open: a missing protection response
+   never *escalates*). A job is *required* if its display name — or any matrix-leg history name —
+   matches a context in the union.
+4. **Verdict** (`classifyDormancy`, pure) per job:
+   - `considered < DORMANCY_MIN_RUNS` → **alive** (insufficient history — fail-open, never flag).
+   - `executed > 0` → **alive** (it ran at least once).
+   - else (`executed == 0`, enough history):
+     - required check → **`fail`** (`dormant_required`): *required status check never runs — merge gate proves nothing (#579).*
+     - statically-empty matrix → **`warn`** (`dormant_wiring`): *matrix expands to 0 legs — job can never run.*
+     - no `if:` (should always run) → **`warn`** (`dormant_wiring`): *job skipped in all N runs — dead wiring (broken `needs`/empty matrix).*
+     - has `if:`, not required → **not flagged** (`conditional_ok` — legitimate rare path, AC-3/AC-8).
+5. **Grace window:** the pass is gated by `workflowAgeOk(owner, repo, wf)` (recently-added workflow
+   excused) and by the `considered ≥ DORMANCY_MIN_RUNS` floor (recently-added job has too little
+   history). A young job is therefore skipped by construction.
+6. **Render contract:** `detectDormantJobs` emits a `Check` **only** for `dormant_required` (`fail`)
+   and `dormant_wiring` (`warn`); `alive` and `conditional_ok` emit nothing. Checks are named
+   `"<wf>:<branch>:<job> dormancy"`, sub-grouped by job, appended to the existing `Dead Gates`
+   section. The section's existing `checks.length === 0` fallback then covers sub-checks B **and** C:
+   the single clean-state `pass` ("per-job dormancy: no dormant jobs") fires only when neither
+   produced a finding. Read-only — no `git`/`gh` mutation, no run re-trigger.
+
+## Data Model & Consumers
+
+### Data structures
+
+```mermaid
+classDiagram
+  class ParsedJob {
+    +string id
+    +string displayName
+    +boolean hasIf
+    +boolean matrixEmpty
+    +string[] needs
+  }
+  class JobRunStats {
+    +int considered
+    +int executed
+    +int skipped
+  }
+  note for JobRunStats "skipped is NEVER counted in executed; considered excludes runs where the job entry is absent or the run-level conclusion is skipped/cancelled"
+  class DormancyVerdict {
+    <<union>>
+    alive | dormant_required(fail) | dormant_wiring(warn) | conditional_ok(unflagged)
+  }
+  note for DormancyVerdict "produced by classifyDormancy(job: ParsedJob, stats: JobRunStats, isRequired: boolean, minRuns: number)"
+  class Check {
+    +string name
+    +Status status
+    +string detail
+  }
+  ParsedJob ..> DormancyVerdict
+  JobRunStats ..> DormancyVerdict
+  DormancyVerdict --> Check : rendered (fail/warn only) into Dead Gates
+```
+
+### Consumer map
+
+```mermaid
+flowchart TD
+  YAML[".github/workflows/*.yml"] -->|parseWorkflowJobs| PJ["ParsedJob[]"]
+  GH["gh run list / gh run view --json jobs,conclusion"] -->|fetchJobHistory| JS["JobRunStats per job"]
+  PROT["classic contexts[] + checks[].context + ruleset contexts"] -->|fetchRequiredContexts| REQ["required context set"]
+  PJ --> DET["detectDormantJobs<br/>(calls classifyDormancy per job)"]
+  JS --> DET
+  REQ --> DET
+  DET -->|"Check[] (fail/warn only)"| DG["checkDeadGates → Dead Gates Section"]
+  DG -.->|formatText / --json| OUT["/checkup output"]
+  DG -.->|future| CRON["cron summary (out of scope)"]
+```
+
+### Consumer summary
+
+| Consumer | Fields consumed | When | Status |
+|---|---|---|---|
+| `classifyDormancy` | `ParsedJob.{hasIf,matrixEmpty}`, `JobRunStats.{considered,executed}`, `isRequired`, `minRuns` (C1) | per job | this issue |
+| `detectDormantJobs` | `DormancyVerdict`, job/wf/branch labels | per job | this issue |
+| `checkDeadGates` (Section C) | `Check[]` from `detectDormantJobs` (fail/warn only) | per `/checkup` | this issue |
+| `formatText` / `--json` renderer | `Check.{name,status,detail}` | render | existing (#278) |
+| cron summary roll-up | `Check.status` | future | out of scope |
+
+## Breadboard
+
+### Affordances — new symbols in `doctor-github.ts`
+
+| ID | Affordance | Kind | Wiring |
+|---|---|---|---|
+| N1 | `parseWorkflowJobs(content): ParsedJob[]` | pure parser | called by N4 per workflow file |
+| N2 | `fetchJobHistory(owner, repo, wf, branch, jobs, limit): Map<string,JobRunStats>` | runtime (gh) | called by N4; `--repo owner/repo` on every call; run-level skip exclusion + anchored matrix-leg match |
+| N3 | `fetchRequiredContexts(owner, repo, branch): Set<string>` | runtime (gh) | called by N4 once per branch (memoized); unions classic `contexts[]` + `checks[].context` + ruleset contexts; any 404 → contributes ∅ |
+| N4 | `detectDormantJobs(ghOk, owner, repo): Check[]` | runtime orchestrator | invoked by N5; iterates `PROTECTED_BRANCHES` × `STANDARD_WORKFLOWS` |
+| N5 | `checkDeadGates(...)` Section C | integration point | appends `...detectDormantJobs(ghOk, owner, repo)` after sub-check B, before the shared `checks.length === 0` pass fallback |
+| N6 | `classifyDormancy(job, stats, isRequired, minRuns): DormancyVerdict` | pure verdict | called by N4 per job; emits a `Check` only for `fail`/`warn` verdicts |
+| C1 | `DORMANCY_MIN_RUNS = 5` | const | floor for `considered` |
+| C2 | `DORMANCY_RUN_LIMIT = 10` | const | `gh run` sample size per wf/branch |
+
+### Wiring narrative
+
+`checkDeadGates` (N5) — after sub-check B, before the final `pass` fallback — calls
+`detectDormantJobs` (N4) and pushes its `Check[]` into the section's `checks`. N4 reuses the existing
+`ghOk`/`repoAgeOk` guards already evaluated in B (skip the whole pass when `!ghOk` or `!repoAgeOk`).
+For each branch that exists × each workflow with `countPushRuns > 0` (alive) and `workflowAgeOk`, N4:
+parses the local workflow file → N1; resolves required contexts → N3 (memoized per branch); samples
+history for the parsed jobs → N2; per job → N6; maps `fail`/`warn` verdicts to a `Check`
+(`alive`/`conditional_ok` emit nothing). Pure logic (N1, N6) is unit-tested directly; N4 is
+integration-tested via the doctor subprocess like the existing `checkDeadGates` block.
+
+## Slices
+
+| # | Slice | Demo-able outcome |
+|---|---|---|
+| S1 | `parseWorkflowJobs` (N1) + `ParsedJob` type | unit test: parses `if:`, empty matrix, `needs`, display name from fixtures (incl. a name containing ` (`) |
+| S2 | `classifyDormancy` (N6) + verdict type + constants | unit test: full verdict matrix (alive / insufficient-history / required-fail / wiring-warn / empty-matrix-warn / conditional-unflagged) |
+| S3 | `fetchJobHistory` (N2) + `fetchRequiredContexts` (N3) | runtime helpers: run-level skip exclusion, absent-job exclusion, `skipped`≠`executed`, anchored matrix-leg aggregation; required-context union of classic+checks+ruleset with 404 fail-open |
+| S4 | `detectDormantJobs` (N4) wired into `checkDeadGates` (N5) | integration test (subprocess): Dead Gates renders per-job dormancy sub-grouped by job; clean-state pass; read-only |
+
+## Success Criteria
+
+> New AC labels start at **AC-6** — `dead-gate.test.ts` already uses AC-1…AC-5 (+AC-3b) for #278.
+
+- [ ] **AC-6 (issue AC-1):** an unconditional job (no `if:`) or statically-empty matrix with `executed == 0` across `≥ DORMANCY_MIN_RUNS` retained runs → `warn` (`dormant_wiring`) — unit-tested + asserted in rendered Check status.
+- [ ] **AC-7 (issue AC-2):** a job with `executed == 0` across `≥ DORMANCY_MIN_RUNS` runs that **is a required status check** → `fail` (`dormant_required`, "merge gate proves nothing / #579") — unit-tested; takes precedence over the `conditional_ok` path even when `hasIf == true` (the #579 e2e case: required + skipped-every-run).
+- [ ] **AC-8 (issue AC-3):** a conditional job (`hasIf == true`) that is **not** required and skips every run (`executed == 0, skipped > 0`) → **not flagged** (no Check emitted) — unit-tested.
+- [ ] **AC-9 (issue AC-4):** grace window — a workflow failing `workflowAgeOk` is skipped entirely; a job with `considered < DORMANCY_MIN_RUNS` (incl. mid-window additions counted only in runs where the job appears) → **alive**, not flagged — unit-tested.
+- [ ] **AC-10 (issue AC-5):** `detectDormantJobs` output renders inside the existing `Dead Gates` section, named `"<wf>:<branch>:<job> dormancy"`, sub-grouped by job (no new top-level section); read-only (no `git`/`gh` mutation, no run re-trigger) — integration-tested via the existing read-only guard pattern.
+- [ ] **AC-11 (required-context resolution):** `fetchRequiredContexts` unions classic `contexts[]` + `checks[].context` + ruleset `required_status_checks` contexts; an endpoint 404 contributes ∅ and **never escalates** a job to `fail` (fail-open) — unit-tested with fixture responses for each source and the 404 case.
+- [ ] **Parser:** `parseWorkflowJobs` enumerates `{id, displayName, hasIf, matrixEmpty, needs}` from a workflow YAML string (pure, no I/O), including a display name containing ` (` — unit-tested against fixtures.
+- [ ] **Eligibility semantics:** `fetchJobHistory` excludes runs whose run-level `conclusion ∈ {skipped, cancelled}` and runs where the job entry is absent from `considered`; counts `conclusion == 'skipped'` into `skipped` (never `executed`); aggregates matrix legs by anchored prefix — unit-tested.
+- [ ] **Clean state:** when no job is `dormant_*`, the existing `checks.length === 0` fallback emits exactly one `pass` Check covering sub-checks B+C — integration-tested.
+- [ ] **`--repo` correctness:** every `gh run list` / `gh run view` call in N2 passes `--repo <owner>/<repo>` (cron-safe from arbitrary cwd) — asserted by inspection/test.
+- [ ] `bun run lint`, `bun run typecheck`, and `bun test` (checkup suite) all pass.
+
+## Notes / Deferred
+
+- **Per-job git-blame age** (precise "job younger than window" vs the workflow-age proxy) is deferred;
+  the `workflowAgeOk` + absent-job-aware `considered ≥ DORMANCY_MIN_RUNS` floor is the F-lite grace gate.
+- **Matrix-leg name format** `"<job> (<leg>)"` is an observed GitHub Actions display convention, not a
+  documented `gh run view --json jobs` API contract. If it changes, anchored matching degrades to
+  treating legs as top-level jobs (false negatives, not false positives) — documented inline in N2.
+- **AC-7 end-to-end on roxabi-plugins:** probe (2026-06-12) confirms the required `ci` check is in
+  **classic protection** (`required_status_checks.contexts:["ci"]` and `.checks:[{context:"ci"}]`);
+  the `staging` ruleset has no `required_status_checks` rule. So the classic source already makes the
+  `fail` escalation live in production; the ruleset union (AC-11) is defensive for ruleset-enforced
+  repos. The unit test proves the `classifyDormancy(isRequired=true)→fail` logic with a synthetic
+  stats fixture (no dependence on live protection state).
+- **`gh` call budget:** ≤ `|PROTECTED_BRANCHES| × |STANDARD_WORKFLOWS| × DORMANCY_RUN_LIMIT` run-view
+  calls (≤80), bounded further by alive-workflow + branch-exists gating + per-branch memoized N3.
+  Acceptable for read-only cron.

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
@@ -2,16 +2,43 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { detectUnsafeTokenInTriggeredWorkflow } from '../doctor-github'
+import {
+  aggregateJobStats,
+  classifyDormancy,
+  DORMANCY_MIN_RUNS,
+  detectUnsafeTokenInTriggeredWorkflow,
+  type JobRunStats,
+  type ParsedJob,
+  parseRequiredContexts,
+  parseWorkflowJobs,
+  type RunRecord,
+} from '../doctor-github'
 
 /**
  * Dead Gate detector — acceptance tests.
  *
- * AC-1: github.token / secrets.GITHUB_TOKEN in push-triggered steps → flagged as 'dead'
- * AC-2: secrets.PAT in push-triggered steps → flagged as 'pat-warn' (not 'dead')
- * AC-3: App token via actions/create-github-app-token → steps.<id>.outputs.token → NOT flagged
- * AC-4: Push-gate merge-relative history: 0 push runs + ≥N merges → fail (integration via subprocess)
- * AC-5: findings appear in 'Dead Gates' Section
+ * Spec criterion → test mapping (spec: artifacts/specs/288-conditional-job-skip-rate-spec.mdx)
+ *
+ * | Spec criterion       | Label | Test location(s)                                       |
+ * |----------------------|-------|--------------------------------------------------------|
+ * | Token taxonomy dead  | AC-1  | detectUnsafeToken > AC-1 (unit)                        |
+ * | Token taxonomy warn  | AC-2  | detectUnsafeToken > AC-2 (unit)                        |
+ * | App token safe       | AC-3  | detectUnsafeToken > AC-3 (unit) + AC-3 integration     |
+ * | Push-gate history    | AC-4  | integration > AC-4                                     |
+ * | Section render       | AC-5  | integration > AC-5                                     |
+ * | Wiring-warn          | AC-6  | integration > dormant_wiring WARN + unit AC-7d/7e      |
+ * | Required-fail        | AC-7  | integration > AC-10 (dormant_required → fail)          |
+ * | Conditional-ok       | AC-8  | integration > AC-11 (conditional_ok → not flagged)     |
+ * | Grace window         | AC-9  | integration > SC3 grace window                         |
+ * | Render contract      | AC-10 | integration > AC-10 (named check, sub-grouped)         |
+ * | Req-ctx resolution   | AC-11 | unit > parseRequiredContexts AC-9a/b/c/d/e/f           |
+ * | Parser               | —     | unit > parseWorkflowJobs AC-6a–6f                      |
+ * | Eligibility          | —     | unit > aggregateJobStats AC-8a–8e                      |
+ * | Clean state          | —     | integration > clean state (all jobs execute)           |
+ * | --repo correctness   | —     | unit > --repo correctness (source inspection)          |
+ *
+ * Note: test-file AC labels (AC-6…AC-11 below) differ from spec AC labels above;
+ * the mapping table is the authoritative cross-reference.
  */
 
 // ── Unit tests: detectUnsafeTokenInTriggeredWorkflow ──────────────────────────
@@ -536,5 +563,621 @@ describe('checkDeadGates (integration via subprocess)', () => {
 
     // Outputs are identical (no state written between runs)
     expect(result1.stdout).toBe(result2.stdout)
+  })
+
+  // ── AC-10: dormant_required job → fail check in Doctor output ─────────────────
+  it('AC-10: dormant required job emits fail check in Dead Gates section', () => {
+    // Workflow with a single required job that appears in required contexts
+    fs.mkdirSync(path.join(tmpDir, '.github', 'workflows'), { recursive: true })
+    fs.writeFileSync(
+      path.join(tmpDir, '.github', 'workflows', 'ci.yml'),
+      [
+        'name: CI',
+        'on:',
+        '  push:',
+        '    branches: [main]',
+        'jobs:',
+        '  build:',
+        '    name: Build',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - run: echo ok',
+      ].join('\n'),
+    )
+
+    // Fake gh: repo is old, ci.yml has push runs on main, branch exists,
+    // required contexts return "Build", run list returns 5 runs all with build job skipped
+    makeFakeExec(
+      tmpDir,
+      'gh',
+      `#!/bin/sh
+ARGS="$*"
+# repo created_at (old repo — more than 14 days)
+if echo "$ARGS" | grep -q 'repos/TestOrg/test-repo$'; then
+  echo '{"created_at":"2020-01-01T00:00:00Z","visibility":"public"}'
+  exit 0
+fi
+# branch protection required contexts (dual-root: top-level contexts array)
+if echo "$ARGS" | grep -q 'required_status_checks$'; then
+  echo '{"contexts":["Build"],"checks":[]}'
+  exit 0
+fi
+# ruleset required status checks (empty)
+if echo "$ARGS" | grep -q 'rules/branches/main$' || echo "$ARGS" | grep -q 'rules/branches/staging$'; then
+  echo '[]'
+  exit 0
+fi
+# branch exists check
+if echo "$ARGS" | grep -q 'branches/main$' || echo "$ARGS" | grep -q 'branches/staging$'; then
+  echo '{"name":"main"}'
+  exit 0
+fi
+# workflow created_at (old)
+if echo "$ARGS" | grep -q 'workflows/ci.yml$'; then
+  echo '{"created_at":"2020-01-01T00:00:00Z"}'
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'workflows/auto-merge.yml$' || echo "$ARGS" | grep -q 'workflows/pr-title.yml$' || echo "$ARGS" | grep -q 'workflows/deploy-preview.yml$'; then
+  echo '{"created_at":"2020-01-01T00:00:00Z"}'
+  exit 0
+fi
+# countPushRuns: \`gh run list ... --json databaseId --jq length\` → scalar count (ci.yml alive, others 0).
+# (Distinct from fetchJobHistory below, which asks for --json databaseId,conclusion and wants an array.)
+if echo "$ARGS" | grep -q 'run list' && echo "$ARGS" | grep -q 'length'; then
+  if echo "$ARGS" | grep -q 'ci.yml'; then echo '5'; else echo '0'; fi
+  exit 0
+fi
+# fetchJobHistory: \`gh run list ... --json databaseId,conclusion\` → run array (ci.yml has 5 push runs).
+if echo "$ARGS" | grep -q 'run list' && echo "$ARGS" | grep -q 'databaseId,conclusion'; then
+  if echo "$ARGS" | grep -q 'ci.yml'; then
+    echo '[{"databaseId":1,"conclusion":"success"},{"databaseId":2,"conclusion":"success"},{"databaseId":3,"conclusion":"success"},{"databaseId":4,"conclusion":"success"},{"databaseId":5,"conclusion":"success"}]'
+  else
+    echo '[]'
+  fi
+  exit 0
+fi
+# any other run list → empty
+if echo "$ARGS" | grep -q 'run list'; then
+  echo '[]'
+  exit 0
+fi
+# run view — build job conclusion is skipped in all 5 runs
+if echo "$ARGS" | grep -q 'run view'; then
+  echo '{"conclusion":"success","jobs":[{"name":"Build","conclusion":"skipped"}]}'
+  exit 0
+fi
+# merge commits
+if echo "$ARGS" | grep -q 'log' || echo "$ARGS" | grep -q 'commits'; then
+  echo '[{"sha":"abc"},{"sha":"def"},{"sha":"ghi"},{"sha":"jkl"},{"sha":"mno"}]'
+  exit 0
+fi
+echo '{}'
+exit 0`,
+    )
+
+    const result = runDoctor(tmpDir, ['--json'])
+    const parsed = JSON.parse(result.stdout) as Array<{
+      name: string
+      checks: Array<{ name: string; status: string; detail: string }>
+    }>
+    const deadGates = parsed.find((s) => s.name === 'Dead Gates')
+    expect(deadGates).toBeDefined()
+
+    // Non-vacuous: the detector MUST run (fake countPushRuns returns 5 for ci.yml) and flag the
+    // required Build job that skips every run → fail, sub-grouped by job (#579 signature).
+    const dormantCheck = deadGates?.checks.find((c) => c.name.includes('Build') && c.name.includes('dormancy'))
+    expect(dormantCheck).toBeDefined()
+    expect(dormantCheck?.status).toBe('fail')
+    expect(dormantCheck?.detail).toContain('required status check')
+    expect(dormantCheck?.name).toContain('ci.yml:main:Build')
+  })
+
+  // ── AC-11: conditional_ok job → not flagged ────────────────────────────────────
+  it('AC-11: conditional_ok job (has if:, not required) is not flagged', () => {
+    fs.mkdirSync(path.join(tmpDir, '.github', 'workflows'), { recursive: true })
+    fs.writeFileSync(
+      path.join(tmpDir, '.github', 'workflows', 'ci.yml'),
+      [
+        'name: CI',
+        'on:',
+        '  push:',
+        '    branches: [main]',
+        'jobs:',
+        '  deploy:',
+        '    name: Deploy',
+        '    if: github.ref == "refs/heads/main"',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - run: echo deploy',
+      ].join('\n'),
+    )
+
+    // Fake gh: no required contexts, deploy job always skipped
+    makeFakeExec(
+      tmpDir,
+      'gh',
+      `#!/bin/sh
+ARGS="$*"
+if echo "$ARGS" | grep -q 'repos/TestOrg/test-repo$'; then
+  echo '{"created_at":"2020-01-01T00:00:00Z","visibility":"public"}'
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'required_status_checks$'; then
+  echo '{"contexts":[],"checks":[]}'
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'rules/branches'; then
+  echo '[]'
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'branches/main$' || echo "$ARGS" | grep -q 'branches/staging$'; then
+  echo '{"name":"main"}'
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'workflows'; then
+  echo '{"created_at":"2020-01-01T00:00:00Z"}'
+  exit 0
+fi
+# countPushRuns (--jq length) → scalar; fetchJobHistory (--json databaseId,conclusion) → array.
+if echo "$ARGS" | grep -q 'run list' && echo "$ARGS" | grep -q 'length'; then
+  if echo "$ARGS" | grep -q 'ci.yml'; then echo '5'; else echo '0'; fi
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'run list' && echo "$ARGS" | grep -q 'databaseId,conclusion'; then
+  if echo "$ARGS" | grep -q 'ci.yml'; then
+    echo '[{"databaseId":1,"conclusion":"success"},{"databaseId":2,"conclusion":"success"},{"databaseId":3,"conclusion":"success"},{"databaseId":4,"conclusion":"success"},{"databaseId":5,"conclusion":"success"}]'
+  else
+    echo '[]'
+  fi
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'run list'; then
+  echo '[]'
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'run view'; then
+  echo '{"conclusion":"success","jobs":[{"name":"Deploy","conclusion":"skipped"}]}'
+  exit 0
+fi
+echo '{}'
+exit 0`,
+    )
+
+    const result = runDoctor(tmpDir, ['--json'])
+    const parsed = JSON.parse(result.stdout) as Array<{
+      name: string
+      checks: Array<{ name: string; status: string }>
+    }>
+    const deadGates = parsed.find((s) => s.name === 'Dead Gates')
+    expect(deadGates).toBeDefined()
+
+    // True negative: the harness demonstrably runs the detector (proven by AC-10, which uses the
+    // same fake-gh mechanism and DOES flag a required dormant job). Here the only job is a
+    // conditional `if:` job that is not required and skips every run → conditional_ok → no Check.
+    const deployDormant = deadGates?.checks.find((c) => c.name.includes('Deploy') && c.name.includes('dormancy'))
+    expect(deployDormant).toBeUndefined()
+  })
+
+  // ── Clean state (spec criterion): every job executes → no dormancy finding ──────
+  it('clean state: a workflow whose jobs all execute produces no dormancy finding', () => {
+    fs.mkdirSync(path.join(tmpDir, '.github', 'workflows'), { recursive: true })
+    fs.writeFileSync(
+      path.join(tmpDir, '.github', 'workflows', 'ci.yml'),
+      [
+        'name: CI',
+        'on:',
+        '  push:',
+        '    branches: [main]',
+        'jobs:',
+        '  build:',
+        '    name: Build',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - run: echo ok',
+      ].join('\n'),
+    )
+
+    // Fake gh: every workflow is alive (countPushRuns=5 → push-gate B never fails), the Build
+    // job executes in every run → classifyDormancy returns alive → sub-check C emits nothing.
+    makeFakeExec(
+      tmpDir,
+      'gh',
+      `#!/bin/sh
+ARGS="$*"
+if echo "$ARGS" | grep -q 'repos/TestOrg/test-repo$'; then
+  echo '{"created_at":"2020-01-01T00:00:00Z","visibility":"public"}'; exit 0
+fi
+if echo "$ARGS" | grep -q 'required_status_checks$'; then
+  echo '{"contexts":[],"checks":[]}'; exit 0
+fi
+if echo "$ARGS" | grep -q 'rules/branches'; then
+  echo '[]'; exit 0
+fi
+if echo "$ARGS" | grep -q 'branches/main$' || echo "$ARGS" | grep -q 'branches/staging$'; then
+  echo '{"name":"main"}'; exit 0
+fi
+if echo "$ARGS" | grep -q 'workflows'; then
+  echo '{"created_at":"2020-01-01T00:00:00Z"}'; exit 0
+fi
+if echo "$ARGS" | grep -q 'run list' && echo "$ARGS" | grep -q 'length'; then
+  echo '5'; exit 0
+fi
+if echo "$ARGS" | grep -q 'run list' && echo "$ARGS" | grep -q 'databaseId,conclusion'; then
+  if echo "$ARGS" | grep -q 'ci.yml'; then
+    echo '[{"databaseId":1,"conclusion":"success"},{"databaseId":2,"conclusion":"success"},{"databaseId":3,"conclusion":"success"},{"databaseId":4,"conclusion":"success"},{"databaseId":5,"conclusion":"success"}]'
+  else
+    echo '[]'
+  fi
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'run list'; then echo '[]'; exit 0; fi
+if echo "$ARGS" | grep -q 'run view'; then
+  echo '{"conclusion":"success","jobs":[{"name":"Build","conclusion":"success"}]}'; exit 0
+fi
+echo '{}'
+exit 0`,
+    )
+
+    const result = runDoctor(tmpDir, ['--json'])
+    const parsed = JSON.parse(result.stdout) as Array<{
+      name: string
+      checks: Array<{ name: string; status: string; detail?: string }>
+    }>
+    const deadGates = parsed.find((s) => s.name === 'Dead Gates')
+    expect(deadGates).toBeDefined()
+    // No per-job dormancy Check when every job executes.
+    expect(deadGates?.checks.find((c) => c.name.includes('dormancy'))).toBeUndefined()
+    // Section is fully healthy: no fail or warn from any sub-check (A token-taxonomy, B push-gate, C dormancy).
+    expect(deadGates?.checks.filter((c) => c.status === 'fail' || c.status === 'warn')).toHaveLength(0)
+    // (Note: sub-check A always emits a token-taxonomy Check, so the `checks.length === 0` fallback
+    // in checkDeadGates is defensively unreachable here; clean-state is signalled by the absence of
+    // fail/warn findings, with token-taxonomy reporting pass.)
+    expect(deadGates?.checks.find((c) => c.name === 'token taxonomy')?.status).toBe('pass')
+  })
+
+  // ── dormant_wiring WARN render (spec AC-6 at integration level) ─────────────────
+  it('AC-6 (render): an unconditional job skipped every run → warn check in Dead Gates section', () => {
+    fs.mkdirSync(path.join(tmpDir, '.github', 'workflows'), { recursive: true })
+    fs.writeFileSync(
+      path.join(tmpDir, '.github', 'workflows', 'ci.yml'),
+      [
+        'name: CI',
+        'on:',
+        '  push:',
+        '    branches: [main]',
+        'jobs:',
+        '  lint:',
+        '    name: Lint',
+        '    needs: [build]',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - run: echo lint',
+      ].join('\n'),
+    )
+
+    // Fake gh: ci.yml alive, Lint not a required context, Lint skipped in every run (broken needs).
+    // No job-level if: → classifyDormancy returns dormant_wiring → warn.
+    makeFakeExec(
+      tmpDir,
+      'gh',
+      `#!/bin/sh
+ARGS="$*"
+if echo "$ARGS" | grep -q 'repos/TestOrg/test-repo$'; then
+  echo '{"created_at":"2020-01-01T00:00:00Z","visibility":"public"}'; exit 0
+fi
+if echo "$ARGS" | grep -q 'required_status_checks$'; then
+  echo '{"contexts":[],"checks":[]}'; exit 0
+fi
+if echo "$ARGS" | grep -q 'rules/branches'; then
+  echo '[]'; exit 0
+fi
+if echo "$ARGS" | grep -q 'branches/main$' || echo "$ARGS" | grep -q 'branches/staging$'; then
+  echo '{"name":"main"}'; exit 0
+fi
+if echo "$ARGS" | grep -q 'workflows'; then
+  echo '{"created_at":"2020-01-01T00:00:00Z"}'; exit 0
+fi
+if echo "$ARGS" | grep -q 'run list' && echo "$ARGS" | grep -q 'length'; then
+  if echo "$ARGS" | grep -q 'ci.yml'; then echo '5'; else echo '0'; fi
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'run list' && echo "$ARGS" | grep -q 'databaseId,conclusion'; then
+  if echo "$ARGS" | grep -q 'ci.yml'; then
+    echo '[{"databaseId":1,"conclusion":"success"},{"databaseId":2,"conclusion":"success"},{"databaseId":3,"conclusion":"success"},{"databaseId":4,"conclusion":"success"},{"databaseId":5,"conclusion":"success"}]'
+  else
+    echo '[]'
+  fi
+  exit 0
+fi
+if echo "$ARGS" | grep -q 'run list'; then echo '[]'; exit 0; fi
+if echo "$ARGS" | grep -q 'run view'; then
+  echo '{"conclusion":"success","jobs":[{"name":"Lint","conclusion":"skipped"}]}'; exit 0
+fi
+echo '{}'
+exit 0`,
+    )
+
+    const result = runDoctor(tmpDir, ['--json'])
+    const parsed = JSON.parse(result.stdout) as Array<{
+      name: string
+      checks: Array<{ name: string; status: string; detail: string }>
+    }>
+    const deadGates = parsed.find((s) => s.name === 'Dead Gates')
+    expect(deadGates).toBeDefined()
+    const lintDormant = deadGates?.checks.find((c) => c.name.includes('Lint') && c.name.includes('dormancy'))
+    expect(lintDormant).toBeDefined()
+    expect(lintDormant?.status).toBe('warn')
+    expect(lintDormant?.detail).toContain('dead wiring')
+    expect(lintDormant?.name).toContain('ci.yml:main:Lint')
+  })
+})
+
+// ─── AC-6: parseWorkflowJobs ────────────────────────────────────────────────
+
+describe('parseWorkflowJobs', () => {
+  it('AC-6a: parses job id, displayName, hasIf=false, matrixEmpty=false, needs', () => {
+    const yaml = [
+      'jobs:',
+      '  build:',
+      '    name: Build App',
+      '    runs-on: ubuntu-latest',
+      '    needs: [lint]',
+      '    steps:',
+      '      - run: echo ok',
+    ].join('\n')
+    const jobs = parseWorkflowJobs(yaml)
+    expect(jobs).toHaveLength(1)
+    expect(jobs[0].id).toBe('build')
+    expect(jobs[0].displayName).toBe('Build App')
+    expect(jobs[0].hasIf).toBe(false)
+    expect(jobs[0].matrixEmpty).toBe(false)
+    expect(jobs[0].needs).toEqual(['lint'])
+  })
+
+  it('AC-6b: uses job id as displayName when name: is absent', () => {
+    const yaml = ['jobs:', '  deploy:', '    runs-on: ubuntu-latest', '    steps:', '      - run: echo deploy'].join(
+      '\n',
+    )
+    const jobs = parseWorkflowJobs(yaml)
+    expect(jobs).toHaveLength(1)
+    expect(jobs[0].id).toBe('deploy')
+    expect(jobs[0].displayName).toBe('deploy')
+  })
+
+  it('AC-6c: hasIf=true when job has an if: condition', () => {
+    const yaml = [
+      'jobs:',
+      '  release:',
+      '    if: github.ref == "refs/heads/main"',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - run: echo release',
+    ].join('\n')
+    const jobs = parseWorkflowJobs(yaml)
+    expect(jobs[0].hasIf).toBe(true)
+  })
+
+  it('AC-6d: matrixEmpty=true when matrix has an empty array axis', () => {
+    const yaml = [
+      'jobs:',
+      '  test:',
+      '    strategy:',
+      '      matrix:',
+      '        os: []',
+      '    runs-on: ${{ matrix.os }}',
+      '    steps:',
+      '      - run: echo test',
+    ].join('\n')
+    const jobs = parseWorkflowJobs(yaml)
+    expect(jobs[0].matrixEmpty).toBe(true)
+  })
+
+  it('AC-6e: matrixEmpty=false for non-empty matrix', () => {
+    const yaml = [
+      'jobs:',
+      '  test:',
+      '    strategy:',
+      '      matrix:',
+      '        os: [ubuntu-latest, windows-latest]',
+      '    runs-on: ${{ matrix.os }}',
+      '    steps:',
+      '      - run: echo test',
+    ].join('\n')
+    const jobs = parseWorkflowJobs(yaml)
+    expect(jobs[0].matrixEmpty).toBe(false)
+  })
+
+  it('AC-6f: needs as string (single dep) parsed as array', () => {
+    const yaml = [
+      'jobs:',
+      '  e2e:',
+      '    needs: build',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - run: echo e2e',
+    ].join('\n')
+    const jobs = parseWorkflowJobs(yaml)
+    expect(jobs[0].needs).toContain('build')
+  })
+})
+
+// ─── AC-7: classifyDormancy ──────────────────────────────────────────────────
+
+describe('classifyDormancy', () => {
+  const job: ParsedJob = { id: 'build', displayName: 'Build', hasIf: false, matrixEmpty: false, needs: [] }
+
+  it('AC-7a: considered < minRuns → alive', () => {
+    const stats: JobRunStats = { considered: 3, executed: 0, skipped: 3 }
+    expect(classifyDormancy(job, stats, true, 5)).toBe('alive')
+  })
+
+  it('AC-7b: executed > 0 → alive', () => {
+    const stats: JobRunStats = { considered: 10, executed: 2, skipped: 8 }
+    expect(classifyDormancy(job, stats, true, 5)).toBe('alive')
+  })
+
+  it('AC-7c: executed == 0, considered >= minRuns, isRequired → dormant_required', () => {
+    const stats: JobRunStats = { considered: 5, executed: 0, skipped: 5 }
+    expect(classifyDormancy(job, stats, true, 5)).toBe('dormant_required')
+  })
+
+  it('AC-7d: executed == 0, considered >= minRuns, matrixEmpty, not required → dormant_wiring', () => {
+    const matrixJob: ParsedJob = { ...job, matrixEmpty: true }
+    const stats: JobRunStats = { considered: 5, executed: 0, skipped: 5 }
+    expect(classifyDormancy(matrixJob, stats, false, 5)).toBe('dormant_wiring')
+  })
+
+  it('AC-7e: executed == 0, considered >= minRuns, no if, not required, not matrixEmpty → dormant_wiring', () => {
+    const stats: JobRunStats = { considered: 5, executed: 0, skipped: 5 }
+    expect(classifyDormancy(job, stats, false, 5)).toBe('dormant_wiring')
+  })
+
+  it('AC-7f: executed == 0, considered >= minRuns, has if, not required → conditional_ok', () => {
+    const ifJob: ParsedJob = { ...job, hasIf: true }
+    const stats: JobRunStats = { considered: 5, executed: 0, skipped: 5 }
+    expect(classifyDormancy(ifJob, stats, false, 5)).toBe('conditional_ok')
+  })
+})
+
+// ─── AC-8: aggregateJobStats ─────────────────────────────────────────────────
+
+describe('aggregateJobStats', () => {
+  const job: ParsedJob = { id: 'build', displayName: 'Build', hasIf: false, matrixEmpty: false, needs: [] }
+
+  it('AC-8a: skipped and cancelled runs excluded from eligible set', () => {
+    const runs: RunRecord[] = [
+      { runConclusion: 'skipped', jobs: [{ name: 'Build', conclusion: 'success' }] },
+      { runConclusion: 'cancelled', jobs: [{ name: 'Build', conclusion: 'success' }] },
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: 'success' }] },
+    ]
+    const stats = aggregateJobStats(job, runs)
+    // Only the third run is eligible; considered = 1, executed = 1
+    expect(stats.considered).toBe(1)
+    expect(stats.executed).toBe(1)
+  })
+
+  it('AC-8b: absent job (job not present in run) does not count toward considered', () => {
+    const runs: RunRecord[] = [
+      { runConclusion: 'success', jobs: [] },
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: 'success' }] },
+    ]
+    const stats = aggregateJobStats(job, runs)
+    // First run: eligible but job absent → not considered
+    // Second run: eligible + job present → considered + executed
+    expect(stats.considered).toBe(1)
+    expect(stats.executed).toBe(1)
+  })
+
+  it('AC-8c: skipped job conclusion does not count as executed', () => {
+    const runs: RunRecord[] = [
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: 'skipped' }] },
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: 'skipped' }] },
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: 'skipped' }] },
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: 'skipped' }] },
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: 'skipped' }] },
+    ]
+    const stats = aggregateJobStats(job, runs)
+    expect(stats.considered).toBe(5)
+    expect(stats.executed).toBe(0)
+    expect(stats.skipped).toBe(5)
+  })
+
+  it('AC-8d: matrix leg matching via displayName prefix', () => {
+    // Matrix leg: "Build (ubuntu-latest)" matches job with displayName "Build"
+    const runs: RunRecord[] = [
+      { runConclusion: 'success', jobs: [{ name: 'Build (ubuntu-latest)', conclusion: 'success' }] },
+      { runConclusion: 'success', jobs: [{ name: 'Build (windows-latest)', conclusion: 'skipped' }] },
+    ]
+    const stats = aggregateJobStats(job, runs)
+    // Both runs have a matching leg → both considered; 1 executed (ubuntu), 1 skipped (windows)
+    expect(stats.considered).toBe(2)
+    expect(stats.executed).toBe(1)
+    expect(stats.skipped).toBe(1)
+  })
+
+  it('AC-8e: exact name match (no matrix leg) works', () => {
+    const runs: RunRecord[] = [{ runConclusion: 'success', jobs: [{ name: 'Build', conclusion: 'success' }] }]
+    const stats = aggregateJobStats(job, runs)
+    expect(stats.considered).toBe(1)
+    expect(stats.executed).toBe(1)
+  })
+})
+
+// ─── AC-9: parseRequiredContexts ─────────────────────────────────────────────
+
+describe('parseRequiredContexts', () => {
+  it('AC-9a: classic dual-root form — top-level contexts array', () => {
+    const json = JSON.stringify({ contexts: ['ci', 'Build'], checks: [] })
+    const result = parseRequiredContexts(json)
+    expect(result.has('ci')).toBe(true)
+    expect(result.has('Build')).toBe(true)
+  })
+
+  it('AC-9b: classic dual-root form — top-level checks array with context field', () => {
+    const json = JSON.stringify({ contexts: [], checks: [{ context: 'trufflehog' }] })
+    const result = parseRequiredContexts(json)
+    expect(result.has('trufflehog')).toBe(true)
+  })
+
+  it('AC-9c: ruleset form — required_status_checks rule with contexts array', () => {
+    const json = JSON.stringify([
+      {
+        type: 'required_status_checks',
+        parameters: { required_status_checks: [{ context: 'ci' }, { context: 'lint' }] },
+      },
+    ])
+    const result = parseRequiredContexts(json)
+    expect(result.has('ci')).toBe(true)
+    expect(result.has('lint')).toBe(true)
+  })
+
+  it('AC-9d: empty / 404 response (empty string) → empty set (fail-open)', () => {
+    const result = parseRequiredContexts('')
+    expect(result.size).toBe(0)
+  })
+
+  it('AC-9e: malformed JSON → empty set (fail-open)', () => {
+    const result = parseRequiredContexts('not json at all')
+    expect(result.size).toBe(0)
+  })
+
+  it('AC-9f: union of contexts + checks in dual-root form', () => {
+    const json = JSON.stringify({ contexts: ['Build'], checks: [{ context: 'lint' }] })
+    const result = parseRequiredContexts(json)
+    expect(result.has('Build')).toBe(true)
+    expect(result.has('lint')).toBe(true)
+    expect(result.size).toBe(2)
+  })
+})
+
+// ─── --repo correctness (spec criterion, source inspection) ──────────────────
+// `gh run list` / `gh run view` MUST carry `--repo owner/repo` (cron-safe from any cwd), whereas
+// `gh api` MUST NOT (it embeds owner/repo in the path and errors on `--repo`). The latter is a
+// regression guard: an earlier draft passed `--repo` to fetchRequiredContexts' `gh api` calls,
+// which fail-open silently and disabled the AC-7 (dormant_required) escalation in production.
+
+describe('--repo correctness', () => {
+  const source = fs.readFileSync(new URL('../doctor-github.ts', import.meta.url), 'utf8')
+
+  const bodyOf = (fnName: string): string => {
+    const start = source.indexOf(`export function ${fnName}`)
+    expect(start).toBeGreaterThan(-1)
+    const rest = source.slice(start + 1)
+    const next = rest.search(/\nexport (function|interface|type|const) /)
+    return next === -1 ? rest : rest.slice(0, next)
+  }
+
+  it('fetchJobHistory passes --repo on every gh run list / gh run view call', () => {
+    const body = bodyOf('fetchJobHistory')
+    expect(body).toContain("'list'")
+    expect(body).toContain("'view'")
+    const repoCount = (body.match(/'--repo'/g) ?? []).length
+    expect(repoCount).toBeGreaterThanOrEqual(2)
+  })
+
+  it('fetchRequiredContexts does NOT pass --repo on gh api calls (gh api rejects --repo → fail-open)', () => {
+    const body = bodyOf('fetchRequiredContexts')
+    expect(body).toContain("'api'")
+    expect(body).not.toContain("'--repo'")
   })
 })

--- a/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
@@ -561,16 +561,31 @@ describe('checkDeadGates (integration via subprocess)', () => {
   })
 
   it('AC-1 (read-only): doctor does not mutate repo or run state', () => {
-    // Read-only: running doctor twice produces the same output
-    const result1 = runDoctor(tmpDir, ['--json'])
-    const result2 = runDoctor(tmpDir, ['--json'])
+    // Snapshot the fixture tree (relative path → contents) so we can assert nothing changed.
+    const snapshot = (root: string): Record<string, string> => {
+      const out: Record<string, string> = {}
+      const walk = (d: string) => {
+        for (const name of fs.readdirSync(d)) {
+          const full = path.join(d, name)
+          if (fs.statSync(full).isDirectory()) walk(full)
+          else out[path.relative(root, full)] = fs.readFileSync(full, 'utf8')
+        }
+      }
+      walk(root)
+      return out
+    }
 
-    // Both runs parse successfully
-    expect(() => JSON.parse(result1.stdout)).not.toThrow()
-    expect(() => JSON.parse(result2.stdout)).not.toThrow()
+    const before = snapshot(tmpDir)
+    const result = runDoctor(tmpDir, ['--json'])
+    const after = snapshot(tmpDir)
 
-    // Outputs are identical (no state written between runs)
-    expect(result1.stdout).toBe(result2.stdout)
+    // Doctor ran successfully (valid JSON) and mutated nothing in the repo — the true read-only
+    // property. We deliberately do NOT byte-compare two stdout captures: doctor's live environment
+    // probes (e.g. `which trufflehog`, `command -v roxabi`) can flap under concurrent pre-push load
+    // without any state mutation, which made the old `result1.stdout === result2.stdout` assertion
+    // flaky under the 4-way parallel pre-push (see trufflehog-prepush-flake memory / #288).
+    expect(() => JSON.parse(result.stdout)).not.toThrow()
+    expect(after).toEqual(before)
   })
 
   // ── AC-10: dormant_required job → fail check in Doctor output ─────────────────

--- a/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
@@ -7,6 +7,7 @@ import {
   classifyDormancy,
   DORMANCY_MIN_RUNS,
   detectUnsafeTokenInTriggeredWorkflow,
+  isJobRequired,
   type JobRunStats,
   type ParsedJob,
   parseRequiredContexts,
@@ -27,7 +28,7 @@ import {
  * | Push-gate history    | AC-4  | integration > AC-4                                     |
  * | Section render       | AC-5  | integration > AC-5                                     |
  * | Wiring-warn          | AC-6  | integration > dormant_wiring WARN + unit AC-7d/7e      |
- * | Required-fail        | AC-7  | integration > AC-10 (dormant_required → fail)          |
+ * | Required-fail        | AC-7  | integration > AC-10 + unit > isJobRequired (matrix leg)|
  * | Conditional-ok       | AC-8  | integration > AC-11 (conditional_ok → not flagged)     |
  * | Grace window         | AC-9  | integration > SC3 grace window                         |
  * | Render contract      | AC-10 | integration > AC-10 (named check, sub-grouped)         |
@@ -380,8 +381,13 @@ describe('checkDeadGates (integration via subprocess)', () => {
         // branches staging/main: exist
         '  "api repos/TestOrg/test-repo/branches/staging") echo "{}"; exit 0 ;;',
         '  "api repos/TestOrg/test-repo/branches/main") echo "{}"; exit 0 ;;',
-        // push run count: return 0 (no push runs landed)
-        '  "run list"*"--event"*"push"*"--json"*"databaseId"*) echo "0"; exit 0 ;;',
+        // push run count (scalar): countPushRuns uses `--json databaseId --jq length` → return 0.
+        // The `--jq` anchor keeps this from also answering fetchJobHistory's `--json databaseId,conclusion`
+        // (array) call — distinct shapes must not collide (#288 review #5).
+        '  "run list"*"--event"*"push"*"--json databaseId --jq"*) echo "0"; exit 0 ;;',
+        // job-history list (array shape): defensive — pushCount=0 short-circuits before this fires,
+        // but answer with a valid empty array so a future pushCount>0 fixture never gets "0".
+        '  "run list"*"--json databaseId,conclusion"*) echo "[]"; exit 0 ;;',
         // merge commit count: ≥5 merges
         '  "api repos/TestOrg/test-repo/commits"*) echo "7"; exit 0 ;;',
         '  "label list"*) echo "[]"; exit 0 ;;',
@@ -467,7 +473,9 @@ describe('checkDeadGates (integration via subprocess)', () => {
         '  "repo view"*"createdAt"*) echo "2020-01-01T00:00:00Z"; exit 0 ;;',
         '  "api repos/TestOrg/test-repo/branches/staging") echo "{}"; exit 0 ;;',
         '  "api repos/TestOrg/test-repo/branches/main") echo "{}"; exit 0 ;;',
-        '  "run list"*"--event"*"push"*"--json"*"databaseId"*) echo "0"; exit 0 ;;',
+        // scalar push-run count (anchored on `--jq`) vs array job-history shape — see #288 review #5.
+        '  "run list"*"--event"*"push"*"--json databaseId --jq"*) echo "0"; exit 0 ;;',
+        '  "run list"*"--json databaseId,conclusion"*) echo "[]"; exit 0 ;;',
         '  "api repos/TestOrg/test-repo/actions/workflows/"*) date -u -d "2 days ago" +%Y-%m-%dT%H:%M:%SZ; exit 0 ;;',
         '  "api repos/TestOrg/test-repo/commits"*) echo "7"; exit 0 ;;',
         '  "label list"*) echo "[]"; exit 0 ;;',
@@ -1101,6 +1109,64 @@ describe('aggregateJobStats', () => {
     expect(stats.considered).toBe(1)
     expect(stats.executed).toBe(1)
   })
+
+  it('AC-8f (#288 review #2): null/empty conclusion (in-progress) does not count as executed', () => {
+    // A run still in progress reports a null (here empty-string) conclusion. Counting it as
+    // executed would fail-open and mask a dormant required gate, so it must land in `skipped`.
+    const runs: RunRecord[] = [
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: '' }] },
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: 'skipped' }] },
+    ]
+    const stats = aggregateJobStats(job, runs)
+    expect(stats.considered).toBe(2)
+    expect(stats.executed).toBe(0)
+    expect(stats.skipped).toBe(2)
+  })
+
+  it('AC-8g (#288 review #3): a sibling job sharing the matrix prefix is not absorbed', () => {
+    // The matrix parent "Build" never runs its own leg (always skipped → dormant), while a SEPARATE
+    // static job literally named "Build (debug)" runs every time. Without sibling exclusion the
+    // sibling's success masks the parent's dormancy. With it, the parent is correctly all-skipped.
+    const runs: RunRecord[] = Array.from({ length: 6 }, () => ({
+      runConclusion: 'success',
+      jobs: [
+        { name: 'Build (linux)', conclusion: 'skipped' }, // parent's real matrix leg — dormant
+        { name: 'Build (debug)', conclusion: 'success' }, // a separate job that shares the prefix
+      ],
+    }))
+    const withExclusion = aggregateJobStats(job, runs, new Set(['Build (debug)']))
+    expect(withExclusion.considered).toBe(6)
+    expect(withExclusion.executed).toBe(0) // sibling success must NOT mask the parent's dormancy
+    expect(withExclusion.skipped).toBe(6)
+
+    // Backward-compatible default: the legacy 2-arg call keeps the greedy prefix match (documents
+    // the prior behavior the caller now guards against by passing sibling names).
+    const greedy = aggregateJobStats(job, runs)
+    expect(greedy.executed).toBe(6)
+  })
+})
+
+// ─── isJobRequired (#288 review #1): matrix-leg-aware required-context match ──
+
+describe('isJobRequired', () => {
+  it('matches a non-matrix job by exact display name', () => {
+    expect(isJobRequired('Build', new Set(['Build', 'Lint']))).toBe(true)
+  })
+
+  it('matches a matrix job via any registered leg context (the bare parent name is never required)', () => {
+    // GitHub registers one required context per matrix leg ("Build (ubuntu-latest)"), never "Build".
+    const required = new Set(['Build (ubuntu-latest)', 'Build (windows-latest)'])
+    expect(isJobRequired('Build', required)).toBe(true)
+  })
+
+  it('does not false-positive on an unrelated context that merely shares a prefix substring', () => {
+    // "Build-extras" shares the "Build" prefix but is not a matrix leg (no " (") → not required.
+    expect(isJobRequired('Build', new Set(['Build-extras', 'lint (fast)']))).toBe(false)
+  })
+
+  it('returns false when the required set is empty (fail-open: nothing escalates)', () => {
+    expect(isJobRequired('Build', new Set())).toBe(false)
+  })
 })
 
 // ─── AC-9: parseRequiredContexts ─────────────────────────────────────────────
@@ -1160,10 +1226,12 @@ describe('--repo correctness', () => {
   const source = fs.readFileSync(new URL('../doctor-github.ts', import.meta.url), 'utf8')
 
   const bodyOf = (fnName: string): string => {
-    const start = source.indexOf(`export function ${fnName}`)
+    // Match `export function` and `export async function` alike — and stop the body at the next
+    // export of either form, so an async export never gets swallowed into the prior body.
+    const start = source.search(new RegExp(`export (?:async )?function ${fnName}\\b`))
     expect(start).toBeGreaterThan(-1)
     const rest = source.slice(start + 1)
-    const next = rest.search(/\nexport (function|interface|type|const) /)
+    const next = rest.search(/\nexport (?:async )?(function|interface|type|const) /)
     return next === -1 ? rest : rest.slice(0, next)
   }
 

--- a/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/dead-gate.test.ts
@@ -1126,16 +1126,18 @@ describe('aggregateJobStats', () => {
   })
 
   it('AC-8f (#288 review #2): null/empty conclusion (in-progress) does not count as executed', () => {
-    // A run still in progress reports a null (here empty-string) conclusion. Counting it as
-    // executed would fail-open and mask a dormant required gate, so it must land in `skipped`.
+    // A run still in progress reports a real `null` conclusion from `gh run view --json jobs` (the
+    // widened RunRecord type now admits it directly, iter-2). Counting it as executed would fail-open
+    // and mask a dormant required gate, so null — like '' and 'skipped' — must land in `skipped`.
     const runs: RunRecord[] = [
-      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: '' }] },
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: null }] }, // in-progress → null
+      { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: '' }] }, // legacy empty-string shape
       { runConclusion: 'success', jobs: [{ name: 'Build', conclusion: 'skipped' }] },
     ]
     const stats = aggregateJobStats(job, runs)
-    expect(stats.considered).toBe(2)
+    expect(stats.considered).toBe(3)
     expect(stats.executed).toBe(0)
-    expect(stats.skipped).toBe(2)
+    expect(stats.skipped).toBe(3)
   })
 
   it('AC-8g (#288 review #3): a sibling job sharing the matrix prefix is not absorbed', () => {
@@ -1181,6 +1183,24 @@ describe('isJobRequired', () => {
 
   it('returns false when the required set is empty (fail-open: nothing escalates)', () => {
     expect(isJobRequired('Build', new Set())).toBe(false)
+  })
+
+  it('(#288 review #1 iter-2): a required context owned by a sibling job is not claimed by the parent', () => {
+    // A separate static job literally named "Build (debug)" is required; the matrix parent "Build"
+    // is NOT. Passing "Build (debug)" as a sibling excludes it from the prefix match, so the dormant
+    // parent does not wrongly read as required and escalate to fail — the mirror of the
+    // aggregateJobStats sibling guard.
+    const required = new Set(['Build (debug)', 'Lint'])
+    expect(isJobRequired('Build', required, new Set(['Build (debug)']))).toBe(false)
+
+    // Greedy default (no sibling set) reproduces the pre-guard bug: the parent claims the sibling's
+    // context. Documents the exact behavior the dormancy caller now guards against.
+    expect(isJobRequired('Build', required)).toBe(true)
+
+    // A genuine matrix leg ("Build (ubuntu-latest)") is still matched even with siblings present.
+    expect(
+      isJobRequired('Build', new Set(['Build (ubuntu-latest)', 'Build (debug)']), new Set(['Build (debug)'])),
+    ).toBe(true)
   })
 })
 

--- a/plugins/dev-core/skills/checkup/doctor-github.ts
+++ b/plugins/dev-core/skills/checkup/doctor-github.ts
@@ -673,6 +673,8 @@ export function detectUnsafeTokenInTriggeredWorkflow(
  */
 const PUSH_GATE_MERGE_THRESHOLD = 5
 const GRACE_DAYS = 14
+export const DORMANCY_MIN_RUNS = 5
+export const DORMANCY_RUN_LIMIT = 10
 
 // Returns the age in days of the ISO timestamp in `result.stdout`, or Infinity when
 // it cannot be determined (fail-open: an unknown age never triggers a false dead-gate).
@@ -747,6 +749,425 @@ function countMergeCommits(owner: string, repo: string, branch: string, n: numbe
   if (!result.ok) return -1
   const count = parseInt(result.stdout.trim(), 10)
   return Number.isNaN(count) ? -1 : count
+}
+
+// ── T1: Workflow job parser ────────────────────────────────────────────────────
+
+export interface ParsedJob {
+  id: string
+  displayName: string
+  hasIf: boolean
+  matrixEmpty: boolean
+  needs: string[]
+}
+
+/**
+ * Pure parser: extract job metadata from a workflow YAML string.
+ * Uses the same 2-space header idiom as detectUnsafeTokenInTriggeredWorkflow.
+ * No I/O — safe to unit-test without a filesystem.
+ */
+export function parseWorkflowJobs(content: string): ParsedJob[] {
+  const lines = content.split('\n')
+
+  // Find `jobs:` section
+  let jobsSectionLine = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (/^jobs:\s*$/.test(lines[i])) {
+      jobsSectionLine = i
+      break
+    }
+  }
+  if (jobsSectionLine === -1) return []
+
+  // Collect 2-space-indented job headers under `jobs:`
+  const jobHeaders: Array<{ name: string; start: number }> = []
+  for (let i = jobsSectionLine + 1; i < lines.length; i++) {
+    const m = lines[i].match(/^ {2}([a-zA-Z0-9][a-zA-Z0-9_-]*):\s*$/)
+    if (m) {
+      jobHeaders.push({ name: m[1], start: i })
+    } else if (/^\S/.test(lines[i]) && lines[i].trim() && !lines[i].trimStart().startsWith('#')) {
+      break
+    }
+  }
+
+  const jobs: ParsedJob[] = []
+  for (let j = 0; j < jobHeaders.length; j++) {
+    const { name: id, start } = jobHeaders[j]
+    const end = j + 1 < jobHeaders.length ? jobHeaders[j + 1].start : lines.length
+    const jobLines = lines.slice(start + 1, end)
+
+    // Extract display name (4-space-indented `name:` field)
+    let displayName = id
+    for (const line of jobLines) {
+      const nm = line.match(/^ {4}name:\s+(.+)$/)
+      if (nm) {
+        displayName = nm[1].trim().replace(/^['"]|['"]$/g, '')
+        break
+      }
+    }
+
+    // Detect job-level `if:` (4-space-indented)
+    const hasIf = jobLines.some((l) => /^ {4}if:\s*\S/.test(l))
+
+    // Detect statically-empty matrix:
+    //   strategy.matrix: {}  or  strategy.matrix: []  or any axis: []
+    let matrixEmpty = false
+    let inMatrix = false
+    for (const line of jobLines) {
+      if (/^ {6}matrix:\s*$/.test(line) || /^ {6}matrix:\s*(\{\}|\[\])\s*$/.test(line)) {
+        inMatrix = true
+        if (/^ {6}matrix:\s*(\{\}|\[\])\s*$/.test(line)) matrixEmpty = true
+        continue
+      }
+      if (inMatrix) {
+        // An axis with an empty list: `      axis: []`
+        if (/^ {8}[a-zA-Z0-9_-]+:\s*\[\]\s*$/.test(line)) {
+          matrixEmpty = true
+        }
+        // Left the matrix block
+        if (/^ {0,5}\S/.test(line)) inMatrix = false
+      }
+    }
+
+    // Extract needs: (scalar string, inline array, or YAML list)
+    const needs: string[] = []
+    let inNeeds = false
+    for (const line of jobLines) {
+      if (/^ {4}needs:\s*\S/.test(line)) {
+        const val = line.replace(/^ {4}needs:\s*/, '').trim()
+        if (val.startsWith('[') && val.endsWith(']')) {
+          // Inline array: `    needs: [build, lint]`
+          const inner = val.slice(1, -1)
+          for (const item of inner.split(',')) {
+            const trimmed = item.trim().replace(/^['"]|['"]$/g, '')
+            if (trimmed) needs.push(trimmed)
+          }
+        } else {
+          // Scalar: `    needs: build`
+          needs.push(val.replace(/^['"]|['"]$/g, ''))
+        }
+        inNeeds = false
+        continue
+      }
+      if (/^ {4}needs:\s*$/.test(line)) {
+        inNeeds = true
+        continue
+      }
+      if (inNeeds) {
+        const item = line.match(/^ {6}-\s+(.+)$/)
+        if (item) {
+          needs.push(item[1].trim().replace(/^['"]|['"]$/g, ''))
+        } else {
+          inNeeds = false
+        }
+      }
+    }
+
+    jobs.push({ id, displayName, hasIf, matrixEmpty, needs })
+  }
+
+  return jobs
+}
+
+// ── T2: Dormancy verdict ───────────────────────────────────────────────────────
+
+export type DormancyVerdict = 'alive' | 'dormant_required' | 'dormant_wiring' | 'conditional_ok'
+
+/**
+ * Pure verdict function — no I/O.
+ * Precedence: insufficient history → alive; executed > 0 → alive;
+ * required check → fail (dormant_required); empty matrix or no if → warn (dormant_wiring);
+ * has if + not required → conditional_ok (not flagged).
+ */
+export function classifyDormancy(
+  job: ParsedJob,
+  stats: JobRunStats,
+  isRequired: boolean,
+  minRuns: number,
+): DormancyVerdict {
+  if (stats.considered < minRuns) return 'alive'
+  if (stats.executed > 0) return 'alive'
+  // executed == 0 and sufficient history
+  if (isRequired) return 'dormant_required'
+  if (job.matrixEmpty || !job.hasIf) return 'dormant_wiring'
+  return 'conditional_ok'
+}
+
+// ── T3: Run-history aggregation ────────────────────────────────────────────────
+
+export interface JobRunStats {
+  considered: number
+  executed: number
+  skipped: number
+}
+
+export interface RunRecord {
+  runConclusion: string
+  jobs: Array<{ name: string; conclusion: string }>
+}
+
+/**
+ * Pure aggregation: given a list of run records and a parsed job, return JobRunStats.
+ * Run-level eligibility: exclude runs with runConclusion ∈ {skipped, cancelled}.
+ * Absent-job exclusion: considered counts only retained runs where the job entry appears.
+ * Matrix-leg matching: anchored prefix — historyName === displayName OR startsWith(displayName + ' (').
+ * skipped conclusion never counts as executed.
+ */
+export function aggregateJobStats(job: ParsedJob, runs: RunRecord[]): JobRunStats {
+  let considered = 0
+  let executed = 0
+  let skipped = 0
+
+  for (const run of runs) {
+    const c = run.runConclusion
+    if (c === 'skipped' || c === 'cancelled') continue
+
+    // Find all job entries for this job (direct match or matrix leg)
+    const matching = run.jobs.filter((j) => j.name === job.displayName || j.name.startsWith(job.displayName + ' ('))
+    if (matching.length === 0) continue // job absent from this run — don't count
+
+    considered++
+    // At least one leg ran (not skipped) → executed
+    const anyExecuted = matching.some((j) => j.conclusion !== 'skipped')
+    if (anyExecuted) {
+      executed++
+    } else {
+      skipped++
+    }
+  }
+
+  return { considered, executed, skipped }
+}
+
+// ── T4: Required-context lookup + job history fetch ───────────────────────────
+
+/**
+ * Pure parser: extract required check contexts from a branch-protection API response.
+ * Handles both response shapes so each source can be parsed by the same function:
+ *   - classic protection (object): dual-root `contexts[]` + `checks[].context`,
+ *     and the `required_status_checks` nested form.
+ *   - ruleset rules (top-level array): each `required_status_checks` rule's
+ *     `parameters.required_status_checks[].context`.
+ * Any parse failure / empty string → ∅ (fail-open: a missing protection response never escalates).
+ */
+export function parseRequiredContexts(apiJson: string): Set<string> {
+  const out = new Set<string>()
+  try {
+    const data = JSON.parse(apiJson)
+    if (!data || typeof data !== 'object') return out
+
+    // Ruleset endpoint: a top-level array of rules — collect required_status_checks contexts.
+    if (Array.isArray(data)) {
+      for (const rule of data) {
+        if (rule?.type === 'required_status_checks' && Array.isArray(rule?.parameters?.required_status_checks)) {
+          for (const rsc of rule.parameters.required_status_checks) {
+            if (rsc && typeof rsc.context === 'string') out.add(rsc.context)
+          }
+        }
+      }
+      return out
+    }
+
+    // Classic endpoint: `required_status_checks.contexts[]` or top-level `contexts[]`
+    const rsc = data.required_status_checks ?? data
+    if (Array.isArray(rsc.contexts)) {
+      for (const ctx of rsc.contexts) {
+        if (typeof ctx === 'string') out.add(ctx)
+      }
+    }
+    // Classic endpoint (modern Checks-API): `.checks[].context` at rsc level or top-level
+    if (Array.isArray(rsc.checks)) {
+      for (const ch of rsc.checks) {
+        if (ch && typeof ch.context === 'string') out.add(ch.context)
+      }
+    }
+  } catch {
+    // parse failure → contribute nothing (fail-open)
+  }
+  return out
+}
+
+/**
+ * Fetch required status check contexts for a branch, unioning three sources:
+ * 1. Classic branch protection `contexts[]`
+ * 2. Classic branch protection `checks[].context`
+ * 3. Ruleset `required_status_checks` rule contexts
+ * Any 404 / error → contributes ∅ (fail-open: never escalates).
+ */
+export function fetchRequiredContexts(owner: string, repo: string, branch: string): Set<string> {
+  const out = new Set<string>()
+
+  // Source 1+2: classic branch protection. NOTE: `gh api` does NOT accept --repo (the owner/repo
+  // is embedded in the path); passing it errors with "unknown flag: --repo" → result.ok=false →
+  // fail-open. --repo belongs only on `gh run list`/`gh run view` (see fetchJobHistory).
+  const classicResult = spawnSync([
+    'gh',
+    'api',
+    `repos/${owner}/${repo}/branches/${branch}/protection/required_status_checks`,
+  ])
+  if (classicResult.ok) {
+    for (const ctx of parseRequiredContexts(classicResult.stdout)) out.add(ctx)
+  }
+
+  // Source 3: ruleset `required_status_checks` rule contexts (parsed by the same fn)
+  const rulesetResult = spawnSync(['gh', 'api', `repos/${owner}/${repo}/rules/branches/${branch}`])
+  if (rulesetResult.ok) {
+    for (const ctx of parseRequiredContexts(rulesetResult.stdout)) out.add(ctx)
+  }
+
+  return out
+}
+
+/**
+ * Fetch the last DORMANCY_RUN_LIMIT push runs for a workflow/branch and build a
+ * Map<jobDisplayName, JobRunStats> for each parsed job.
+ * Passes --repo owner/repo on every gh call (cron-safe from arbitrary cwd).
+ */
+export function fetchJobHistory(
+  owner: string,
+  repo: string,
+  wf: string,
+  branch: string,
+  jobs: ParsedJob[],
+  limit: number,
+): Map<string, JobRunStats> {
+  // List run IDs
+  const listResult = spawnSync([
+    'gh',
+    'run',
+    'list',
+    '--repo',
+    `${owner}/${repo}`,
+    '--workflow',
+    wf,
+    '--branch',
+    branch,
+    '--event',
+    'push',
+    '--limit',
+    String(limit),
+    '--json',
+    'databaseId,conclusion',
+  ])
+  if (!listResult.ok) return new Map()
+
+  let runList: Array<{ databaseId: number; conclusion: string }> = []
+  try {
+    runList = JSON.parse(listResult.stdout)
+  } catch {
+    return new Map()
+  }
+
+  // Fetch each run's job details
+  const runRecords: RunRecord[] = []
+  for (const run of runList) {
+    const viewResult = spawnSync([
+      'gh',
+      'run',
+      'view',
+      String(run.databaseId),
+      '--repo',
+      `${owner}/${repo}`,
+      '--json',
+      'jobs,conclusion',
+    ])
+    if (!viewResult.ok) continue
+    try {
+      const data = JSON.parse(viewResult.stdout)
+      runRecords.push({
+        runConclusion: data.conclusion ?? run.conclusion ?? '',
+        jobs: Array.isArray(data.jobs)
+          ? data.jobs.map((j: { name: string; conclusion: string }) => ({ name: j.name, conclusion: j.conclusion }))
+          : [],
+      })
+    } catch {}
+  }
+
+  // Aggregate stats per job
+  const statsMap = new Map<string, JobRunStats>()
+  for (const job of jobs) {
+    statsMap.set(job.id, aggregateJobStats(job, runRecords))
+  }
+  return statsMap
+}
+
+// ── T5: detectDormantJobs orchestrator ────────────────────────────────────────
+
+/**
+ * For each protected branch × each standard workflow that has push runs and passes
+ * workflowAgeOk, parse jobs, cross-ref history, classify dormancy, emit Check[] for
+ * dormant_required (fail) and dormant_wiring (warn) only.
+ */
+export function detectDormantJobs(ghOk: boolean, owner: string, repo: string): Check[] {
+  if (!ghOk || !repoAgeOk(owner, repo)) return []
+
+  const checks: Check[] = []
+  // Memoize required contexts per branch
+  const reqCache = new Map<string, Set<string>>()
+
+  for (const branch of PROTECTED_BRANCHES) {
+    // Check branch exists
+    const branchCheck = spawnSync(['gh', 'api', `repos/${owner}/${repo}/branches/${branch}`])
+    if (!branchCheck.ok) continue
+
+    for (const wf of STANDARD_WORKFLOWS) {
+      // Only check workflows that are alive at the workflow level (have push runs)
+      const pushCount = countPushRuns(owner, repo, wf, branch)
+      if (pushCount <= 0) continue
+
+      // Grace window on the workflow itself
+      if (!workflowAgeOk(owner, repo, wf)) continue
+
+      // Read local workflow file
+      const wfPath = `.github/workflows/${wf}`
+      if (!existsSync(wfPath)) continue
+      let content: string
+      try {
+        content = readFileSync(wfPath, 'utf8') as string
+      } catch {
+        continue
+      }
+
+      const jobs = parseWorkflowJobs(content)
+      if (jobs.length === 0) continue
+
+      // Fetch required contexts (memoized per branch)
+      if (!reqCache.has(branch)) {
+        reqCache.set(branch, fetchRequiredContexts(owner, repo, branch))
+      }
+      const requiredContexts = reqCache.get(branch)!
+
+      // Fetch job history
+      const statsMap = fetchJobHistory(owner, repo, wf, branch, jobs, DORMANCY_RUN_LIMIT)
+
+      for (const job of jobs) {
+        const stats = statsMap.get(job.id) ?? { considered: 0, executed: 0, skipped: 0 }
+        // A job is required if its display name — or any matrix-leg history name — matches
+        const isRequired = requiredContexts.has(job.displayName)
+        const verdict = classifyDormancy(job, stats, isRequired, DORMANCY_MIN_RUNS)
+
+        if (verdict === 'dormant_required') {
+          checks.push({
+            name: `${wf}:${branch}:${job.displayName} dormancy`,
+            status: 'fail',
+            detail: `required status check '${job.displayName}' never ran in last ${stats.considered} eligible runs — merge gate proves nothing (#579).`,
+          })
+        } else if (verdict === 'dormant_wiring') {
+          const reason = job.matrixEmpty
+            ? 'matrix expands to 0 legs — job can never run'
+            : `job skipped in all ${stats.considered} eligible runs — dead wiring (broken needs/empty matrix)`
+          checks.push({
+            name: `${wf}:${branch}:${job.displayName} dormancy`,
+            status: 'warn',
+            detail: reason,
+          })
+        }
+        // alive + conditional_ok → emit nothing
+      }
+    }
+  }
+
+  return checks
 }
 
 export function checkDeadGates(ghOk: boolean, owner: string, repo: string): Section {
@@ -853,11 +1274,15 @@ export function checkDeadGates(ghOk: boolean, owner: string, repo: string): Sect
     }
   }
 
+  // --- C. Per-job dormancy detector ---
+  const dormantChecks = detectDormantJobs(ghOk, owner, repo)
+  for (const c of dormantChecks) checks.push(c)
+
   if (checks.length === 0) {
     checks.push({
       name: 'push-gate history',
       status: 'pass',
-      detail: 'no dead push-gates detected',
+      detail: 'no dead push-gates or dormant jobs detected',
     })
   }
 

--- a/plugins/dev-core/skills/checkup/doctor-github.ts
+++ b/plugins/dev-core/skills/checkup/doctor-github.ts
@@ -911,9 +911,12 @@ export interface RunRecord {
  * Run-level eligibility: exclude runs with runConclusion ∈ {skipped, cancelled}.
  * Absent-job exclusion: considered counts only retained runs where the job entry appears.
  * Matrix-leg matching: anchored prefix — historyName === displayName OR startsWith(displayName + ' (').
- * skipped conclusion never counts as executed.
+ *   `siblings` (other jobs' display names) are excluded from prefix matches so a parent job never
+ *   absorbs a separate job that literally shares its prefix ("Build" vs "Build (debug)") (#288 review #3).
+ * Only a real, non-skipped conclusion counts as executed; a null/empty (in-progress) conclusion does
+ * not, else an in-flight run would fail-open and mask a dormant required gate (#288 review #2).
  */
-export function aggregateJobStats(job: ParsedJob, runs: RunRecord[]): JobRunStats {
+export function aggregateJobStats(job: ParsedJob, runs: RunRecord[], siblings: Set<string> = new Set()): JobRunStats {
   let considered = 0
   let executed = 0
   let skipped = 0
@@ -922,13 +925,19 @@ export function aggregateJobStats(job: ParsedJob, runs: RunRecord[]): JobRunStat
     const c = run.runConclusion
     if (c === 'skipped' || c === 'cancelled') continue
 
-    // Find all job entries for this job (direct match or matrix leg)
-    const matching = run.jobs.filter((j) => j.name === job.displayName || j.name.startsWith(job.displayName + ' ('))
+    // Find all job entries for this job (direct match or matrix leg). A sibling job whose literal
+    // name shares the prefix ("Build (debug)" vs matrix parent "Build") is excluded so its runs are
+    // never absorbed into the parent's stats (#288 review #3).
+    const matching = run.jobs.filter(
+      (j) => j.name === job.displayName || (j.name.startsWith(job.displayName + ' (') && !siblings.has(j.name)),
+    )
     if (matching.length === 0) continue // job absent from this run — don't count
 
     considered++
-    // At least one leg ran (not skipped) → executed
-    const anyExecuted = matching.some((j) => j.conclusion !== 'skipped')
+    // At least one leg actually ran (a real, non-skipped conclusion) → executed. A null/empty
+    // conclusion (in-progress/queued) must NOT count as executed, else an in-flight run fails open
+    // and masks a dormant required gate (#288 review #2).
+    const anyExecuted = matching.some((j) => Boolean(j.conclusion) && j.conclusion !== 'skipped')
     if (anyExecuted) {
       executed++
     } else {
@@ -1083,12 +1092,25 @@ export function fetchJobHistory(
     } catch {}
   }
 
-  // Aggregate stats per job
+  // Aggregate stats per job. Pass each job the set of OTHER jobs' display names so a matrix parent
+  // ("Build") never absorbs a separate job that literally shares its prefix ("Build (debug)").
+  const allNames = new Set(jobs.map((j) => j.displayName))
   const statsMap = new Map<string, JobRunStats>()
   for (const job of jobs) {
-    statsMap.set(job.id, aggregateJobStats(job, runRecords))
+    const siblings = new Set([...allNames].filter((n) => n !== job.displayName))
+    statsMap.set(job.id, aggregateJobStats(job, runRecords, siblings))
   }
   return statsMap
+}
+
+/**
+ * A workflow job is a required status check if its display name matches a required context
+ * directly, OR if any matrix-leg context registered under it ("Build (ubuntu-latest)") matches.
+ * Matrix jobs register one context per leg and never the bare parent name, so the anchored-prefix
+ * check is mandatory for the AC-7 (dormant_required) escalation to fire on matrix jobs (#288 review #1).
+ */
+export function isJobRequired(displayName: string, requiredContexts: Set<string>): boolean {
+  return requiredContexts.has(displayName) || [...requiredContexts].some((c) => c.startsWith(displayName + ' ('))
 }
 
 // ── T5: detectDormantJobs orchestrator ────────────────────────────────────────
@@ -1142,8 +1164,7 @@ export function detectDormantJobs(ghOk: boolean, owner: string, repo: string): C
 
       for (const job of jobs) {
         const stats = statsMap.get(job.id) ?? { considered: 0, executed: 0, skipped: 0 }
-        // A job is required if its display name — or any matrix-leg history name — matches
-        const isRequired = requiredContexts.has(job.displayName)
+        const isRequired = isJobRequired(job.displayName, requiredContexts)
         const verdict = classifyDormancy(job, stats, isRequired, DORMANCY_MIN_RUNS)
 
         if (verdict === 'dormant_required') {

--- a/plugins/dev-core/skills/checkup/doctor-github.ts
+++ b/plugins/dev-core/skills/checkup/doctor-github.ts
@@ -903,7 +903,10 @@ export interface JobRunStats {
 
 export interface RunRecord {
   runConclusion: string
-  jobs: Array<{ name: string; conclusion: string }>
+  // `conclusion` is null for an in-progress/queued job leg — `gh run view --json jobs` returns
+  // null, not '' — so the type must admit null (#288 review #2). Boolean(j.conclusion) below treats
+  // both null and '' as "not executed", so widening the type changes no behavior, only honesty.
+  jobs: Array<{ name: string; conclusion: string | null }>
 }
 
 /**
@@ -915,6 +918,12 @@ export interface RunRecord {
  *   absorbs a separate job that literally shares its prefix ("Build" vs "Build (debug)") (#288 review #3).
  * Only a real, non-skipped conclusion counts as executed; a null/empty (in-progress) conclusion does
  * not, else an in-flight run would fail-open and mask a dormant required gate (#288 review #2).
+ *
+ * @param siblings other jobs' display names, excluded from prefix matches (see above). The empty
+ *   default reproduces the pre-guard (greedy) attribution and is a silent-regression hazard: a
+ *   production caller that omits it loses the "Build" vs "Build (debug)" separation with no type
+ *   error. The dormancy path (fetchJobHistory) MUST pass the real sibling set; the default exists
+ *   only for direct unit tests of the bare matrix-leg semantics.
  */
 export function aggregateJobStats(job: ParsedJob, runs: RunRecord[], siblings: Set<string> = new Set()): JobRunStats {
   let considered = 0
@@ -1086,7 +1095,10 @@ export function fetchJobHistory(
       runRecords.push({
         runConclusion: data.conclusion ?? run.conclusion ?? '',
         jobs: Array.isArray(data.jobs)
-          ? data.jobs.map((j: { name: string; conclusion: string }) => ({ name: j.name, conclusion: j.conclusion }))
+          ? data.jobs.map((j: { name: string; conclusion: string | null }) => ({
+              name: j.name,
+              conclusion: j.conclusion,
+            }))
           : [],
       })
     } catch {}
@@ -1108,9 +1120,24 @@ export function fetchJobHistory(
  * directly, OR if any matrix-leg context registered under it ("Build (ubuntu-latest)") matches.
  * Matrix jobs register one context per leg and never the bare parent name, so the anchored-prefix
  * check is mandatory for the AC-7 (dormant_required) escalation to fire on matrix jobs (#288 review #1).
+ *
+ * @param siblings other jobs' display names. A required context that exactly matches a sibling's
+ *   display name ("Build (debug)") belongs to that separate static job, NOT to a matrix leg of this
+ *   one — so it is excluded from the prefix match. This is the mirror of the aggregateJobStats
+ *   sibling guard (#288 review #1, iter-2): without it, a required static "Build (debug)" would make
+ *   a dormant matrix "Build" wrongly read as required and escalate to fail. The empty default
+ *   reproduces the pre-guard (greedy) behavior — callers in the dormancy path MUST pass the real
+ *   sibling set; the default exists only for direct unit tests of the bare-prefix semantics.
  */
-export function isJobRequired(displayName: string, requiredContexts: Set<string>): boolean {
-  return requiredContexts.has(displayName) || [...requiredContexts].some((c) => c.startsWith(displayName + ' ('))
+export function isJobRequired(
+  displayName: string,
+  requiredContexts: Set<string>,
+  siblings: Set<string> = new Set(),
+): boolean {
+  return (
+    requiredContexts.has(displayName) ||
+    [...requiredContexts].some((c) => c.startsWith(displayName + ' (') && !siblings.has(c))
+  )
 }
 
 // ── T5: detectDormantJobs orchestrator ────────────────────────────────────────
@@ -1162,9 +1189,14 @@ export function detectDormantJobs(ghOk: boolean, owner: string, repo: string): C
       // Fetch job history
       const statsMap = fetchJobHistory(owner, repo, wf, branch, jobs, DORMANCY_RUN_LIMIT)
 
+      // Other jobs' display names — passed to isJobRequired so a matrix parent ("Build") never
+      // claims a required context that belongs to a separate static sibling ("Build (debug)").
+      const allJobNames = new Set(jobs.map((j) => j.displayName))
+
       for (const job of jobs) {
         const stats = statsMap.get(job.id) ?? { considered: 0, executed: 0, skipped: 0 }
-        const isRequired = isJobRequired(job.displayName, requiredContexts)
+        const siblings = new Set([...allJobNames].filter((n) => n !== job.displayName))
+        const isRequired = isJobRequired(job.displayName, requiredContexts, siblings)
         const verdict = classifyDormancy(job, stats, isRequired, DORMANCY_MIN_RUNS)
 
         if (verdict === 'dormant_required') {


### PR DESCRIPTION
## Summary
- Add sub-check **C** (per-job dormancy) to `checkDeadGates()` in `doctor-github.ts`: cross-references static job wiring (`parseWorkflowJobs`) against per-job run history (`fetchJobHistory` → `aggregateJobStats`) to flag CI jobs that were eligible to run (their workflow ran) yet executed **0 times** across the observation window — escalating to `fail` when the dormant job is also a **required status check** (the #579 signature: a required e2e job filtered out every run while regressions merged under a green check). Renders sub-grouped by job inside the existing `Dead Gates` section; read-only.
- Verdict ladder (`classifyDormancy`, pure): `considered < MIN` → alive · `executed > 0` → alive · else required → `fail` (dormant_required) · empty-matrix/no-`if:` → `warn` (dormant_wiring) · conditional `if:` + not-required → unflagged. Required contexts resolved (`parseRequiredContexts`) by unioning classic `contexts[]` + `checks[].context` + ruleset rules, fail-open on 404.
- **Bug fix surfaced by a de-vacuumed test:** `gh api` rejects `--repo` (`unknown flag`); `fetchRequiredContexts` wrongly passed it → both calls failed-open → required contexts always empty → every dormant *required* job mis-graded `warn` instead of `fail`, **silently disabling the #579 escalation in production**. `--repo` is retained only on the three `gh run list`/`gh run view` calls (where it is valid). A source-inspection test guards against regression.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #288: checkup conditional-job skip-rate detector (#579 class) | OPEN (size:F-lite, P1-high) |
| Analysis | — | Absent (F-lite — analyze skipped) |
| Spec | [288-…-spec.mdx](artifacts/specs/288-conditional-job-skip-rate-spec.mdx) | Present |
| Implementation | 1 feat + 3 docs commits on `feat/288-conditional-job-skip-rate` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (dead-gate 18→47, +29) | Passed |

## Test Plan
- [ ] `/checkup` on a repo whose required job skips every run → `fail` under Dead Gates, sub-grouped `wf:branch:job dormancy`
- [ ] Conditional rare-path job (`if:`, not required, skips every run) → **not** flagged (no false positive)
- [ ] Unconditional / empty-matrix job skipping every run → `warn` (dead wiring)
- [ ] Grace window: workflow failing `workflowAgeOk` or job with `< DORMANCY_MIN_RUNS` history → not flagged
- [ ] Required-context lookup works against live `gh api` (no `--repo`) — `dormant_required` escalation fires

Fixes #288

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`