### PR TITLE
feat(dev-core): route shape diagrams through forge-chart sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Entries are generated automatically by `/promote` and committed to staging before the promotion PR.
 
+## Unreleased
+
+### Changed
+
+* **dev-core:** replace inline mermaid/ASCII shape diagrams with forge-chart sidecars in `clarify`, `analyze`, `spec`, and `plan` — HTML in `artifacts/visuals/`, SSoT at `references/forge-chart-sidecar.md`; supersedes mermaid diagram requirements added in `e455a5b`
+
 ## [0.3.0](https://github.com/Roxabi/roxabi-plugins/compare/roxabi-plugins/v0.2.0...roxabi-plugins/v0.3.0) (2026-04-17)
 
 

--- a/plugins/dev-core/README.md
+++ b/plugins/dev-core/README.md
@@ -6,6 +6,7 @@ Full development lifecycle orchestrator for Roxabi projects. Covers framing, ana
 
 - **Package manager** — Bun, npm, pnpm, or yarn (configured via `stack.yml`)
 - [GitHub CLI](https://cli.github.com/) (`gh`) — issue fetching, PR creation, label management
+- **[forge](https://github.com/Roxabi/roxabi-forge)** plugin — architecture diagrams in shape artifacts (`clarify`, `analyze`, `spec`, `plan`) are forge-chart sidecars in `artifacts/visuals/`, not inline mermaid/ASCII. Install: `claude plugin install forge`
 - **Formatter** — optional; configure any formatter in `stack.yml` (`build.formatter_fix_cmd` or `build.formatters[]`). Biome, Prettier, Ruff, Black — all work. Leave empty to disable auto-formatting.
 
 ## Install

--- a/plugins/dev-core/references/forge-chart-sidecar.md
+++ b/plugins/dev-core/references/forge-chart-sidecar.md
@@ -1,0 +1,78 @@
+# Forge-Chart Sidecar — dev-core visual standard
+
+SSoT for architecture and data-flow visuals in dev-core shape artifacts. Read before generating any diagram in `clarify`, `analyze`, `spec`, or `plan`.
+
+## Rule
+
+¬inline mermaid. ¬ASCII art. ¬chat-only diagram blocks for node-edge / architecture / data-flow content.
+
+∀ visual requirement → **forge-chart sidecar**: generate HTML via the `forge-chart` skill, copy into the repo, link from the artifact (or chat recap).
+
+## Prerequisite
+
+Forge plugin installed:
+
+```bash
+claude plugin install forge
+```
+
+¬installed → STOP + ask user to install forge before continuing past Step 2 of the owning skill.
+
+## Pipeline (mandatory)
+
+1. **Delegate** — `Skill(skill: "forge-chart", args: "{topic} — {diagram kind} for issue #{N}")`
+2. **Generate** — fd-engine path for node-edge architecture (`type:"architecture"` or `"hub-spoke"`, `theme:"lyra-v2"`) via `scripts/gen-fd.py`; fgraph `lane-swim` for multi-actor sequences; HTML `<table>` only for pure tabular matrices (no edges).
+3. **Validate** — `validate-fd.py` exit 0 before copying (forge-chart Deliver gate).
+4. **Copy sidecar** — from forge output to versioned repo path:
+
+```bash
+mkdir -p artifacts/visuals
+cp ~/.roxabi/forge/<project>/visuals/<slug>.html artifacts/visuals/<filename>.html
+```
+
+5. **Link** — in the artifact or chat recap (¬embed the HTML inline):
+
+```markdown
+**Diagram:** [{title}](../visuals/{N}-{slug}-{kind}.html)
+```
+
+Open locally: `file://{absolute-path}/artifacts/visuals/{filename}.html`
+
+## Filename convention
+
+`{N}-{slug}-{kind}.html`
+
+| `kind` | Used by | forge-chart type |
+|--------|---------|------------------|
+| `boundary` | `clarify` §2 | `architecture` — actors + boundary |
+| `shapes` | `analyze` §Shapes | `architecture` — shape comparison (zones per shape) |
+| `data-flow` | `analyze` §Fit Check, `plan` §Architecture | `architecture` + optional `useCases[]` |
+| `data-model` | `spec` §Data Model | fgraph `layered` — entities/fields/relations |
+| `consumers` | `spec` §Data Model | `hub-spoke` or `architecture` — data center + consumers |
+| `file-map` | `plan` §Architecture | `architecture` — files as nodes, call edges |
+
+`N` optional when no issue (free-text clarify) → `{slug}-{kind}.html`.
+
+## Section mapping
+
+| Skill | Section | Sidecar required when |
+|-------|---------|----------------------|
+| `clarify` | §2 Business Architecture | always (≥2 actors or layers) |
+| `analyze` | §Shapes | F-lite/F-full, ≥2 shapes |
+| `analyze` | §Fit Check | F-lite/F-full, data flow or arch choice |
+| `spec` | §Data Model & Consumers | F-lite/F-full |
+| `plan` | §Architecture | always (τ ∈ {F-lite, F-full}) |
+
+Tier S may omit shape/fit sidecars in `analyze`; may omit Data Model sidecars in `spec`.
+
+## Text flows in clarify §3
+
+Actor chains (`Actor → action → layer → outcome`) stay as one-line text — they are UX flows, not topology diagrams. ¬convert to mermaid/ASCII boxes.
+
+## Consumer summary table
+
+Keep the markdown table in `spec` §Data Model (consumer → fields → when → status). The sidecar is the visual; the table is the machine-readable index.
+
+## Quality bar
+
+Match forge-chart Craft Quality Bar (lyra-diagram gold standard): premium cards, bezier edges, `glow` on hub, `flow` on passive edges, per-node icons where helpful. See `forge-chart` SKILL.md § Craft Quality Bar.

--- a/plugins/dev-core/skills/analyze/README.md
+++ b/plugins/dev-core/skills/analyze/README.md
@@ -30,7 +30,7 @@ Triggers: `"analyze"` | `"technical analysis"` | `"deep dive"` | `"explore the p
 artifacts/analyses/{N}-{slug}-analysis.mdx
 ```
 
-Sections: Source, Problem, Outcome, Appetite, Shapes (2–3), Fit Check.
+Sections: Source, Problem, Outcome, Appetite, Shapes (2–3), Fit Check. Architecture visuals are forge-chart sidecars in `artifacts/visuals/` (linked from Shapes / Fit Check — not inline mermaid).
 
 ## Chain position
 

--- a/plugins/dev-core/skills/analyze/SKILL.md
+++ b/plugins/dev-core/skills/analyze/SKILL.md
@@ -98,6 +98,8 @@ Pre-fill context from φ — skip answered questions.
 
 ## Step 2c — Generate Analysis
 
+F-lite/F-full: generate forge-chart sidecars per [forge-chart-sidecar.md](${CLAUDE_PLUGIN_ROOT}/references/forge-chart-sidecar.md) **before** writing α.
+
 Write α:
 
 ```mdx

--- a/plugins/dev-core/skills/analyze/SKILL.md
+++ b/plugins/dev-core/skills/analyze/SKILL.md
@@ -124,6 +124,8 @@ description: "{one-line description}"
 
 ## Shapes
 
+**Diagram:** [{shapes title}](../visuals/{N}-{slug}-shapes.html)
+
 ### Shape 1: {name}
 
 {description}
@@ -140,17 +142,28 @@ description: "{one-line description}"
 
 ## Fit Check
 
+**Diagram:** [{data flow title}](../visuals/{N}-{slug}-data-flow.html)
+
 {Which shape best fits constraints + appetite, and why. Which shapes are eliminated.}
 ```
 
-### Mermaid Diagrams (optional, recommended for F-lite/F-full)
+### Forge-Chart Sidecars (F-lite/F-full)
 
-When analysis involves data flow or architectural choices, include mermaid in `## Fit Check` or `## Shapes`:
-- **Shape comparison** (`flowchart`): show key structural differences visually
-- **Data flow discovery** (`flowchart`): diagram current state for concrete findings
-- **Files impacted** table: always include when ≥3 files touched
+Read [forge-chart-sidecar.md](${CLAUDE_PLUGIN_ROOT}/references/forge-chart-sidecar.md) before generating visuals.
 
-Tier S may omit Shapes + Fit Check.
+When analysis involves data flow or architectural choices, generate forge-chart sidecars (¬inline mermaid, ¬ASCII):
+- **`## Shapes`** (≥2 shapes) → `{N}-{slug}-shapes.html` — architecture diagram with zones per shape
+- **`## Fit Check`** (data flow or arch choice) → `{N}-{slug}-data-flow.html` — recommended shape topology
+
+Link in α:
+
+```markdown
+**Diagram:** [{title}](../visuals/{N}-{slug}-{kind}.html)
+```
+
+**Files impacted** table: always include when ≥3 files touched.
+
+Tier S may omit Shapes + Fit Check sidecars.
 
 ∃ specific technical question → spawn domain expert via Task. See [references/expert-consultation.md](${CLAUDE_SKILL_DIR}/references/expert-consultation.md).
 
@@ -193,7 +206,7 @@ Present summary: shapes found, trade-offs, recommended shape, unresolved concern
 
 → present choice **Approve** → update issue status → done | **Revise** → collect feedback → revise α → loop from Step 3.
 
-On approval → commit: `git add artifacts/analyses/{N}-{slug}-analysis.mdx` + commit per CLAUDE.md Rule 5.
+On approval → commit: `git add artifacts/analyses/{N}-{slug}-analysis.mdx artifacts/visuals/` + commit per CLAUDE.md Rule 5.
 
 ```bash
 bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts set <N> --status Analysis

--- a/plugins/dev-core/skills/clarify/SKILL.md
+++ b/plugins/dev-core/skills/clarify/SKILL.md
@@ -114,7 +114,7 @@ Apply template strictly. ∀ section MUST appear, even if brief. Order is load-b
 
 ## 2. Business Architecture (where the boundary sits)
 
-**Diagram:** [{title}]({relative-path-to-sidecar.html})
+**Diagram:** [{title}](../visuals/{N}-{slug}-boundary.html) <!-- ¬issue: ../visuals/{slug}-boundary.html -->
 
 The boundary being changed: **{name it explicitly}** — {one-line description}.
 

--- a/plugins/dev-core/skills/clarify/SKILL.md
+++ b/plugins/dev-core/skills/clarify/SKILL.md
@@ -3,7 +3,7 @@ name: clarify
 argument-hint: '["topic" | --issue <N> | --resume]'
 description: Intent-first architecture recap — explain what we are really solving (intent → biz-arch → UX flows → data flow per layer → use cases × layers → open intent Qs); defer technical implementation until approved. Phase-agnostic, ephemeral, no artifact. Triggers "clarify intent" | "explain the architecture" | "restate what we are solving" | "recap the issue" | "restructure the answer" | "intent first" | "explain it properly" | "what is the architecture" | "explain from intent down" | "step back and explain".
 version: 0.1.0
-allowed-tools: Bash, Read, Glob, Grep, ToolSearch
+allowed-tools: Bash, Read, Write, Glob, Grep, Skill, ToolSearch
 ---
 
 # Clarify
@@ -93,6 +93,8 @@ Build context map without mutating anything:
 
 ## Step 2 — Render 6 Sections
 
+Generate §2 boundary sidecar first — `Skill(skill: "forge-chart", …)` per [forge-chart-sidecar.md](${CLAUDE_PLUGIN_ROOT}/references/forge-chart-sidecar.md); copy to `artifacts/visuals/`.
+
 Apply template strictly. ∀ section MUST appear, even if brief. Order is load-bearing.
 
 ### Section template
@@ -112,9 +114,7 @@ Apply template strictly. ∀ section MUST appear, even if brief. Order is load-b
 
 ## 2. Business Architecture (where the boundary sits)
 
-\`\`\`
-{ASCII box diagram — actors, layers, the boundary being changed}
-\`\`\`
+**Diagram:** [{title}]({relative-path-to-sidecar.html})
 
 The boundary being changed: **{name it explicitly}** — {one-line description}.
 
@@ -170,7 +170,7 @@ The use case with friction: **{name}** — that is where design decisions live.
 ### Rules per section
 
 - **Section 1 (Intent):** MUST contrast today vs target as a 2-column table. MUST include "Why this matters beyond {local scope}" — connect to ecosystem.
-- **Section 2 (Architecture):** MUST include an ASCII diagram naming the actors and boundary. MUST name the boundary explicitly.
+- **Section 2 (Architecture):** MUST include a forge-chart sidecar (`{N}-{slug}-boundary.html` or `{slug}-boundary.html`) naming actors and boundary — see [forge-chart-sidecar.md](${CLAUDE_PLUGIN_ROOT}/references/forge-chart-sidecar.md). Link only (¬inline mermaid, ¬ASCII). MUST name the boundary explicitly.
 - **Section 3 (Flows):** MUST include ≥1 happy path AND ≥1 adversarial/failure flow. MUST surface a nuance the obvious framing gets wrong.
 - **Section 4 (Data flow):** MUST be a table with TODAY and TARGET columns. MUST highlight which layers actually change.
 - **Section 5 (Use cases × layers):** MUST surface the use case with friction (where design decisions live).

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -307,7 +307,7 @@ adv → re-scan → Step 7 immediately.
 **Trigger:** in Step 8, the step that just completed == `plan` ∧ τ ∈ {F-lite, F-full} ∧ new S* == `implement`.
 τ=S never reaches here — `plan` is skipped, so the pipeline goes straight to `implement` with no pause.
 
-**Why:** `/plan` consumed heavy context (spec read, scope glob/grep, micro-task generation, mermaid). `/implement` spawns fresh agents whose context is injected from the task list + plan artifact — the planning conversation is dead weight. Tasks persist (task list + plan artifact `## Task IDs`); `/implement` Step 1b re-attaches after a context reset. `/compact` = soft restart → safe.
+**Why:** `/plan` consumed heavy context (spec read, scope glob/grep, micro-task generation, forge-chart sidecars). `/implement` spawns fresh agents whose context is injected from the task list + plan artifact — the planning conversation is dead weight. Tasks persist (task list + plan artifact `## Task IDs`); `/implement` Step 1b re-attaches after a context reset. `/compact` = soft restart → safe.
 
 **Behavior:** do **NOT** auto-chain to `/implement`. Print the recommendation block below and **STOP this turn** (Claude cannot invoke `/compact` — it is user-typed):
 

--- a/plugins/dev-core/skills/plan/README.md
+++ b/plugins/dev-core/skills/plan/README.md
@@ -22,7 +22,7 @@ Triggers: `"plan"` | `"plan this"` | `"implementation plan"` | `"break it down"`
 2. **Scope** — Globs + Greps the codebase to identify files to create/modify; finds reference patterns.
 3. **Agents** — assigns tasks to: `frontend-dev`, `backend-dev`, `tester`, `devops`, `doc-writer`, `architect`, `security-auditor` based on file paths from `stack.yml`.
 4. **Micro-tasks** — generates tasks with: description, file path, code skeleton, verify command, expected output, time estimate, parallel-safe flag, phase (RED/GREEN/REFACTOR/RED-GATE).
-5. **Write artifact** — creates `artifacts/plans/{N}-{slug}-plan.mdx` with mermaid data-flow and file×function diagrams.
+5. **Write artifact** — creates `artifacts/plans/{N}-{slug}-plan.mdx` with forge-chart sidecars (`data-flow`, `file-map`) linked from `artifacts/visuals/`.
 6. **Seed tasks** — creates Claude Code tasks for every micro-task; wires `blockedBy` dependencies; persists task IDs in the artifact.
 
 ## Output artifact

--- a/plugins/dev-core/skills/plan/SKILL.md
+++ b/plugins/dev-core/skills/plan/SKILL.md
@@ -149,6 +149,8 @@ See [references/micro-task-example.mdx](${CLAUDE_SKILL_DIR}/references/micro-tas
 
 ## Step 5 — Write Plan Artifact
 
+Generate architecture sidecars per [forge-chart-sidecar.md](${CLAUDE_PLUGIN_ROOT}/references/forge-chart-sidecar.md) **before** writing π.
+
 Write to `artifacts/plans/{N}-{slug}-plan.mdx`. Create `artifacts/plans/` dir if needed.
 
 Use [references/plan-template.mdx](${CLAUDE_SKILL_DIR}/references/plan-template.mdx). See [references/micro-task-example.mdx](${CLAUDE_SKILL_DIR}/references/micro-task-example.mdx) for task formatting.

--- a/plugins/dev-core/skills/plan/SKILL.md
+++ b/plugins/dev-core/skills/plan/SKILL.md
@@ -166,7 +166,7 @@ generated: {ISO}
 
 Include:
 - Summary (1–2 sentences)
-- Architecture diagrams (mermaid, see below)
+- Architecture sidecars (forge-chart, see below)
 - Bootstrap Context (from analysis if ∃, omit if ¬∃)
 - Agents table (agent, task count, files)
 - Wave Structure table (see below)
@@ -174,13 +174,22 @@ Include:
 - Micro-Tasks (grouped by slice/criteria, with RED-GATE sentinels)
 - Task Seeding Blueprint (see below)
 
-### Mermaid Diagrams
+### Forge-Chart Sidecars
+
+Read [forge-chart-sidecar.md](${CLAUDE_PLUGIN_ROOT}/references/forge-chart-sidecar.md) before generating visuals.
 
 `## Architecture` must include:
-1. **Data flow** (`flowchart TD`) — full pipeline: config files → loader functions → data structures → composition → runtime injection. Group nodes into subgraphs by file. Highlight key paths with distinct styles.
-2. **File × Function map** (`flowchart LR`) — functions/classes per file, call relationships. Group by source file. Show test files as consumers.
+1. **Data flow sidecar** — `{N}-{slug}-data-flow.html` (fd-engine `architecture`): full pipeline — config → loaders → data structures → composition → runtime. Group by file via zones.
+2. **File × Function map sidecar** — `{N}-{slug}-file-map.html` (fd-engine `architecture`): functions/classes per file, call edges; test files as consumers.
 
-Diagrams go AFTER Summary, BEFORE Bootstrap Context.
+Link in π (¬inline mermaid, ¬ASCII):
+
+```markdown
+**Data flow:** [{title}](../visuals/{N}-{slug}-data-flow.html)
+**File map:** [{title}](../visuals/{N}-{slug}-file-map.html)
+```
+
+Sidecars go AFTER Summary, BEFORE Bootstrap Context.
 
 ### Wave Structure
 
@@ -294,7 +303,7 @@ This lets `/implement` re-attach to tasks after a session restart (TaskList woul
 
 ### Step 6c — Commit
 
-`git add artifacts/plans/{N}-{slug}-plan.mdx` + commit per CLAUDE.md Rule 5.
+`git add artifacts/plans/{N}-{slug}-plan.mdx artifacts/visuals/` + commit per CLAUDE.md Rule 5.
 
 → Then **Exit** — approval lands on a compact pause (recommend `/compact` before `/implement`), ¬auto-chain. See Exit.
 

--- a/plugins/dev-core/skills/plan/references/plan-template.mdx
+++ b/plugins/dev-core/skills/plan/references/plan-template.mdx
@@ -15,51 +15,15 @@ generated: "2026-01-01T00:00:00Z"
 
 ### Data Flow
 
-```mermaid
-flowchart TD
-    subgraph "Config Files"
-        CF1["{config file 1}"]
-        CF2["{config file 2}"]
-    end
+**Diagram:** [{data flow title}](../visuals/{N}-{slug}-data-flow.html)
 
-    subgraph "{source_file}.py — Loading"
-        FN1["load_function()"]
-        DC1["DataClass"]
-    end
-
-    subgraph "{source_file}.py — Runtime"
-        FN2["process_function()"]
-        OUT["Output / Side effect"]
-    end
-
-    CF1 --> FN1
-    CF2 --> FN1
-    FN1 --> DC1
-    DC1 --> FN2
-    FN2 --> OUT
-```
+{One-line summary of config → loader → runtime pipeline.}
 
 ### File x Function Map
 
-```mermaid
-flowchart LR
-    subgraph "{path/to/source_a}"
-        FA1["{Function/Class 1}"]
-        FA2["{Function/Class 2}"]
-    end
+**Diagram:** [{file map title}](../visuals/{N}-{slug}-file-map.html)
 
-    subgraph "{path/to/source_b}"
-        FB1["{Function/Class 3}"]
-    end
-
-    subgraph "tests/"
-        T1["test_{module}.py"]
-    end
-
-    FA1 -->|"returns"| FA2
-    FA2 -->|"calls"| FB1
-    FA1 -.->|"tested by"| T1
-```
+{One-line summary of file groupings and critical call paths.}
 
 ## Bootstrap Context
 

--- a/plugins/dev-core/skills/spec/README.md
+++ b/plugins/dev-core/skills/spec/README.md
@@ -32,7 +32,7 @@ Triggers: `"write spec"` | `"spec this"` | `"solution design"` | `"acceptance cr
 artifacts/specs/{N}-{slug}-spec.mdx
 ```
 
-Sections: Context, Goal, Users, Expected Behavior, Data Model & Consumers (mermaid), Breadboard, Slices, Success Criteria.
+Sections: Context, Goal, Users, Expected Behavior, Data Model & Consumers (forge-chart sidecars in `artifacts/visuals/`), Breadboard, Slices, Success Criteria.
 
 ## Chain position
 

--- a/plugins/dev-core/skills/spec/SKILL.md
+++ b/plugins/dev-core/skills/spec/SKILL.md
@@ -111,19 +111,28 @@ Write σ. Must include:
 | `## Goal` — one-sentence outcome | — |
 | `## Users` — who is affected | — |
 | `## Expected Behavior` — narrative walkthrough | — |
-| `## Data Model & Consumers` — mermaid diagrams (see below) | Tier S |
+| `## Data Model & Consumers` — forge-chart sidecars (see below) | Tier S |
 | `## Breadboard` — affordance tables + wiring | Tier S |
 | `## Slices` — vertical increments table | Tier S |
 | `## Success Criteria` — `- [ ]` checkboxes, each binary | — |
 
-### Mermaid Diagrams (Tier F-lite, F-full)
+### Forge-Chart Sidecars (Tier F-lite, F-full)
+
+Read [forge-chart-sidecar.md](${CLAUDE_PLUGIN_ROOT}/references/forge-chart-sidecar.md) before generating visuals.
 
 `## Data Model & Consumers` must include:
-1. **Data structure diagram** (`classDiagram`) — core types/models, fields, relationships. Frozen/mutable annotations where relevant.
-2. **Consumer map** (`flowchart`) — who consumes data, which fields, when. Solid = this issue, dashed = future (out of scope but fields must be accessible).
+1. **Data structure sidecar** — `{N}-{slug}-data-model.html` (fgraph layered or fd-engine): core types/models, fields, relationships. Frozen/mutable in node labels.
+2. **Consumer map sidecar** — `{N}-{slug}-consumers.html` (hub-spoke or architecture): who consumes data, which fields, when. Solid edges = this issue; dashed = future.
 3. **Consumer summary table** — consumer → fields consumed, when, status (this issue / future).
 
-Diagrams go BEFORE Breadboard. They answer "what is the data shape and who uses it" while Breadboard answers "how do pieces wire together."
+Link each sidecar (¬inline mermaid, ¬ASCII):
+
+```markdown
+**Data structure:** [{title}](../visuals/{N}-{slug}-data-model.html)
+**Consumer map:** [{title}](../visuals/{N}-{slug}-consumers.html)
+```
+
+Sidecars go BEFORE Breadboard. They answer "what is the data shape and who uses it" while Breadboard answers "how do pieces wire together."
 
 May contain χ (max 3–5). χ items block `/plan` — must be resolved first.
 
@@ -182,7 +191,7 @@ Present summary: scope, |slices|, |acceptance criteria|, |χ|, pre-check results
 
 Q: **Approve** → continue pipeline | **Revise** → collect feedback → revise σ → loop from Step 3.
 
-On approval → commit: `git add artifacts/specs/{N}-{slug}-spec.mdx` + commit per CLAUDE.md Rule 5.
+On approval → commit: `git add artifacts/specs/{N}-{slug}-spec.mdx artifacts/visuals/` + commit per CLAUDE.md Rule 5.
 
 Run Gate 2.5 → update issue status:
 ```bash

--- a/plugins/dev-core/skills/spec/SKILL.md
+++ b/plugins/dev-core/skills/spec/SKILL.md
@@ -103,6 +103,8 @@ Interview pre-fills from SRC. Focus on gaps to spec level:
 - Slices: vertical increments, independently demo-able
 - Ambiguity detection via 9-category taxonomy (see interview SKILL.md)
 
+F-lite/F-full: generate forge-chart sidecars per [forge-chart-sidecar.md](${CLAUDE_PLUGIN_ROOT}/references/forge-chart-sidecar.md) **before** writing σ.
+
 Write σ. Must include:
 
 | Section | Skip if |

--- a/plugins/dev-core/skills/spec/references/templates.md
+++ b/plugins/dev-core/skills/spec/references/templates.md
@@ -33,45 +33,15 @@ description: "{one-line description}"
 
 ### Data Structure
 
-```mermaid
-classDiagram
-    class {MainConfig} {
-        <<frozen>>
-        +field_a: type
-        +sub: SubConfig
-    }
+**Diagram:** [{data model title}](../visuals/{N}-{slug}-data-model.html)
 
-    class SubConfig {
-        <<frozen>>
-        +field_b: type
-    }
-
-    {MainConfig} *-- SubConfig
-```
+{One-line summary of core types and frozen/mutable annotations.}
 
 ### Consumer Map
 
-```mermaid
-flowchart LR
-    DATA["{MainConfig}"]
+**Diagram:** [{consumer map title}](../visuals/{N}-{slug}-consumers.html)
 
-    subgraph "Current Consumers (this issue)"
-        C1["Consumer 1\nreads field_a"]
-    end
-
-    subgraph "Future Consumers (separate issues)"
-        C2["Consumer 2\nreads sub.field_b"]
-    end
-
-    DATA -->|"field_a"| C1
-    DATA -.->|"sub.field_b"| C2
-
-    style DATA fill:#f9f,stroke:#333
-    style C1 fill:#bbf,stroke:#333
-    style C2 fill:#ffe,stroke:#999,stroke-dasharray: 5 5
-```
-
-**Legend:** Solid = this issue. Dashed = future consumers.
+**Legend:** Solid edges = this issue. Dashed edges = future consumers.
 
 | Consumer | Fields consumed | When | Status |
 |----------|----------------|------|--------|

--- a/plugins/dev-init/skills/init/lib/scaffold-rules.ts
+++ b/plugins/dev-init/skills/init/lib/scaffold-rules.ts
@@ -209,6 +209,7 @@ function artifactModel(stack: StackConfig): Section {
     analyses: 'artifacts/analyses',
     specs: 'artifacts/specs',
     plans: 'artifacts/plans',
+    visuals: 'artifacts/visuals',
   }
 
   const content = `Artifacts are the state markers \`/dev\` uses for progress detection and resumption.
@@ -218,7 +219,8 @@ function artifactModel(stack: StackConfig): Section {
 | **Frame** | \`${artifacts.frames ?? 'artifacts/frames'}/\` | What's the problem? |
 | **Analysis** | \`${artifacts.analyses ?? 'artifacts/analyses'}/\` | How deep is it? |
 | **Spec** | \`${artifacts.specs ?? 'artifacts/specs'}/\` | What will we build? |
-| **Plan** | \`${artifacts.plans ?? 'artifacts/plans'}/\` | How do we build it? |`
+| **Plan** | \`${artifacts.plans ?? 'artifacts/plans'}/\` | How do we build it? |
+| **Visuals** | \`${artifacts.visuals ?? 'artifacts/visuals'}/\` | Architecture diagrams (forge-chart sidecars) |`
 
   return { id: 'artifact-model', title: 'Artifact Model', content }
 }

--- a/plugins/dev-init/skills/init/lib/scaffold.ts
+++ b/plugins/dev-init/skills/init/lib/scaffold.ts
@@ -281,7 +281,13 @@ export async function scaffold(opts: ScaffoldOpts): Promise<ScaffoldResult> {
   }
 
   // artifacts/
-  for (const dir of ['artifacts/frames', 'artifacts/analyses', 'artifacts/specs', 'artifacts/plans', 'artifacts/visuals']) {
+  for (const dir of [
+    'artifacts/frames',
+    'artifacts/analyses',
+    'artifacts/specs',
+    'artifacts/plans',
+    'artifacts/visuals',
+  ]) {
     fs.mkdirSync(dir, { recursive: true })
   }
   result.artifactsCreated = true

--- a/plugins/dev-init/skills/init/lib/scaffold.ts
+++ b/plugins/dev-init/skills/init/lib/scaffold.ts
@@ -281,7 +281,7 @@ export async function scaffold(opts: ScaffoldOpts): Promise<ScaffoldResult> {
   }
 
   // artifacts/
-  for (const dir of ['artifacts/frames', 'artifacts/analyses', 'artifacts/specs', 'artifacts/plans']) {
+  for (const dir of ['artifacts/frames', 'artifacts/analyses', 'artifacts/specs', 'artifacts/plans', 'artifacts/visuals']) {
     fs.mkdirSync(dir, { recursive: true })
   }
   result.artifactsCreated = true


### PR DESCRIPTION
## Summary

Shape pipeline skills (`clarify`, `analyze`, `spec`, `plan`) no longer mandate inline mermaid or ASCII architecture diagrams. They now require **forge-chart sidecars**: self-contained HTML in `artifacts/visuals/`, linked from `.mdx` artifacts.

## Changes

- Add SSoT: `plugins/dev-core/references/forge-chart-sidecar.md`
- Update `clarify`, `analyze`, `spec`, `plan` SKILL.md + templates
- Document **forge** plugin as dev-core prerequisite
- CHANGELOG Unreleased entry (supersedes `e455a5b` mermaid requirements)

## Out of scope

- Historical `artifacts/*.mdx` with inline mermaid (not migrated)
- `readme-upgrade` (GitHub README context — mermaid/ASCII unchanged)

## Test plan

- [ ] Re-install dev-core: `claude plugin install dev-core`
- [ ] Run `/analyze` or `/spec` on a test issue — verify sidecar generation + link in artifact
- [ ] Confirm `artifacts/visuals/` committed alongside `.mdx`