### PR TITLE
fix(dev-core): isolate analyze-branches fixture from inherited git env

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/cleanup/__tests__/analyze-branches.test.sh
+++ b/plugins/dev-core/skills/cleanup/__tests__/analyze-branches.test.sh
@@ -2,6 +2,14 @@
 # Integration test for analyze-branches.sh using a temporary git fixture.
 set -euo pipefail
 
+# Isolate from any inherited git context. This fixture builds a throwaway repo
+# via mktemp + cd + git init and relies on cwd-based repo discovery — but a git
+# hook (e.g. pre-push, which runs this suite) exports GIT_DIR/GIT_WORK_TREE into
+# the environment, and those override cwd discovery. Without clearing them the
+# fixture's `git branch -M main`, `git worktree add`, etc. would target the
+# caller's REAL repository instead of the temp one below.
+unset $(git rev-parse --local-env-vars)
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ANALYZE="${SCRIPT_DIR}/../analyze-branches.sh"
 


### PR DESCRIPTION
## Problem

`plugins/dev-core/skills/cleanup/__tests__/analyze-branches.test.sh` builds a throwaway repo via `mktemp -d` + `cd` + `git init`, relying on **cwd-based repo discovery** for isolation.

That isolation silently fails when the suite runs **inside a git hook**. Git exports `GIT_DIR`/`GIT_WORK_TREE` into the hook environment (and all children: lefthook → bun → vitest → bash), and those env vars **override cwd discovery**. So the fixture's `git branch -M main`, `git worktree add`, etc. target the **caller's real repository** instead of the temp repo.

### Impact (severe, latent)

The `test` **pre-push** gate runs this suite → **every `git push` from this repo renames the pusher's current branch to `main` and spawns fixture branches/worktrees** (`feat/19-auth`, `feat/33-i18n`, `wt-i18n`). Green standalone (no `GIT_DIR` in env), destructive only under a hook — so it slipped through. Introduced in #303.

## Fix

```bash
unset $(git rev-parse --local-env-vars)
```

at the top of the fixture — clears **all** repo-local git env vars (15: `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_COMMON_DIR`, …), so the fixture always operates on its own temp repo. Canonical idiom (git's own test harness does this). `git -C` alone would **not** work — `GIT_DIR` beats `-C`.

## Evidence

Ran the **fixed** fixture with `GIT_DIR`/`GIT_WORK_TREE` exported at a sacrificial repo (simulating a hook):
- ✅ `PASS: analyze-branches.test.sh`
- ✅ sacrificial repo's branch unchanged, zero fixture branches/worktrees created

Pre-push test gate on this branch: `554 passed | 4 skipped`, no clobber.

Scope: only this one shell fixture has the vulnerable `git init` pattern (scanned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)