### PR TITLE
fix(dev-init): top-up push semantics + standard-set parity for context-lint.yml

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/checkup/cookbooks/infra-checks.md
+++ b/plugins/dev-core/skills/checkup/cookbooks/infra-checks.md
@@ -51,7 +51,7 @@ After fixes, re-run + display updated result.
 
 Only run if Phase 1 doctor shows ⚠️/❌ for Workflows or Secrets.
 
-1. **Workflows** — doctor checks local `.github/workflows/` + remote REST. Standard: `ci.yml`, `auto-merge.yml`, `pr-title.yml` (+ `deploy-preview.yml` if Vercel).
+1. **Workflows** — doctor checks local `.github/workflows/` + remote REST. Standard: `ci.yml`, `auto-merge.yml`, `pr-title.yml`, `context-lint.yml` (+ `deploy-preview.yml` if Vercel).
 
 2. **PAT secret** — missing → `gh secret set PAT --repo <owner>/<repo> --body "$(gh auth token)"`. D✅("PAT secret").
 

--- a/plugins/dev-core/skills/ci-setup/cookbooks/workflows.md
+++ b/plugins/dev-core/skills/ci-setup/cookbooks/workflows.md
@@ -40,6 +40,7 @@ Standard set: `ci.yml`, `auto-merge.yml`, `pr-title.yml`, `context-lint.yml` (+ 
      - `true` → pre-select App; `false` → pre-select PAT.
    - Run: `bun $I_TS workflows --owner <owner> --repo <repo> --stack <stack> --test <test> --deploy <deploy>`
      (the generator emits an App-token `auto-merge.yml` — #281 landed; the token mode selected above governs which credentials to provision below)
+     > **Top-up par défaut** : les fichiers déjà présents sur le repo sont **skippés** — les repos font évoluer leur `ci.yml` bien au-delà du template (factory: 190 lignes/3 jobs; enishu: e2e Playwright). Ajouter `--force` UNIQUEMENT pour régénérer volontairement, après diff explicite des fichiers qui seraient écrasés.
    - **If mode = github-app:**
      - `gh variable set ROXABI_CI_APP_ID --org <org> --body <app-id>` (org-level)
        OR (private repo / free-plan org): `gh variable set ROXABI_CI_APP_ID --repo <owner>/<repo> --body <app-id>`

--- a/plugins/dev-core/skills/shared/adapters/github-infra.ts
+++ b/plugins/dev-core/skills/shared/adapters/github-infra.ts
@@ -5,7 +5,13 @@
 
 import { ConfigError } from '../domain/errors'
 
-export const STANDARD_WORKFLOWS = ['ci.yml', 'auto-merge.yml', 'pr-title.yml', 'deploy-preview.yml'] as const
+export const STANDARD_WORKFLOWS = [
+  'ci.yml',
+  'auto-merge.yml',
+  'pr-title.yml',
+  'context-lint.yml',
+  'deploy-preview.yml',
+] as const
 
 /**
  * Token mode for CI workflows.

--- a/plugins/dev-init/skills/init/__tests__/workflows.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/workflows.test.ts
@@ -65,13 +65,18 @@ describe('generateAutoMergeYml', () => {
 })
 
 describe('generateCiYml', () => {
-  it('generates bun + vitest CI', () => {
+  it('generates bun + vitest CI (bun run test, not bun test)', () => {
     const yml = generateCiYml({ stack: 'bun', test: 'vitest', deploy: 'none' })
     expect(yml).toContain('oven-sh/setup-bun@v2')
     expect(yml).toContain('bun install')
     expect(yml).toContain('bun lint')
     expect(yml).toContain('bun typecheck')
-    expect(yml).toContain('bun test')
+    expect(yml).toContain('run: bun run test')
+  })
+
+  it('uses the native bun runner for non-vitest bun stacks', () => {
+    const yml = generateCiYml({ stack: 'bun', test: 'jest', deploy: 'none' })
+    expect(yml).toContain('run: bun test')
   })
 
   it('generates node + jest CI', () => {

--- a/plugins/dev-init/skills/init/init.ts
+++ b/plugins/dev-init/skills/init/init.ts
@@ -6,8 +6,9 @@
  * Usage:
  *   bun init.ts prereqs [--json]
  *   bun init.ts discover [--json]
- *   bun init.ts workflows --owner <owner> --repo <repo> --stack <bun|node|python> --test <vitest|jest|pytest|none> --deploy <vercel|none> [--branch <branch>]
- *   bun init.ts push-workflows --owner <owner> --repo <repo> [--branch <branch>]  # generic only (auto-merge + pr-title + context-lint)
+ *   bun init.ts workflows --owner <owner> --repo <repo> --stack <bun|node|python> --test <vitest|jest|pytest|none> --deploy <vercel|none> [--branch <branch>] [--force]
+ *   bun init.ts push-workflows --owner <owner> --repo <repo> [--branch <branch>] [--force]  # generic only (auto-merge + pr-title + context-lint)
+ *   (both default to TOP-UP: existing workflow files are skipped; --force overwrites)
  *   bun init.ts protect-branches --repo <owner/repo>
  *   bun init.ts scaffold-rules [--stack-path .claude/stack.yml] [--project-name <name>] [--claude-md CLAUDE.md]
  *   bun init.ts scaffold --github-repo <owner/repo> [--vercel-token <token>] [--vercel-project-id <id>] [--vercel-team-id <id>] [--force]
@@ -51,8 +52,9 @@ switch (command) {
     const stack = parseFlag('--stack', 'bun') as 'bun' | 'node' | 'python'
     const test = parseFlag('--test', 'vitest') as 'vitest' | 'jest' | 'pytest' | 'none'
     const deploy = parseFlag('--deploy', 'none') as 'vercel' | 'none'
+    const force = process.argv.includes('--force')
     if (owner && repo) {
-      const result = await pushWorkflows(owner, repo, { stack, test, deploy }, branch)
+      const result = await pushWorkflows(owner, repo, { stack, test, deploy }, branch, force)
       console.log(JSON.stringify({ pushed: result }, null, 2))
     } else {
       // fallback: local write (no owner/repo provided)
@@ -71,7 +73,7 @@ switch (command) {
       console.error('Usage: init.ts push-workflows --owner <owner> --repo <repo> [--branch <branch>]')
       process.exit(1)
     }
-    const result = await pushGenericWorkflows(owner, repo, branch)
+    const result = await pushGenericWorkflows(owner, repo, branch, process.argv.includes('--force'))
     console.log(JSON.stringify({ pushed: result }, null, 2))
     break
   }

--- a/plugins/dev-init/skills/init/lib/workflows.ts
+++ b/plugins/dev-init/skills/init/lib/workflows.ts
@@ -231,25 +231,25 @@ jobs:
           V=0
           # dead repo-relative @imports (home-dir @~/... imports are machine-local — skipped on CI)
           while IFS= read -r file; do
-            dir=\$(dirname "\$file")
+            dir=$(dirname "$file")
             while IFS= read -r imp; do
               target=\${imp#@}
-              case "\$target" in "~/"*|/*) continue ;; esac
-              if [ ! -e "\$dir/\$target" ]; then
-                echo "::error file=\$file::dead @import: \$imp"
-                V=\$((V + 1))
+              case "$target" in "~/"*|/*) continue ;; esac
+              if [ ! -e "$dir/$target" ]; then
+                echo "::error file=$file::dead @import: $imp"
+                V=$((V + 1))
               fi
-            done < <(grep -o '^@[^ ]*' "\$file" || true)
+            done < <(grep -o '^@[^ ]*' "$file" || true)
           done < <(find . \\( -name node_modules -o -name .worktrees -o -name worktrees -o -name .git \\) -prune -o \\( -name 'CLAUDE.md' -o -name 'AGENTS.md' \\) -print)
           # unfilled scaffold placeholders
           while IFS= read -r f; do
-            echo "::error file=\$f::unfilled scaffold placeholder (gotchas)"
-            V=\$((V + 1))
+            echo "::error file=$f::unfilled scaffold placeholder (gotchas)"
+            V=$((V + 1))
           done < <(grep -rl 'Add project-specific gotchas here' --include=CLAUDE.md . 2>/dev/null || true)
-          if [ "\$V" -eq 0 ]; then
+          if [ "$V" -eq 0 ]; then
             echo "context-lint: clean"
           else
-            echo "context-lint: \$V violation(s)"
+            echo "context-lint: $V violation(s)"
             exit 1
           fi
 `
@@ -275,7 +275,10 @@ export function generateCiYml(opts: WorkflowOpts): string {
     lintCmd = 'bun lint'
     typecheckCmd = 'bun typecheck'
     if (opts.test !== 'none') {
-      testStep = '\n      - name: Test\n        run: bun test'
+      // `bun test` runs Bun's own runner and silently ignores vitest — vitest repos
+      // need `bun run test` to hit the package.json script (enishu 312781c).
+      const bunTestCmd = opts.test === 'vitest' ? 'bun run test' : 'bun test'
+      testStep = `\n      - name: Test\n        run: ${bunTestCmd}`
     }
   } else {
     setupStep = '      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: npm ci'
@@ -366,14 +369,16 @@ async function getToken(): Promise<string> {
 }
 
 /** Push a single file to a repo via the GH contents API (create-or-update).
- *  `path` is the full repo-relative path (e.g. `.github/workflows/ci.yml`). */
+ *  `path` is the full repo-relative path (e.g. `.github/workflows/ci.yml`).
+ *  With `skipExisting`, a file already present is left untouched ('skipped') —
+ *  repos evolve their workflows past the templates, so overwrite must be opt-in. */
 export async function pushWorkflowFile(
   owner: string,
   repo: string,
   path: string,
   content: string,
-  opts: { branch: string; message?: string },
-): Promise<'created' | 'updated'> {
+  opts: { branch: string; message?: string; skipExisting?: boolean },
+): Promise<'created' | 'updated' | 'skipped'> {
   const token = await getToken()
   const { branch } = opts
   const b64 = Buffer.from(content).toString('base64')
@@ -386,6 +391,7 @@ export async function pushWorkflowFile(
 
   const checkRes = await fetch(url, { headers })
   const existing = checkRes.ok ? ((await checkRes.json()) as { sha: string }) : null
+  if (existing && opts.skipExisting) return 'skipped'
 
   const body: Record<string, string> = {
     message: opts?.message ?? `chore: ${existing ? 'update' : 'add'} ${path}`,
@@ -410,15 +416,18 @@ export async function pushWorkflowFile(
 
 export interface PushResult {
   file: string
-  status: 'created' | 'updated'
+  status: 'created' | 'updated' | 'skipped'
 }
 
-/** Push all workflow files to a remote repo via GitHub REST API. No local git required. */
+/** Push all workflow files to a remote repo via GitHub REST API. No local git required.
+ *  Default is TOP-UP: files already present on the repo are skipped (repos evolve
+ *  their ci.yml far past the template — see roxabi-factory/enishu). `force` overwrites. */
 export async function pushWorkflows(
   owner: string,
   repo: string,
   opts: WorkflowOpts,
   branch: string,
+  force = false,
 ): Promise<PushResult[]> {
   const files: Array<{ name: string; content: string }> = [
     { name: 'auto-merge.yml', content: generateAutoMergeYml() },
@@ -432,14 +441,23 @@ export async function pushWorkflows(
 
   const results: PushResult[] = []
   for (const { name, content } of files) {
-    const status = await pushWorkflowFile(owner, repo, `.github/workflows/${name}`, content, { branch })
+    const status = await pushWorkflowFile(owner, repo, `.github/workflows/${name}`, content, {
+      branch,
+      skipExisting: !force,
+    })
     results.push({ file: name, status })
   }
   return results
 }
 
-/** Push a specific subset of workflow files (e.g. only the generic ones). */
-export async function pushGenericWorkflows(owner: string, repo: string, branch: string): Promise<PushResult[]> {
+/** Push a specific subset of workflow files (e.g. only the generic ones).
+ *  Same top-up default as pushWorkflows: existing files are skipped unless `force`. */
+export async function pushGenericWorkflows(
+  owner: string,
+  repo: string,
+  branch: string,
+  force = false,
+): Promise<PushResult[]> {
   const files = [
     { name: 'auto-merge.yml', content: generateAutoMergeYml() },
     { name: 'pr-title.yml', content: generatePrTitleYml() },
@@ -447,7 +465,10 @@ export async function pushGenericWorkflows(owner: string, repo: string, branch: 
   ]
   const results: PushResult[] = []
   for (const { name, content } of files) {
-    const status = await pushWorkflowFile(owner, repo, `.github/workflows/${name}`, content, { branch })
+    const status = await pushWorkflowFile(owner, repo, `.github/workflows/${name}`, content, {
+      branch,
+      skipExisting: !force,
+    })
     results.push({ file: name, status })
   }
   return results

--- a/plugins/dev-init/skills/shared/adapters/github-infra.ts
+++ b/plugins/dev-init/skills/shared/adapters/github-infra.ts
@@ -7,7 +7,13 @@
 
 import { ConfigError } from '../domain/errors'
 
-export const STANDARD_WORKFLOWS = ['ci.yml', 'auto-merge.yml', 'pr-title.yml', 'deploy-preview.yml'] as const
+export const STANDARD_WORKFLOWS = [
+  'ci.yml',
+  'auto-merge.yml',
+  'pr-title.yml',
+  'context-lint.yml',
+  'deploy-preview.yml',
+] as const
 
 /**
  * Token mode for CI workflows.


### PR DESCRIPTION
Suite de #315, corrige les 2 P0 relevés par l'audit gap CI/CD (2026-07-02) :

1. **Désarmement du piège clobber** : `pushWorkflows`/`pushGenericWorkflows` skippent désormais les fichiers déjà présents (`--force` pour écraser explicitement). Sans ça, l'ajout de `context-lint.yml` au standard set cassait le guard « all present → skip » de ci-setup sur toute la flotte, et une régénération acceptée écrasait les ci.yml évolués (factory : 190 lignes / 3 jobs intégration+docker ; enishu : job e2e Playwright ; bouly-site : `bun lint`/`bun typecheck` inexistants → CI rouge garanti). Le rollout de context-lint.yml devient additif et sûr.
2. **Parité standard set** : `STANDARD_WORKFLOWS` (github-infra.ts canonical dev-core + copie sync dev-init) et la ligne « Standard » de checkup/infra-checks.md incluent `context-lint.yml` — #315 n'avait mis à jour que le cookbook ci-setup ; checkup et ci-setup étaient en désaccord.
3. **Bug bun+vitest** : `bun test` → `bun run test` quand test=vitest (`bun test` lance le runner natif Bun et ignore vitest ; enishu l'avait corrigé à la main le jour même du scaffold, 312781c).

Gate : lint/typecheck/test verts (560 tests). Bump dev-core 0.8.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)