### PR TITLE
fix(dev-core): drop unused TeamCreate/TeamDelete tools from agents

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/agents/architect.md
+++ b/plugins/dev-core/agents/architect.md
@@ -11,7 +11,7 @@ description: |
   assistant: "I'll use the architect agent to design the architecture."
   </example>
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "TeamCreate", "TeamDelete", "SendMessage"]
+tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=true, write_code=false, review_code=true, run_tests=false

--- a/plugins/dev-core/agents/product-lead.md
+++ b/plugins/dev-core/agents/product-lead.md
@@ -12,7 +12,7 @@ description: |
   assistant: "I'll use the product-lead agent to define requirements."
   </example>
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "TeamCreate", "TeamDelete", "SendMessage"]
+tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false

--- a/plugins/dev-core/skills/shared/references/tier-classification.md
+++ b/plugins/dev-core/skills/shared/references/tier-classification.md
@@ -43,7 +43,7 @@ Canonical rules for classifying work into S / F-lite / F-full. Referenced by `/f
 |---|---|---------|--------|
 | 1–3 | **S** | Worktree + direct impl + PR | Single session, ¬α |
 | 4–6 | **F-lite** | Worktree + subagents + /code-review | Task subagents (1–2 domain + tester) |
-| 7–10 | **F-full** | Bootstrap + worktree + α team + /code-review | TeamCreate (3+ α, test-first) |
+| 7–10 | **F-full** | Bootstrap + worktree + α team + /code-review | Task subagents (3+ α, test-first) |
 
 ## Resolution Rules
 

--- a/plugins/dev-init/skills/shared/references/tier-classification.md
+++ b/plugins/dev-init/skills/shared/references/tier-classification.md
@@ -43,7 +43,7 @@ Canonical rules for classifying work into S / F-lite / F-full. Referenced by `/f
 |---|---|---------|--------|
 | 1–3 | **S** | Worktree + direct impl + PR | Single session, ¬α |
 | 4–6 | **F-lite** | Worktree + subagents + /code-review | Task subagents (1–2 domain + tester) |
-| 7–10 | **F-full** | Bootstrap + worktree + α team + /code-review | TeamCreate (3+ α, test-first) |
+| 7–10 | **F-full** | Bootstrap + worktree + α team + /code-review | Task subagents (3+ α, test-first) |
 
 ## Resolution Rules
 


### PR DESCRIPTION
Removes the experimental teammates tools (`TeamCreate`/`TeamDelete`) — unused and not recommended.

## Changes

- **architect.md** + **product-lead.md** — drop `TeamCreate`/`TeamDelete` from `tools` (the only 2 of 12 agents that had them). They converge on the standard `Task`/`SendMessage` toolset like every other agent. `SendMessage` (normal subagent messaging) is kept.
- **tier-classification.md** (dev-core + dev-init) — F-full tier α-mode: `TeamCreate (3+ α, test-first)` → `Task subagents (3+ α, test-first)`, consistent with the F-lite row. Conceptual "α team" wording retained (achieved via parallel `Task`, not the Team feature).
- dev-core `0.8.6 → 0.8.7`.

## Notes

- ⚠️ **Stacked on #304** (base = `fix/gitdir-isolation`). #304 must merge first — it fixes a pre-push fixture that otherwise clobbers the pusher's branch. GitHub will auto-retarget this PR's base to `staging` once #304 merges.
- `SendMessage`/"teammates" references in agent comms sections are unrelated (standard `Task`-spawned subagent messaging) and intentionally kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)