### PR TITLE
feat(dev-init): extend context-lint to Grok harness paths

### DIFF
--- a/plugins/dev-init/skills/init/__tests__/workflows.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/workflows.test.ts
@@ -147,6 +147,18 @@ describe('generateContextLintYml', () => {
     expect(yml).toContain("'**/CLAUDE.md'")
     expect(yml).toContain("'**/AGENTS.md'")
     expect(yml).toContain("'.claude/**'")
+    expect(yml).toContain("'.grok/**'")
+    expect(yml).toContain("'.agents/**'")
+  })
+
+  it('lints Grok and Claude harness markdown (not only root CLAUDE/AGENTS)', () => {
+    const yml = generateContextLintYml()
+    expect(yml).toContain('*/.grok/rules/*')
+    expect(yml).toContain('*/.grok/skills/*')
+    expect(yml).toContain('*/.grok/agents/*')
+    expect(yml).toContain('*/.claude/rules/*')
+    expect(yml).toContain('*/.claude/skills/*')
+    expect(yml).toContain('*/.agents/skills/*')
   })
 
   it('emits interpolated bash (no unresolved TS template escapes)', () => {

--- a/plugins/dev-init/skills/init/init.ts
+++ b/plugins/dev-init/skills/init/init.ts
@@ -8,6 +8,7 @@
  *   bun init.ts discover [--json]
  *   bun init.ts workflows --owner <owner> --repo <repo> --stack <bun|node|python> --test <vitest|jest|pytest|none> --deploy <vercel|none> [--branch <branch>] [--force]
  *   bun init.ts push-workflows --owner <owner> --repo <repo> [--branch <branch>] [--force]  # generic only (auto-merge + pr-title + context-lint)
+ *   bun init.ts push-context-lint --owner <owner> --repo <repo> [--branch <branch>]  # context-lint.yml only (always updates)
  *   (both default to TOP-UP: existing workflow files are skipped; --force overwrites)
  *   bun init.ts protect-branches --repo <owner/repo>
  *   bun init.ts scaffold-rules [--stack-path .claude/stack.yml] [--project-name <name>] [--claude-md CLAUDE.md]
@@ -75,6 +76,20 @@ switch (command) {
     }
     const result = await pushGenericWorkflows(owner, repo, branch, process.argv.includes('--force'))
     console.log(JSON.stringify({ pushed: result }, null, 2))
+    break
+  }
+
+  case 'push-context-lint': {
+    const { pushContextLintYml } = await import('./lib/workflows')
+    const owner = parseFlag('--owner', '')
+    const repo = parseFlag('--repo', '')
+    const branch = parseFlag('--branch', 'main')
+    if (!owner || !repo) {
+      console.error('Usage: init.ts push-context-lint --owner <owner> --repo <repo> [--branch <branch>]')
+      process.exit(1)
+    }
+    const status = await pushContextLintYml(owner, repo, branch)
+    console.log(JSON.stringify({ file: 'context-lint.yml', status }, null, 2))
     break
   }
 

--- a/plugins/dev-init/skills/init/lib/workflows.ts
+++ b/plugins/dev-init/skills/init/lib/workflows.ts
@@ -194,10 +194,11 @@ jobs:
 }
 
 /** Generic context lint — keeps agent-context files honest:
- *  repo-relative `@imports` in CLAUDE.md/AGENTS.md must resolve, and scaffold
- *  placeholders must be filled. Home-dir imports (`@~/...`) are machine-local
- *  and skipped on CI. Stack-agnostic (pure bash, no deps). Ecosystem-level
- *  checks (project index, factory registry) live in the central
+ *  repo-relative `@imports` in harness context files must resolve, and scaffold
+ *  placeholders must be filled. Covers Claude (.claude/rules, CLAUDE.md) and Grok
+ *  (.grok/rules, .grok/skills/SKILL.md, .grok/agents). Home-dir imports (`@~/...`)
+ *  are machine-local and skipped on CI. Stack-agnostic (pure bash, no deps).
+ *  Ecosystem-level checks (project index, factory registry) live in the central
  *  ~/projects/scripts/context-lint.sh, deliberately not here. */
 export function generateContextLintYml(): string {
   return `name: Context Lint
@@ -208,12 +209,16 @@ on:
       - '**/CLAUDE.md'
       - '**/AGENTS.md'
       - '.claude/**'
+      - '.grok/**'
+      - '.agents/**'
   push:
     branches: [main, staging]
     paths:
       - '**/CLAUDE.md'
       - '**/AGENTS.md'
       - '.claude/**'
+      - '.grok/**'
+      - '.agents/**'
 
 permissions:
   contents: read
@@ -229,6 +234,13 @@ jobs:
         run: |
           set -u
           V=0
+          find_context_files() {
+            find . \\( -name node_modules -o -name .worktrees -o -name worktrees -o -name .git \\) -prune -o -type f \\( \\
+              -name 'CLAUDE.md' -o -name 'AGENTS.md' -o \\
+              \\( -name 'SKILL.md' \\( -path '*/.grok/skills/*' -o -path '*/.claude/skills/*' -o -path '*/.agents/skills/*' \\) \\) -o \\
+              \\( -name '*.md' \\( -path '*/.grok/rules/*' -o -path '*/.claude/rules/*' -o -path '*/.grok/agents/*' \\) \\) \\
+            \\) -print
+          }
           # dead repo-relative @imports (home-dir @~/... imports are machine-local — skipped on CI)
           while IFS= read -r file; do
             dir=$(dirname "$file")
@@ -240,7 +252,7 @@ jobs:
                 V=$((V + 1))
               fi
             done < <(grep -o '^@[^ ]*' "$file" || true)
-          done < <(find . \\( -name node_modules -o -name .worktrees -o -name worktrees -o -name .git \\) -prune -o \\( -name 'CLAUDE.md' -o -name 'AGENTS.md' \\) -print)
+          done < <(find_context_files)
           # unfilled scaffold placeholders
           while IFS= read -r f; do
             echo "::error file=$f::unfilled scaffold placeholder (gotchas)"
@@ -253,6 +265,19 @@ jobs:
             exit 1
           fi
 `
+}
+
+/** Push only context-lint.yml (always updates — safe to re-run after generator changes). */
+export async function pushContextLintYml(
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<'created' | 'updated' | 'skipped'> {
+  return pushWorkflowFile(owner, repo, '.github/workflows/context-lint.yml', generateContextLintYml(), {
+    branch,
+    message: 'chore: update context-lint.yml (Grok + Claude harness paths)',
+    skipExisting: false,
+  })
 }
 
 export function generateCiYml(opts: WorkflowOpts): string {


### PR DESCRIPTION
## Summary

- Extend `generateContextLintYml()` to trigger on `.grok/**` and `.agents/**`
- Lint `@imports` in `.grok/rules`, `.grok/skills/SKILL.md`, `.grok/agents`, `.claude/rules`, `.claude/skills`, `.agents/skills`
- Add `push-context-lint` CLI command for safe fleet-wide workflow updates (updates only `context-lint.yml`)

## Context

Fleet rollout already applied the new YAML to all 27 repos via `push-context-lint` on each repo's default branch. This PR lands the generator source so future `/ci-setup` runs emit the same template.

Related: Roxabi/projects-meta# (chore/context-lint-grok-harness), Roxabi/enishu# (chore/grok-context-gitignore)