### PR TITLE
refactor(dev-core): replace SendMessage with orchestrator summary protocol

### DIFF
--- a/plugins/dev-core/agents/architect.md
+++ b/plugins/dev-core/agents/architect.md
@@ -25,7 +25,7 @@ SA undefined → output: "`.claude/stack.yml` not found in context. Add `@.claud
 SD undefined → warn: "standards.dev_process not set in stack.yml — proceeding without dev process standards." and continue.
 SC undefined → warn: "standards.contributing not set in stack.yml — proceeding without contributing standards." and continue.
 
-**Communication:** use SendMessage to reach teammates (¬plain text). ¬block on uncertainty — message and continue.
+**Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
 
 System architect. Cross-cutting design + architectural consistency. **Standards:** SA | SD | SC

--- a/plugins/dev-core/agents/architect.md
+++ b/plugins/dev-core/agents/architect.md
@@ -26,7 +26,7 @@ SD undefined → warn: "standards.dev_process not set in stack.yml — proceedin
 SC undefined → warn: "standards.contributing not set in stack.yml — proceeding without contributing standards." and continue.
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
-**Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
+**Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).
 
 System architect. Cross-cutting design + architectural consistency. **Standards:** SA | SD | SC
 

--- a/plugins/dev-core/agents/backend-dev.md
+++ b/plugins/dev-core/agents/backend-dev.md
@@ -24,7 +24,7 @@ Let: C := confidence score (0–100) | BP := `{backend.path}` | SB := `{standard
 BP undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
-**Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
+**Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).
 **Quality gates:** after implementation: `{commands.lint}` → `{commands.typecheck}` → `{commands.test}` (skip empty). ✗ → fix before reporting done. Config failures → message devops.
 
 **Domain:** BP`/` | `{shared.types}/` (shared TS types)

--- a/plugins/dev-core/agents/backend-dev.md
+++ b/plugins/dev-core/agents/backend-dev.md
@@ -23,7 +23,7 @@ Let: C := confidence score (0–100) | BP := `{backend.path}` | SB := `{standard
 
 BP undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
-**Communication:** use SendMessage to reach teammates (¬plain text). ¬block on uncertainty — message and continue.
+**Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
 **Quality gates:** after implementation: `{commands.lint}` → `{commands.typecheck}` → `{commands.test}` (skip empty). ✗ → fix before reporting done. Config failures → message devops.
 

--- a/plugins/dev-core/agents/devops.md
+++ b/plugins/dev-core/agents/devops.md
@@ -24,7 +24,7 @@ Let: C := confidence score (0–100) | PM := `{package_manager}` | BO := `{build
 PM undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
-**Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
+**Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).
 **Quality gates:** after config changes: `{commands.build}` (if defined). ✗ → fix before reporting done. App behaviour change → notify domain agent.
 
 **Domain:** `{shared.config}/` | Root configs (`package.json`, `{build.orchestrator_config}`, `{build.formatter_config}`, `tsconfig.json`, `docker-compose.yml`) | `.github/` | `Dockerfile`, `.dockerignore`, `.env.example`

--- a/plugins/dev-core/agents/devops.md
+++ b/plugins/dev-core/agents/devops.md
@@ -23,7 +23,7 @@ Let: C := confidence score (0–100) | PM := `{package_manager}` | BO := `{build
 
 PM undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
-**Communication:** use SendMessage to reach teammates (¬plain text). ¬block on uncertainty — message and continue.
+**Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
 **Quality gates:** after config changes: `{commands.build}` (if defined). ✗ → fix before reporting done. App behaviour change → notify domain agent.
 

--- a/plugins/dev-core/agents/doc-writer.md
+++ b/plugins/dev-core/agents/doc-writer.md
@@ -23,7 +23,7 @@ Let: DP := `{docs.path}` | DF := `{docs.framework}` | FMT := `{docs.format}` | S
 
 DP undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
-**Communication:** use SendMessage to reach teammates (¬plain text). ¬block on uncertainty — message and continue.
+**Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
 
 **Domain:** DP`/` | `CLAUDE.md` | Nav files (DF nav, e.g. `meta.json` for Fumadocs)

--- a/plugins/dev-core/agents/doc-writer.md
+++ b/plugins/dev-core/agents/doc-writer.md
@@ -24,7 +24,7 @@ Let: DP := `{docs.path}` | DF := `{docs.framework}` | FMT := `{docs.format}` | S
 DP undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
-**Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
+**Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).
 
 **Domain:** DP`/` | `CLAUDE.md` | Nav files (DF nav, e.g. `meta.json` for Fumadocs)
 

--- a/plugins/dev-core/agents/fixer.md
+++ b/plugins/dev-core/agents/fixer.md
@@ -24,7 +24,7 @@ Let: φ := finding | Φ := finding set | C := confidence (0–100) | ST := `{sha
 `{commands.lint}` undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
-**Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
+**Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).
 **Quality gates:** after all fixes: `{commands.lint}` → `{commands.typecheck}` → `{commands.test}` (skip empty). ✗ → fix before reporting done. Config failures → message devops.
 
 Apply accepted review comments. ¬new features, ¬over-refactoring.

--- a/plugins/dev-core/agents/fixer.md
+++ b/plugins/dev-core/agents/fixer.md
@@ -23,7 +23,7 @@ Let: φ := finding | Φ := finding set | C := confidence (0–100) | ST := `{sha
 
 `{commands.lint}` undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
-**Communication:** use SendMessage to reach teammates (¬plain text). ¬block on uncertainty — message and continue.
+**Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
 **Quality gates:** after all fixes: `{commands.lint}` → `{commands.typecheck}` → `{commands.test}` (skip empty). ✗ → fix before reporting done. Config failures → message devops.
 

--- a/plugins/dev-core/agents/frontend-dev.md
+++ b/plugins/dev-core/agents/frontend-dev.md
@@ -23,7 +23,7 @@ Let: C := confidence (0–100) | β := `{frontend.path}` | μ := `{frontend.ui_s
 
 β undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
-**Communication:** SendMessage for teammates (¬plain text). ¬block on uncertainty — message + continue.
+**Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
 **Quality gates:** `{commands.lint}` → `{commands.typecheck}` → `{commands.test}` (skip empty). ✗ → fix before done. Config failures → message devops.
 

--- a/plugins/dev-core/agents/frontend-dev.md
+++ b/plugins/dev-core/agents/frontend-dev.md
@@ -24,7 +24,7 @@ Let: C := confidence (0–100) | β := `{frontend.path}` | μ := `{frontend.ui_s
 β undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
-**Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
+**Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).
 **Quality gates:** `{commands.lint}` → `{commands.typecheck}` → `{commands.test}` (skip empty). ✗ → fix before done. Config failures → message devops.
 
 **Domain:** `β/` | `{shared.ui}/` | **Standards:** MUST read `{standards.frontend}` + `{standards.testing}`. Scan `μ/index.ts` for exported primitives — prefer over hand-rolled, customize via `className`.

--- a/plugins/dev-core/agents/product-lead.md
+++ b/plugins/dev-core/agents/product-lead.md
@@ -24,7 +24,7 @@ Let: C := confidence (0–100) | α := `{artifacts.analyses}` | ρ := `{artifact
 
 α undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
-**Communication:** SendMessage for teammates (¬plain text). ¬block on uncertainty — message + continue.
+**Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
 
 Owns vision; drives idea→spec pipeline; manages backlog; writes `α/` + `ρ/`.

--- a/plugins/dev-core/agents/product-lead.md
+++ b/plugins/dev-core/agents/product-lead.md
@@ -25,7 +25,7 @@ Let: C := confidence (0–100) | α := `{artifacts.analyses}` | ρ := `{artifact
 α undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
-**Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
+**Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).
 
 Owns vision; drives idea→spec pipeline; manages backlog; writes `α/` + `ρ/`.
 **Standards:** `{standards.issue_management}` + relevant spec/issue + existing `α/`.

--- a/plugins/dev-core/agents/security-auditor.md
+++ b/plugins/dev-core/agents/security-auditor.md
@@ -24,7 +24,7 @@ Let: C := confidence (0–100) | φ := finding | Φ := finding set | E := exclus
 π undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
-**Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
+**Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).
 
 Identify exploitable vulnerabilities — ¬fix code. Report only φ w/ concrete attack paths. Critical φ → flag for team lead in summary immediately.
 

--- a/plugins/dev-core/agents/security-auditor.md
+++ b/plugins/dev-core/agents/security-auditor.md
@@ -23,10 +23,10 @@ Let: C := confidence (0–100) | φ := finding | Φ := finding set | E := exclus
 
 π undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
-**Communication:** SendMessage for teammates (¬plain text). ¬block on uncertainty — message + continue.
+**Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
 
-Identify exploitable vulnerabilities — ¬fix code. Report only φ w/ concrete attack paths. Critical φ → SendMessage team lead immediately.
+Identify exploitable vulnerabilities — ¬fix code. Report only φ w/ concrete attack paths. Critical φ → flag for team lead in summary immediately.
 
 ## Severity Definitions
 
@@ -132,7 +132,7 @@ O_audit {
   2. Deps: `π audit` ∨ `npm audit` — parse JSON for HIGH/CRITICAL CVEs;
   3. Analyze: ∀ file ∈ scope: check all 10 OWASP categories — report φ only w/ concrete exploit;
   4. Filter: drop φ ∈ E; drop φ where C < 60;
-  5. Report: group by σ (Critical→High→Medium→Low); Critical φ → SendMessage team lead immediately
+  5. Report: group by σ (Critical→High→Medium→Low); Critical φ → flag for team lead in summary immediately
 } → Φ
 
 ## Boundaries
@@ -153,6 +153,6 @@ Scoped file list → focus those first. φ implicates unscoped dep → include, 
 ## Escalation
 
 - C < 70% on σ → default higher, note uncertainty (¬silent drop)
-- Critical/High φ → SendMessage team lead immediately (¬wait for report)
+- Critical/High φ → flag for team lead in summary immediately (¬wait for full report)
 - φ needs runtime verification → note "suspected — needs runtime testing", message devops
 - Dep CVE w/ ∄ fix → report to team lead + document in findings

--- a/plugins/dev-core/agents/tester.md
+++ b/plugins/dev-core/agents/tester.md
@@ -23,7 +23,7 @@ Let: C := confidence (0–100) | ς := `{standards.testing}`
 
 ς undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
-**Communication:** SendMessage for teammates (¬plain text). ¬block on uncertainty — message + continue.
+**Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
 **Quality gates:** `{commands.lint}` → `{commands.typecheck}` → `{commands.test}` (skip empty). ✗ → fix before done. Config failures → message devops.
 

--- a/plugins/dev-core/agents/tester.md
+++ b/plugins/dev-core/agents/tester.md
@@ -24,7 +24,7 @@ Let: C := confidence (0–100) | ς := `{standards.testing}`
 ς undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
-**Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
+**Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).
 **Quality gates:** `{commands.lint}` → `{commands.typecheck}` → `{commands.test}` (skip empty). ✗ → fix before done. Config failures → message devops.
 
 Generate + maintain + validate tests. Testing Trophy: integration = largest layer.

--- a/plugins/dev-core/references/project-overrides.md
+++ b/plugins/dev-core/references/project-overrides.md
@@ -35,7 +35,7 @@ name: backend-dev
 # based-on: dev-core/backend-dev     # traceability — shows which plugin version this overrides
 model: sonnet
 color: white
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList", "SendMessage"]
+tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList"]
 permissionMode: bypassPermissions   # ⚠ removes all confirmation dialogs — review before use
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true
@@ -43,7 +43,7 @@ maxTurns: 50
 
 # Backend Dev (project override)
 
-**Communication:** use SendMessage to reach teammates (¬plain text). ¬block on uncertainty — message and continue.
+**Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
 **Quality gates:** after implementation run `{commands.lint} && {commands.typecheck} && {commands.test}`. ✗ → fix before reporting done. Config failures → message devops.
 

--- a/plugins/dev-core/references/project-overrides.md
+++ b/plugins/dev-core/references/project-overrides.md
@@ -44,7 +44,7 @@ maxTurns: 50
 # Backend Dev (project override)
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
-**Research order:** codebase (Glob/Grep/Read) → context7 → WebSearch (last resort).
+**Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).
 **Quality gates:** after implementation run `{commands.lint} && {commands.typecheck} && {commands.test}`. ✗ → fix before reporting done. Config failures → message devops.
 
 If `{backend.path}` is undefined → output: "`.claude/stack.yml` not found."

--- a/plugins/dev-core/references/team-coordination.md
+++ b/plugins/dev-core/references/team-coordination.md
@@ -101,7 +101,7 @@ When `/plan` generates μ, α receive structured work units via TaskCreate.
 
 ## Communication
 
-"Message the lead" = `SendMessage` w/ concise status, key info upfront.
+"Message the lead" = concise status in final summary to the parent orchestrator, key info upfront.
 
 - Blocker → lead
 - Cross-domain → create task + message lead

--- a/plugins/dev-core/skills/shared/references/base.md
+++ b/plugins/dev-core/skills/shared/references/base.md
@@ -4,8 +4,8 @@ Universal rules inherited by all dev-core agents.
 
 ## Communication
 
-Always use SendMessage to reach teammates. ¬plain text — teammates cannot see output-only responses.
-¬block on uncertainty — message and continue on unblocked work where possible.
+Report status, blockers, and handoffs in your final summary to the parent orchestrator — include key info explicitly.
+¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 
 ## Research Order
 

--- a/plugins/dev-core/skills/shared/references/base.md
+++ b/plugins/dev-core/skills/shared/references/base.md
@@ -9,7 +9,7 @@ Report status, blockers, and handoffs in your final summary to the parent orches
 
 ## Research Order
 
-codebase (Glob/Grep/Read) → context7 docs (`context7-plugin:docs`) → WebSearch (last resort, ¬for internal project questions)
+codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions)
 
 ## Notation
 


### PR DESCRIPTION
## Summary

Follow-up to #325 (merged). Removes all `SendMessage` references from dev-core agents and shared protocols so Grok Build can register domain subagents.

- 9 agents: Communication line → report via final summary to parent orchestrator
- `security-auditor`: escalation wording updated
- `base.md`, `team-coordination.md`, `project-overrides.md` aligned

## Test plan

- [x] `rg SendMessage plugins/dev-core` → no matches
- [ ] `grok inspect` — all 12 dev-core agents registered