### PR TITLE
refactor(dev-core): drop agent frontmatter skills and tools

### DIFF
--- a/plugins/dev-core/README.md
+++ b/plugins/dev-core/README.md
@@ -150,15 +150,14 @@ Three Claude Code hooks for safety and consistency:
 | Bun test blocker | PreToolUse on Bash | Enforces `bun run test` over `bun test` (the latter uses the Bun test runner instead of Vitest and causes CPU spin) |
 | Auto-format | PostToolUse on Edit/Write | Reads `build.formatter_fix_cmd` (single) or `build.formatters[]` (multi, for mixed JS+Python monorepos) from `stack.yml` and runs the right formatter per file extension. Silent no-op when unconfigured. |
 
-## External Dependencies
+## Optional companion plugins
 
-Some agents reference skills from other plugins:
+Agent definitions no longer preload external skills in frontmatter. Invoke companion capabilities on demand via slash commands or the `Skill` tool when installed:
 
-- `frontend-design` (from `frontend-design` plugin)
-- `ui-ux-pro-max` (from `ui-ux-pro-max` plugin)
-- `context7-plugin:docs` (from `context7-plugin`)
+- `ui-ux-pro-max` (from `ui-ux-pro-max` plugin) — frontend polish
+- `context7-plugin:docs` (from `context7-plugin`) — upstream library docs lookup
 
-Install those separately if needed. The core workflow functions without them.
+The core workflow functions without them.
 
 ## License
 

--- a/plugins/dev-core/agents/architect.md
+++ b/plugins/dev-core/agents/architect.md
@@ -15,7 +15,6 @@ permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=true, write_code=false, review_code=true, run_tests=false
 # based-on: shared/base
-skills: adr, context7-plugin:docs
 ---
 
 # Architect

--- a/plugins/dev-core/agents/axial-adr-create.md
+++ b/plugins/dev-core/agents/axial-adr-create.md
@@ -24,7 +24,6 @@ permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false
 # based-on: shared/base
-skills: adr
 ---
 
 # Axial ADR — Create

--- a/plugins/dev-core/agents/backend-dev.md
+++ b/plugins/dev-core/agents/backend-dev.md
@@ -15,7 +15,6 @@ permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true
 # based-on: shared/engineer
-skills: context7-plugin:docs
 ---
 
 # Backend Dev

--- a/plugins/dev-core/agents/devops.md
+++ b/plugins/dev-core/agents/devops.md
@@ -15,7 +15,6 @@ permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=false, run_tests=true
 # based-on: shared/base
-skills: context7-plugin:docs
 ---
 
 # DevOps

--- a/plugins/dev-core/agents/doc-writer.md
+++ b/plugins/dev-core/agents/doc-writer.md
@@ -15,7 +15,6 @@ permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false
 # based-on: shared/base
-skills: context7-plugin:docs
 ---
 
 # Doc Writer

--- a/plugins/dev-core/agents/fixer.md
+++ b/plugins/dev-core/agents/fixer.md
@@ -15,7 +15,6 @@ permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true
 # based-on: shared/base
-skills: fix
 ---
 
 # Fixer

--- a/plugins/dev-core/agents/frontend-dev.md
+++ b/plugins/dev-core/agents/frontend-dev.md
@@ -15,7 +15,6 @@ permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true
 # based-on: shared/engineer
-skills: frontend-design, ui-ux-pro-max, context7-plugin:docs
 ---
 
 # Frontend Dev

--- a/plugins/dev-core/agents/product-lead.md
+++ b/plugins/dev-core/agents/product-lead.md
@@ -16,7 +16,6 @@ permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false
 # based-on: shared/base
-skills: interview, issue-triage, issues, 1b1
 ---
 
 # Product Lead
@@ -33,11 +32,10 @@ Owns vision; drives idea→spec pipeline; manages backlog; writes `α/` + `ρ/`.
 
 ## Role
 
-Drive /dev pipeline (frame→spec→plan→implement→PR) | Gather reqs via interviews | Write stories + criteria in `α/` + `ρ/` | Triage issues (Size/Priority via `/issue-triage`) | Manage parent/child + blocked-by deps | 1b1 walkthrough | Verify deployed features
+Drive /dev pipeline (frame→spec→plan→implement→PR) | Gather reqs via interviews | Write stories + criteria in `α/` + `ρ/` | Triage issues (Size/Priority via `/issue-triage`) | Manage parent/child + blocked-by deps | Verify deployed features
 
 **Interview:** Context (trigger? state?) → Scope (users? in/out?) → Depth (edges, failures, trade-offs) → Validate (summarize + confirm)
 **Triage:** Size: XS(<1h) S(<4h) M(1–2d) L(3–5d) XL(>1w) | Priority: P0(urgent) P1(high) P2(medium) P3(low)
-**1b1:** `/1b1` during review cycles — walk each finding, record accept/reject/defer.
 
 ## Boundaries
 

--- a/plugins/dev-core/agents/security-auditor.md
+++ b/plugins/dev-core/agents/security-auditor.md
@@ -15,7 +15,6 @@ permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false
 # based-on: shared/base
-disallowedTools: ["Write", "Edit"]
 ---
 
 # Security Auditor

--- a/plugins/dev-core/agents/tester.md
+++ b/plugins/dev-core/agents/tester.md
@@ -15,7 +15,6 @@ permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=false, run_tests=true
 # based-on: shared/base
-skills: test
 ---
 
 # Tester

--- a/plugins/dev-core/references/team-coordination.md
+++ b/plugins/dev-core/references/team-coordination.md
@@ -114,5 +114,5 @@ When `/plan` generates μ, α receive structured work units via TaskCreate.
 - `permissionMode` (bypassPermissions | plan)
 - `maxTurns` (30–50)
 - `memory: project` (.claude/agent-memory/)
-- `skills` (preloaded)
-- `disallowedTools` (deny list)
+
+Tool access uses harness defaults unless a project override sets `tools` or `disallowedTools` explicitly.


### PR DESCRIPTION
## Summary

- Remove `skills:`, `tools:`, and `disallowedTools:` from all 12 dev-core agent definitions
- Strip `1b1` walkthrough from `product-lead` role copy (frontmatter + body)

Harnesses now rely on default toolsets instead of optional plugin preloads (context7, frontend-design, 1b1, etc.).

## Motivation

- Grok Build was silently dropping agents whose frontmatter referenced missing skills
- PR #323 removed explicit `tools:` lists; leftover `skills:` deps still blocked registration
- Confirmed: `axial-adr-create` loads in Grok after this change

## Test plan

- [x] `grok inspect` — dev-core agents: recall, axial-adr-review, axial-adr-create registered
- [ ] Claude Code — agents spawn via `/code-review`, `/implement` workflows