### PR TITLE
fix(dev-core): drop agent color frontmatter for Grok compatibility

### DIFF
--- a/plugins/dev-core/agents/architect.md
+++ b/plugins/dev-core/agents/architect.md
@@ -10,7 +10,6 @@ description: |
   user: "Design the caching strategy for the API"
   assistant: "I'll use the architect agent to design the architecture."
   </example>
-color: white
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=true, write_code=false, review_code=true, run_tests=false

--- a/plugins/dev-core/agents/axial-adr-create.md
+++ b/plugins/dev-core/agents/axial-adr-create.md
@@ -19,7 +19,6 @@ description: |
   user: "Re-elicit the axial decomposition"
   assistant: "Running axial-adr-create. Will offer Keep / Supersede / Review if an ADR already exists."
   </example>
-color: yellow
 permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false

--- a/plugins/dev-core/agents/axial-adr-review.md
+++ b/plugins/dev-core/agents/axial-adr-review.md
@@ -19,7 +19,6 @@ description: |
   user: "/spec --issue 88"
   assistant: "Including axial-adr-review among spec reviewers to flag drift along non-primary axis."
   </example>
-color: yellow
 permissionMode: bypassPermissions
 maxTurns: 20
 # capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false

--- a/plugins/dev-core/agents/backend-dev.md
+++ b/plugins/dev-core/agents/backend-dev.md
@@ -10,7 +10,6 @@ description: |
   assistant: "I'll use the backend-dev agent to implement the API."
   </example>
 model: sonnet
-color: white
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true

--- a/plugins/dev-core/agents/devops.md
+++ b/plugins/dev-core/agents/devops.md
@@ -10,7 +10,6 @@ description: |
   assistant: "I'll use the devops agent to debug the CI pipeline."
   </example>
 model: sonnet
-color: white
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=false, run_tests=true

--- a/plugins/dev-core/agents/doc-writer.md
+++ b/plugins/dev-core/agents/doc-writer.md
@@ -10,7 +10,6 @@ description: |
   assistant: "I'll use the doc-writer agent to create the documentation."
   </example>
 model: haiku
-color: white
 permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false

--- a/plugins/dev-core/agents/fixer.md
+++ b/plugins/dev-core/agents/fixer.md
@@ -10,7 +10,6 @@ description: |
   assistant: "I'll use the fixer agent to apply the fixes across the stack."
   </example>
 model: sonnet
-color: white
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true

--- a/plugins/dev-core/agents/frontend-dev.md
+++ b/plugins/dev-core/agents/frontend-dev.md
@@ -10,7 +10,6 @@ description: |
   assistant: "I'll use the frontend-dev agent to implement the UI."
   </example>
 model: sonnet
-color: white
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true

--- a/plugins/dev-core/agents/product-lead.md
+++ b/plugins/dev-core/agents/product-lead.md
@@ -11,7 +11,6 @@ description: |
   user: "Gather requirements for the notification system"
   assistant: "I'll use the product-lead agent to define requirements."
   </example>
-color: white
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false

--- a/plugins/dev-core/agents/recall.md
+++ b/plugins/dev-core/agents/recall.md
@@ -11,7 +11,6 @@ description: |
   orchestrator: "Spawn recall agent for parallel-path-drift"
   assistant: "I'll use the recall agent to confirm scope and find un-cited callsites."
   </example>
-color: purple
 permissionMode: bypassPermissions
 maxTurns: 20
 # capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false

--- a/plugins/dev-core/agents/security-auditor.md
+++ b/plugins/dev-core/agents/security-auditor.md
@@ -10,7 +10,6 @@ description: |
   user: "Audit the authentication module for vulnerabilities"
   assistant: "I'll use the security-auditor agent to perform a security audit."
   </example>
-color: white
 permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false

--- a/plugins/dev-core/agents/tester.md
+++ b/plugins/dev-core/agents/tester.md
@@ -10,7 +10,6 @@ description: |
   assistant: "I'll use the tester agent to generate test coverage."
   </example>
 model: sonnet
-color: white
 permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=false, run_tests=true

--- a/plugins/dev-core/references/project-overrides.md
+++ b/plugins/dev-core/references/project-overrides.md
@@ -34,7 +34,6 @@ Start from plugin α as base. Keep what works, add project-specific:
 name: backend-dev
 # based-on: dev-core/backend-dev     # traceability — shows which plugin version this overrides
 model: sonnet
-color: white
 tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList"]
 permissionMode: bypassPermissions   # ⚠ removes all confirmation dialogs — review before use
 maxTurns: 50


### PR DESCRIPTION
## Summary

Grok Build silently drops plugin agents when frontmatter `color` is invalid (e.g. `white`). Removing the `color` field entirely lets all 12 dev-core agents load in `grok inspect`.

## Changes

- Remove `color:` from all 12 `plugins/dev-core/agents/*.md`
- Remove `color: white` from the override template in `project-overrides.md`

## Verification

```
grok inspect --json → 12 dev-core agents (was 3)
```

No behavior change in Claude Code — `color` is cosmetic only.