### PR TITLE
feat(dev-init): generate context-lint.yml — per-repo CI gate for agent-context files

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/ci-setup/cookbooks/workflows.md
+++ b/plugins/dev-core/skills/ci-setup/cookbooks/workflows.md
@@ -13,7 +13,7 @@ Let:
 
 Set up GitHub Actions via REST API (no local git). Runs from σ values.
 
-Standard set: `ci.yml`, `auto-merge.yml`, `pr-title.yml` (+ `deploy-preview.yml` if Vercel).
+Standard set: `ci.yml`, `auto-merge.yml`, `pr-title.yml`, `context-lint.yml` (+ `deploy-preview.yml` if Vercel).
 
 1. Discover owner/repo:
    ```bash
@@ -39,7 +39,7 @@ Standard set: `ci.yml`, `auto-merge.yml`, `pr-title.yml` (+ `deploy-preview.yml`
      - Detect org: `gh repo view --json isInOrganization --jq '.isInOrganization'`
      - `true` → pre-select App; `false` → pre-select PAT.
    - Run: `bun $I_TS workflows --owner <owner> --repo <repo> --stack <stack> --test <test> --deploy <deploy>`
-     > ⚠️ **Pending dev-core #281:** the `workflows` generator currently emits a `secrets.PAT`-based `auto-merge.yml`; App-token emission (and a `--token-mode` flag) is wired by #281. Do **not** pass `--token-mode` yet — it is not parsed. The token mode selected above governs only which **credentials** to provision below (forward-prep); the generated workflow's token swaps to the roxabi-ci App when #281 lands.
+     (the generator emits an App-token `auto-merge.yml` — #281 landed; the token mode selected above governs which credentials to provision below)
    - **If mode = github-app:**
      - `gh variable set ROXABI_CI_APP_ID --org <org> --body <app-id>` (org-level)
        OR (private repo / free-plan org): `gh variable set ROXABI_CI_APP_ID --repo <owner>/<repo> --body <app-id>`

--- a/plugins/dev-init/skills/init/__tests__/workflows.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/workflows.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { generateAutoMergeYml, generateCiYml, generateDeployYml } from '../lib/workflows'
+import { generateAutoMergeYml, generateCiYml, generateContextLintYml, generateDeployYml } from '../lib/workflows'
 
 describe('generateAutoMergeYml', () => {
   it('emits the App token mint step (no secrets.PAT)', () => {
@@ -117,5 +117,36 @@ describe('generateDeployYml', () => {
   it('has workflow_dispatch trigger', () => {
     const yml = generateDeployYml({ stack: 'bun', test: 'none', deploy: 'none' })
     expect(yml).toContain('workflow_dispatch')
+  })
+})
+
+describe('generateContextLintYml', () => {
+  it('is read-only and uses no secrets', () => {
+    const yml = generateContextLintYml()
+    expect(yml).toContain('permissions:\n  contents: read')
+    expect(yml).not.toContain('secrets.')
+  })
+
+  it('skips machine-local home-dir imports', () => {
+    const yml = generateContextLintYml()
+    expect(yml).toContain('"~/"*')
+  })
+
+  it('fails the job on violations', () => {
+    const yml = generateContextLintYml()
+    expect(yml).toContain('exit 1')
+  })
+
+  it('triggers only on agent-context file paths', () => {
+    const yml = generateContextLintYml()
+    expect(yml).toContain("'**/CLAUDE.md'")
+    expect(yml).toContain("'**/AGENTS.md'")
+    expect(yml).toContain("'.claude/**'")
+  })
+
+  it('emits interpolated bash (no unresolved TS template escapes)', () => {
+    const yml = generateContextLintYml()
+    expect(yml).toContain('target=${imp#@}')
+    expect(yml).not.toContain('\\$')
   })
 })

--- a/plugins/dev-init/skills/init/init.ts
+++ b/plugins/dev-init/skills/init/init.ts
@@ -7,7 +7,7 @@
  *   bun init.ts prereqs [--json]
  *   bun init.ts discover [--json]
  *   bun init.ts workflows --owner <owner> --repo <repo> --stack <bun|node|python> --test <vitest|jest|pytest|none> --deploy <vercel|none> [--branch <branch>]
- *   bun init.ts push-workflows --owner <owner> --repo <repo> [--branch <branch>]  # generic only (auto-merge + pr-title)
+ *   bun init.ts push-workflows --owner <owner> --repo <repo> [--branch <branch>]  # generic only (auto-merge + pr-title + context-lint)
  *   bun init.ts protect-branches --repo <owner/repo>
  *   bun init.ts scaffold-rules [--stack-path .claude/stack.yml] [--project-name <name>] [--claude-md CLAUDE.md]
  *   bun init.ts scaffold --github-repo <owner/repo> [--vercel-token <token>] [--vercel-project-id <id>] [--vercel-team-id <id>] [--force]

--- a/plugins/dev-init/skills/init/lib/workflows.ts
+++ b/plugins/dev-init/skills/init/lib/workflows.ts
@@ -193,6 +193,68 @@ jobs:
 `
 }
 
+/** Generic context lint — keeps agent-context files honest:
+ *  repo-relative `@imports` in CLAUDE.md/AGENTS.md must resolve, and scaffold
+ *  placeholders must be filled. Home-dir imports (`@~/...`) are machine-local
+ *  and skipped on CI. Stack-agnostic (pure bash, no deps). Ecosystem-level
+ *  checks (project index, factory registry) live in the central
+ *  ~/projects/scripts/context-lint.sh, deliberately not here. */
+export function generateContextLintYml(): string {
+  return `name: Context Lint
+
+on:
+  pull_request:
+    paths:
+      - '**/CLAUDE.md'
+      - '**/AGENTS.md'
+      - '.claude/**'
+  push:
+    branches: [main, staging]
+    paths:
+      - '**/CLAUDE.md'
+      - '**/AGENTS.md'
+      - '.claude/**'
+
+permissions:
+  contents: read
+
+jobs:
+  context-lint:
+    name: Context lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Lint agent-context files (@imports + placeholders)
+        run: |
+          set -u
+          V=0
+          # dead repo-relative @imports (home-dir @~/... imports are machine-local — skipped on CI)
+          while IFS= read -r file; do
+            dir=\$(dirname "\$file")
+            while IFS= read -r imp; do
+              target=\${imp#@}
+              case "\$target" in "~/"*|/*) continue ;; esac
+              if [ ! -e "\$dir/\$target" ]; then
+                echo "::error file=\$file::dead @import: \$imp"
+                V=\$((V + 1))
+              fi
+            done < <(grep -o '^@[^ ]*' "\$file" || true)
+          done < <(find . \\( -name node_modules -o -name .worktrees -o -name worktrees -o -name .git \\) -prune -o \\( -name 'CLAUDE.md' -o -name 'AGENTS.md' \\) -print)
+          # unfilled scaffold placeholders
+          while IFS= read -r f; do
+            echo "::error file=\$f::unfilled scaffold placeholder (gotchas)"
+            V=\$((V + 1))
+          done < <(grep -rl 'Add project-specific gotchas here' --include=CLAUDE.md . 2>/dev/null || true)
+          if [ "\$V" -eq 0 ]; then
+            echo "context-lint: clean"
+          else
+            echo "context-lint: \$V violation(s)"
+            exit 1
+          fi
+`
+}
+
 export function generateCiYml(opts: WorkflowOpts): string {
   let setupStep: string
   let lintCmd: string
@@ -361,6 +423,7 @@ export async function pushWorkflows(
   const files: Array<{ name: string; content: string }> = [
     { name: 'auto-merge.yml', content: generateAutoMergeYml() },
     { name: 'pr-title.yml', content: generatePrTitleYml() },
+    { name: 'context-lint.yml', content: generateContextLintYml() },
     { name: 'ci.yml', content: generateCiYml(opts) },
   ]
   if (opts.deploy === 'vercel') {
@@ -380,6 +443,7 @@ export async function pushGenericWorkflows(owner: string, repo: string, branch: 
   const files = [
     { name: 'auto-merge.yml', content: generateAutoMergeYml() },
     { name: 'pr-title.yml', content: generatePrTitleYml() },
+    { name: 'context-lint.yml', content: generateContextLintYml() },
   ]
   const results: PushResult[] = []
   for (const { name, content } of files) {
@@ -405,6 +469,9 @@ export async function writeWorkflows(opts: WorkflowOpts): Promise<string[]> {
 
   fs.writeFileSync(`${dir}/pr-title.yml`, generatePrTitleYml())
   written.push('pr-title.yml')
+
+  fs.writeFileSync(`${dir}/context-lint.yml`, generateContextLintYml())
+  written.push('context-lint.yml')
 
   if (opts.deploy === 'vercel') {
     fs.writeFileSync(`${dir}/deploy-preview.yml`, generateDeployYml(opts))


### PR DESCRIPTION
Route B de l'audit contexte 2026-07-01 : gate CI per-repo pour les fichiers de contexte agent.

- `generateContextLintYml()` : workflow stack-agnostic (bash pur, permissions read-only, zéro secret) — @imports relatifs au repo résolvables + placeholders scaffold remplis ; les imports `@~/...` (machine-locaux) sont ignorés en CI. Déclenché uniquement sur les paths contexte (`**/CLAUDE.md`, `**/AGENTS.md`, `.claude/**`).
- Ajouté au standard set (`pushWorkflows`/`writeWorkflows`) et au set générique (`push-workflows`) → rollout additif possible sur les repos existants sans toucher leurs `ci.yml` évolués.
- Smoke-testé : fixture sale → exit 1 avec annotations `::error`, fixture propre → exit 0.
- Cookbook ci-setup : standard set mis à jour + suppression du warning périmé « Pending #281 » (le générateur émet le token App depuis #284).
- Bump dev-core 0.8.9 (gate check-skill-version).

Les checks d'écosystème (index projets, registry factory) restent dans le `context-lint.sh` central — hors CI par design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)