### PR TITLE
fix(fix): repath review-classes.yml + issue-triage invocation (#286)

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/code-review/SKILL.md
+++ b/plugins/dev-core/skills/code-review/SKILL.md
@@ -139,6 +139,7 @@ Skip rules: architect → |Δ| ≤ 5 ∧ ¬arch keywords | product-lead → spec
 3. scope = Δ ∪ ⋃{resolve(imports(f)) | f ∈ Δ} ∪ `{backend.path}/src/auth/**` — deduplicate
 
 # SYNC REQUIRED: inline class list must match review-classes.yml slugs — see #149
+# CROSS-SKILL CONSUMER: fix/SKILL.md Phase 0 reads this YAML via ${CLAUDE_PLUGIN_ROOT}/skills/code-review/review-classes.yml — moving/renaming it breaks /fix (#286)
 ### Spawn template
 
 > **Note (orchestrator):** The `{format_digest_for_agent(d) for d in digests if d.chunk_index != i}` placeholder is a Python expression evaluated by the orchestrator (Claude main context) BEFORE the Task call — substitute its rendered value into the prompt string. It is NOT a runtime-resolved placeholder. All other `{...}` placeholders are simple value substitutions.

--- a/plugins/dev-core/skills/fix/SKILL.md
+++ b/plugins/dev-core/skills/fix/SKILL.md
@@ -67,14 +67,14 @@ d ∈ D := {tag: str, file: str, line: int, description: str, phase: str}
 
 ## Phase 0 — Load Taxonomy
 
-Read `${CLAUDE_SKILL_DIR}/review-classes.yml` → extract `classes[].class` slugs → `canonical_slugs`.
-File absent, unreadable, or parse error → HALT: `[taxonomy-error] review-classes.yml {reason} at ${CLAUDE_SKILL_DIR}/review-classes.yml — reinstall dev-core plugin.`
+Read `${CLAUDE_PLUGIN_ROOT}/skills/code-review/review-classes.yml` → extract `classes[].class` slugs → `canonical_slugs`. (Canonical YAML ships with `code-review`; `fix` reads it cross-skill — single source, ¬duplicate copy that could drift.)
+File absent, unreadable, or parse error → HALT: `[taxonomy-error] review-classes.yml {reason} at ${CLAUDE_PLUGIN_ROOT}/skills/code-review/review-classes.yml — reinstall dev-core plugin.`
 Used in Phase 1 steps 4–5 to validate class[] values against the live YAML (¬LLM memory).
 
 
 ## Phase 1 — Gather Findings
 
-1. PR# → `gh pr view <#> --json comments,closingIssuesReferences`; parse Conventional Comments from `.comments[].body`; capture `SOURCE_ISSUE` = `.closingIssuesReferences[0].number` (∅ if none — used in Phase 5 Defer to wire blocked-by). When `SOURCE_ISSUE ≠ ∅`, also resolve `SOURCE_PARENT` = `gh api graphql -f query='query{repository(owner:"<O>",name:"<R>"){issue(number:<SOURCE_ISSUE>){parent{number}}}}' --jq '.data.repository.issue.parent.number // empty'` — used in Phase 5 Defer to wire deferred issue as **sibling** under shared parent (see `issue-triage` "Deferred Follow-Ups — Sibling Rule").
+1. PR# → `gh pr view <#> --json comments,closingIssuesReferences`; parse Conventional Comments from `.comments[].body`; capture `SOURCE_ISSUE` = `.closingIssuesReferences[0].number` (∅ if none — used in Phase 5 Defer to wire blocked-by). When `SOURCE_ISSUE ≠ ∅`, also resolve `SOURCE_PARENT` = `gh api graphql -f query='query{repository(owner:"<O>",name:"<R>"){issue(number:<SOURCE_ISSUE>){parent{number}}}}' --jq '.data.repository.issue.parent.number // empty'` — used in Phase 5 Defer to wire deferred issue as **sibling** under shared parent (see `roxabi-issues:issue-triage` "Deferred Follow-Ups — Sibling Rule").
 2. ¬PR# → scan conversation for latest `/code-review` output
 3. F = ∅ → halt
 4. ∀ f: parse → label, file:line, agent, root cause, class[], raw_callsites[], solutions, C(f)
@@ -148,15 +148,14 @@ Demoted from auto-apply → prepend: `Auto-apply failed: {reason}`
 
 → DP(A)(single per finding): **Solution 1** | **Solution 2** | **Defer** (→ create issue) | **Skip**
 
-Defer → create linked follow-up issue via `/issue-triage` (¬raw `gh issue create` — global rule: issue mutations go through the skill so blocked-by + parent are wired atomically). **Sibling rule:** the deferred issue is a sibling of `SOURCE_ISSUE` under their shared parent (¬child of `SOURCE_ISSUE`) — see `issue-triage` SKILL "Deferred Follow-Ups — Sibling Rule":
+Defer → create linked follow-up issue via `roxabi-issues:issue-triage` (¬raw `gh issue create` — global rule: issue mutations go through the skill so blocked-by + parent are wired atomically). **Sibling rule:** the deferred issue is a sibling of `SOURCE_ISSUE` under their shared parent (¬child of `SOURCE_ISSUE`) — see `roxabi-issues:issue-triage` SKILL "Deferred Follow-Ups — Sibling Rule":
 
-```bash
-bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts create \
-  --title "{cat}: {summary}" \
-  --body "{details}" \
-  ${SOURCE_ISSUE:+--blocked-by "#${SOURCE_ISSUE}"} \
-  ${SOURCE_PARENT:+--parent "#${SOURCE_PARENT}"}
-```
+Invoke the `roxabi-issues:issue-triage` skill in **create** mode (requires the **roxabi-issues** plugin installed — issue-triage relocated dev-core → roxabi-issues, 2026-06-09). Pass:
+
+- `--title "{cat}: {summary}"`
+- `--body "{details}"`
+- `--blocked-by "#${SOURCE_ISSUE}"`  — omit when `SOURCE_ISSUE = ∅`
+- `--parent "#${SOURCE_PARENT}"`  — omit when `SOURCE_PARENT = ∅`
 
 `SOURCE_ISSUE` (captured Phase 1, step 1) → blocked-by ensures the deferred finding is traceable back to the issue whose review surfaced it. `SOURCE_PARENT` (also captured Phase 1, step 1) → parent makes the deferred issue a sibling of `SOURCE_ISSUE` under the same epic, so `gh issue view <epic>` shows the full fan-out flat. ∄ SOURCE_ISSUE → create without `--blocked-by` or `--parent`; `{details}` MUST include `**Origin:** PR #<N>` so traceability is preserved. ∄ SOURCE_PARENT (SOURCE_ISSUE is top-level) → create without `--parent` (the deferred issue is also top-level).
 
@@ -169,7 +168,7 @@ bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts create \
 **Action:** {chosen path or open question}
 ```
 
-Triage.ts `--blocked-by` accepts issues only (¬PRs) — when the source review is on a PR with no closing-issue reference, fall back to no `--blocked-by` and rely on the `Origin: PR #N` body line.
+`issue-triage` `--blocked-by` accepts issues only (¬PRs) — when the source review is on a PR with no closing-issue reference, fall back to no `--blocked-by` and rely on the `Origin: PR #N` body line.
 
 ```
 ── Walkthrough Complete ──


### PR DESCRIPTION
## Summary

Two runtime path defects in the `fix` skill (dev-core), both surfaced by a `/fix` run on PR #277/#285:

| # | Defect | Fix |
|---|--------|-----|
| 1 | Phase 0 read `${CLAUDE_SKILL_DIR}/review-classes.yml` — file ships only under `skills/code-review/` → **HALT on every run** | Repath to `${CLAUDE_PLUGIN_ROOT}/skills/code-review/review-classes.yml` (single canonical copy; no duplicate to drift) |
| 2 | Phase 5 Defer called `bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts` — issue-triage relocated to the **roxabi-issues** plugin 2026-06-09 → **Module not found** | Replace the dead bun call with the `roxabi-issues:issue-triage` skill invocation (matches surrounding prose + global "issue mutations go through the skill" rule) |

Approach chosen over copy-sync: `tools/sync-shared.ts` emits a `//`-only `@generated` header → cannot carry a YAML header without extending the shared-source governance machinery (out of S-tier scope). Pointing `fix` at code-review's single canonical YAML is the lower-drift fix.

## Recurrence guard

Added a `# CROSS-SKILL CONSUMER` marker next to the canonical `review-classes.yml` read in `code-review/SKILL.md` so a future maintainer who moves/renames the file knows it breaks `/fix` (Design Principle 5).

## Changes

- `plugins/dev-core/skills/fix/SKILL.md` — Phase 0 repath + HALT message + Phase 5 Defer skill invocation + consistency (`issue-triage` → `roxabi-issues:issue-triage`)
- `plugins/dev-core/skills/code-review/SKILL.md` — cross-skill-consumer marker
- `plugins/dev-core/.claude-plugin/plugin.json` — `0.8.3 → 0.8.4` (skills/ changed → check-skill-version gate)

## QG

lint ✓ · typecheck ✓ · test ✓ (553 passed) · validate_plugins.py ✓ (9 checks) · residual-bug grep clean

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)