### PR TITLE
fix(dev-core): drop agent tools frontmatter for cross-harness compat

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/agents/architect.md
+++ b/plugins/dev-core/agents/architect.md
@@ -11,7 +11,6 @@ description: |
   assistant: "I'll use the architect agent to design the architecture."
   </example>
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=true, write_code=false, review_code=true, run_tests=false

--- a/plugins/dev-core/agents/axial-adr-create.md
+++ b/plugins/dev-core/agents/axial-adr-create.md
@@ -20,7 +20,6 @@ description: |
   assistant: "Running axial-adr-create. Will offer Keep / Supersede / Review if an ADR already exists."
   </example>
 color: yellow
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Skill"]
 permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false

--- a/plugins/dev-core/agents/axial-adr-review.md
+++ b/plugins/dev-core/agents/axial-adr-review.md
@@ -20,7 +20,6 @@ description: |
   assistant: "Including axial-adr-review among spec reviewers to flag drift along non-primary axis."
   </example>
 color: yellow
-tools: ["Read", "Glob", "Grep"]
 permissionMode: bypassPermissions
 maxTurns: 20
 # capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false

--- a/plugins/dev-core/agents/backend-dev.md
+++ b/plugins/dev-core/agents/backend-dev.md
@@ -11,7 +11,6 @@ description: |
   </example>
 model: sonnet
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true

--- a/plugins/dev-core/agents/devops.md
+++ b/plugins/dev-core/agents/devops.md
@@ -11,7 +11,6 @@ description: |
   </example>
 model: sonnet
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=false, run_tests=true

--- a/plugins/dev-core/agents/doc-writer.md
+++ b/plugins/dev-core/agents/doc-writer.md
@@ -11,7 +11,6 @@ description: |
   </example>
 model: haiku
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false

--- a/plugins/dev-core/agents/fixer.md
+++ b/plugins/dev-core/agents/fixer.md
@@ -11,7 +11,6 @@ description: |
   </example>
 model: sonnet
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true

--- a/plugins/dev-core/agents/frontend-dev.md
+++ b/plugins/dev-core/agents/frontend-dev.md
@@ -11,7 +11,6 @@ description: |
   </example>
 model: sonnet
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true

--- a/plugins/dev-core/agents/product-lead.md
+++ b/plugins/dev-core/agents/product-lead.md
@@ -12,7 +12,6 @@ description: |
   assistant: "I'll use the product-lead agent to define requirements."
   </example>
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false

--- a/plugins/dev-core/agents/recall.md
+++ b/plugins/dev-core/agents/recall.md
@@ -12,7 +12,6 @@ description: |
   assistant: "I'll use the recall agent to confirm scope and find un-cited callsites."
   </example>
 color: purple
-tools: ["Read", "Glob", "Grep", "Bash"]
 permissionMode: bypassPermissions
 maxTurns: 20
 # capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false

--- a/plugins/dev-core/agents/security-auditor.md
+++ b/plugins/dev-core/agents/security-auditor.md
@@ -11,7 +11,6 @@ description: |
   assistant: "I'll use the security-auditor agent to perform a security audit."
   </example>
 color: white
-tools: ["Read", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false

--- a/plugins/dev-core/agents/tester.md
+++ b/plugins/dev-core/agents/tester.md
@@ -11,7 +11,6 @@ description: |
   </example>
 model: sonnet
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "EnterWorktree", "ExitWorktree", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "TaskOutput", "TaskStop", "SendMessage"]
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=false, run_tests=true


### PR DESCRIPTION
## Summary
- Remove the `tools:` frontmatter line from all 12 dev-core agent definitions
- Bump dev-core plugin version to **0.8.13**

## Why
Grok Build rejects plugin agents when frontmatter declares Claude-only tool names (`Task`, `SendMessage`, `EnterWorktree`, etc.). Without an explicit `tools:` list, each harness falls back to its default agent toolset and agents register correctly on both Claude Code and Grok.

## Test Plan
- [ ] `grok inspect` lists dev-core agents (`backend-dev`, `tester`, `architect`, …) as spawnable types
- [ ] Claude Code still loads dev-core agents from the plugin cache after marketplace update

---
Generated with Grok Build