### PR TITLE
feat(compress): canonical notation glossary + fidelity guardrails

### DIFF
--- a/artifacts/frames/310-notation-glossary-guardrails-frame.mdx
+++ b/artifacts/frames/310-notation-glossary-guardrails-frame.mdx
@@ -1,0 +1,69 @@
+---
+title: 'compress v2 train B — canonical notation glossary + reserved-var registry + fidelity guardrails'
+issue: 310
+status: approved
+tier: F-lite
+date: 2026-07-04
+---
+
+## Problem
+
+The repo's symbolic notation has no canon, and the compress skill's fidelity model contradicts the measured evidence (issue #310 "Problem"; analysis §2.1–2.3):
+
+- **Three conflicting legends** (four, counting the discovered dev-init fork — see Decisions): compress `references/compress.md` Symbols line (`→` then, `↦` maps-to — moved from SKILL.md:21 by train A), dev-core `base.md:16` (`→` then/maps-to), `doc-writer.md:51` (`⇒` implies, `→` maps to). A compressor cannot collision-check against a canon that does not exist.
+- **Measured Greek collisions**: σ ∈ {spec, stack.yml, Spec doc-type, staging} (4-way); τ = tier/target-file/doc-type; π = plan/test-file; Σ = state-map/standards-test; Ω = override-file (dominant) vs skill-invocation (1).
+- **R1's own example violates house bindings**: `φ:=findings` vs φ=frame, `τ:=80` vs τ=tier, `γ(f)` vs `C(f)`.
+- **The flat `¬compress` list is the wrong fidelity model**: Tencent (arXiv 2604.07192, Cliff's δ<0.01) — encoding form has no detectable compliance effect; **polarity** governs (36/47 failures = default bias); the house style is `¬`-saturated.
+- **The economic premise is false**: most glyphs cost 2–3 BPE tokens; `∀ x ∈ Y:` = `for each x in Y:` = 6 tokens; ⟺/⇔ flips between tokenizers; real savings = prose pruning (R5/R6/R7).
+- **Notation without gloss is reader-hostile**: MetaGlyph — `→` read 0% as transformation, `∈` 26%; LILO — NL gloss is load-bearing.
+
+This issue = P1 + P6 of the adversarially-verified analysis; train B of epic #308, unblocks C.
+
+## Who
+
+- **Primary:** compress users (fidelity guardrails G1–G4 shape every output) and dev-core/skill authors (notation.md becomes the vocabulary SSoT their legends point to).
+- **Secondary:** trains C–E — #311's read-back verifies gloss compliance, #312 lints against the glossary, #313's R12 emits glossary-compliant abstractions; roxabi-cortex vocabulary-governance mechanics (closed enum, human-gated extension — no ADR-009 fulfillment claim).
+
+## Constraints
+
+- **Same-PR coordination**: repointing `base.md` + `doc-writer.md` legends = dev-core `skills/`-adjacent change → `plugins/dev-core/.claude-plugin/plugin.json` semver bump in the same PR (pre-push `check-skill-version` gates it; verified: dev-core is versioned, currently 0.8.13 in-repo). base.md is churning on staging → rebase early and often (descope-under-churn memory).
+- **Marketplace self-containment**: SKILL.md inline whitelist is canonical; the notation.md pointer is an optional enrichment behind an existence test — compress must work with `plugins/shared/` absent; no `~/projects/ssot/*` paths; ssot corpus = out-of-corpus evidence only.
+- **DP drift adaptation (standing, epic #308)**: glyph-conflict adjudications are measured-count decisions made autonomously with the counts + outcome + rationale recorded in notation.md; other decision points use the inline present-choice idiom.
+- **Evidence discipline**: registry seeded from grep with recorded counts (never memory); no hardcoded token tiers; no tokenizer-relative winner encoded as a timeless rule; no per-glyph token-cost column (one-shot measured appendix with method+model+date, or nothing).
+- **G1**: rewrite `¬use Y` → `use Z (¬Y)` only when concrete Z exists; never invent Z; no-alternative → 4-field flag schema `{constraint | polarity | alternative-exists | verification-method}` in Phase 4; vault persistence optional (no P2 ledger dependency).
+- **Phase 0 load budget**: only the ~150-line core loads in compress mode; grammar + maintenance sections load only in glossary (and future lint) modes.
+- **Validator self-protection in the same PR**: `--check notation-legends` — (a) base.md + doc-writer.md legends are one-line pointers, (b) SKILL.md inline whitelist ≡ glossary core table (set-equality; precedent: shared-sources-sync).
+- **SKILL.md stays ≤110 lines** (train A's gate now enforces it — G1–G4 + whitelist + break-even inequality must fit or push detail to references/).
+- Edit repo source only; no `--force`/`--hard`/`--amend`; stage specific files only.
+
+## Out of Scope
+
+- **dev-init's `base.md:16` legend** (discovered fork, identical line, not named by the issue) — repointing it would touch a second versioned plugin and widen the churn surface; recorded as a follow-up (see Decisions). The notation-legends check gates exactly the two files the issue names.
+- Lint mode body (#312) — every lint mention in compress text must be fully specified or absent.
+- Read-back verification, levels, provenance markers (#311); derive (#313).
+- Corpus-wide notation migration (deferred to #312 lint mode).
+- ADR-009 fulfillment claims (mechanics only).
+
+## Decisions
+
+1. **dev-init base.md** stays untouched this PR (descope-under-churn: separate versioned plugin, issue enumerates its targets exhaustively); a follow-up issue will be filed at PR time to repoint it and extend the notation-legends whitelist gate to it.
+2. **Glyph adjudications** (⇒/→, ⟺/⇔) resolved from fresh grep counts at implement time; expected from analysis-time evidence: retain `⟺` (×7 plugin files vs ⇔ ×0 in plugins/), retain `⇒` as sanctioned implies/contrastive register (×33 across 8 files; live legend doc-writer.md:51; dev:45 contrastive use) — `⇒` is NOT drift. Counts + outcome + rationale land in notation.md.
+3. **doc-writer legend line number drift** (:54 → :51 after agent-frontmatter commits) — content intact; cite current lines.
+
+## Premise Validity
+
+**Success in 6 months:** One canonical `notation.md` exists; both named legend surfaces are one-line pointers gated by `--check notation-legends`; compress Phase 3 collision-checks every new Let var against a grep-seeded registry; G1–G4 govern outputs (no bare non-whitelist symbols; polarity flags emitted with the 4-field schema); trains C and D consume the glossary and evidence.md as inputs.
+
+**Failure in 6 months:** By 2027-01: the notation-legends check has been reverted/disabled, or a corpus scan (via #312's lint or plain grep) finds new non-pointer legend lines in the gated files, or compress outputs post-merge still emit bare non-whitelist symbols (G3 violations > 0 in sampled outputs), or the registry is never consulted (zero collision-check evidence in any later train's runs) — the glossary was shelf-ware and the SSoT premise is indicted.
+
+**Simplest alternative:** Fix only compress's own legend and R1 example in place; leave base.md/doc-writer.md alone; skip the registry and G-rules.
+**Why not simplest:** The three conflicting legends remain (the core problem is cross-file, not intra-file); collision-checking is impossible without a canon + registry; train C's read-back needs G3's gloss mandate to test, and train D's lint needs the glossary as its reference — both would be blocked or built on sand; the polarity evidence (Tencent) would remain unencoded exactly where compliance failures originate.
+
+## Complexity
+
+**Tier: F-lite** — label `size:F-lite`; clear scope, two coordinated surfaces (compress + dev-core legend pointers), no unknowns (all design decisions pre-baked by the adversarially-verified analysis).
+
+Signals observed:
+- Issue label `size:F-lite` → F-lite (direct mapping).
+- Coordination cost named and bounded (dev-core bump; churn memory applies).
+- χ target = 0 — every open question is answered in the issue body.

--- a/artifacts/plans/310-notation-glossary-guardrails-plan.mdx
+++ b/artifacts/plans/310-notation-glossary-guardrails-plan.mdx
@@ -1,155 +1,200 @@
 ---
-title: 'Plan: compress v2 train B — slice V1 (P6 guardrails standalone)'
+title: 'Plan: compress v2 train B — slice V2 (P1 glossary SSoT + gates)'
 issue: 310
 spec: artifacts/specs/310-notation-glossary-guardrails-spec.mdx
-complexity: 5/10
+complexity: 6/10
 tier: F-lite
-slice: V1 of 2
+slice: V2 of 2 (V1 implemented: commit 834ad1b)
 generated: 2026-07-04
 ---
 
 ## Summary
 
-Slice V1 (P6): replace compress's flat `¬compress` list with guardrails G1–G4 + canonical inline whitelist + R1 demotion and break-even inequality, wire the existence-gated glossary paths (glossary absent in V1 — the standalone proof), pin the evidence in `references/evidence.md`, all within the ≤110-line budget via the Decision-10 displacement plan.
+Slice V2 (P1): author `plugins/shared/references/notation.md` (core table + grammar + maintenance + grep-seeded registry + adjudications), ship the `glossary` mode body, repoint the two dev-core legends (one-line pointers) with the dev-core semver bump, and land `--check notation-legends` (pointer gate + whitelist↔core-table set-equality) with pytest coverage — closing the loop V1's existence-gated wiring left open.
 
 ## Architecture
 
 **Data flow:** [notation pipeline](../visuals/310-notation-glossary-guardrails-data-flow.html)
 **File map:** [files × sections](../visuals/310-notation-glossary-guardrails-file-map.html)
 
-(Sidecars cover both slices; generated during this V1 plan run.)
+(Sidecars from the V1 plan run cover both slices — unchanged.)
 
 ## Bootstrap Context
 
-- Binding spec decisions: D9 format contracts (Whitelist anchor line, glyph domain excl. reserved vars), D10 displacement (append template + mode-specific edge rows → `references/compress.md`; G1–G4 stay in SKILL.md — cross-mode), D11 standalone Phase-3 degradation (whitelist glyph domain only, documented).
-- Current SKILL.md = 106 lines (train A v2 + fix); budget 110; est. +14–16 added by G-rules/whitelist/inequality/wiring ⇒ displace ~10–12 (D10 targets: the Phase 5 append command block SKILL.md:78-85, and ONLY the mode-specific Edge Cases row :93 "Mode-specific (…) | Per ref(μ)" — rows :91-92 "Agent (¬skill)" and "User rejects at Phase 4" are cross-mode and STAY).
-- `references/compress.md` currently holds the Symbols legend (:5-7) + R1–R10 (:13-30) + `¬compress` line (:32) + mode edge cases (:34-40) + measured rationale (:42-51). The `¬compress` line is superseded by G1–G4 → replace with a one-line pointer to SKILL.md's G-rules; keep mode-specific behaviors.
-- Whitelist seed = union of glyphs in `references/compress.md:7` legend (fresh grep at implement; expected ~20 tokens incl. `:=`, `|X|`, `↦`, `⟺`).
-- G4 citation form: `(evidence: references/evidence.md — Tencent 2604.07192)` inline.
-- Quality bar: dev-core maintainer idiom; G-rules compact (≤2 lines each + shared intro).
+- V1 delivered (834ad1b): SKILL.md 109/110 w/ `Whitelist:` anchor (22 backtick spans), G1–G4, existence-gated Phase 0/3/5 wiring; evidence.md; compress.md updates.
+- Binding spec Decisions: **D9** (core-table `## Core Table` anchor → next `##`; 5-col schema `| glyph | senses | gloss? | fidelity ⚠ | notes/adjudication |`; column-1 backtick extraction; separator-row skip; whitelist anchor; equality domain = operator glyphs only, active rows only; exit tiers: missing file → message contains `not found at` (exit 2), drift → exit 1; non-empty guard; pointer example line; registry schema `| var | binding(s) | grep counts | status |`; → senses from classified fresh grep samples; adjudication record format; writer-side disclaimer verbatim), **D4** (⟺/⇒ expected retained — fresh counts decide), **D6** (dev-core 0.8.13→0.8.14).
+- **Set-equality invariant**: notation.md core table active rows must contain exactly the 22 whitelist glyphs of SKILL.md's `Whitelist:` line (`∀ ∃ ∄ ∈ ∉ ∧ ∨ ¬ → ⟺ ∅ ∩ ∪ ⊂ ∥ |X| := ← { } ; () ↦` — read the real line first). Glyphs beyond the whitelist (e.g. `⇒` retained by adjudication) must ALSO enter the whitelist in the same slice or live outside the core table's active rows — resolve by: add `⇒` (and any other adjudicated-active glyph) to BOTH sides, keeping equality. SKILL.md edit for this is in-scope for T9b (1-line change, budget 109→109).
+- Fresh greps to run and record (T7): `⟺` and `⇔` file counts in plugins/; `⇒` count + file spread; `→` sense sampling (~20 samples classified); σ/Ω/α/β/ω/μ/τ/φ/Δ/Σ/π binding counts. Tools: `git grep -c` / `git grep -l` over `plugins/`.
+- Ref patterns: `tools/validate_plugins.py::check_class_list_sync` (anchored-line set parse) + `check_skill_line_budget` (injectable params, registry const); `tests/test_check_skill_line_budget.py` (fixture + subprocess patterns); `tests/test_check_taxonomy_sync.py` (`run_tool('--check', …)`).
+- Pointer target wording (D9): `` Notation legend → canonical glossary: `${CLAUDE_PLUGIN_ROOT}/../shared/references/notation.md` (repo: `plugins/shared/references/notation.md`) `` — adapted to each file's voice; the check greps for a single legend line containing `notation.md`.
+- check-skill-version: bump satisfies the pre-push gate (base.md ∈ plugins/dev-core/skills/**).
 
 ## Agents
 
 | Agent instance | Tasks | Files |
 |----------------|-------|-------|
-| doc-writer-A | T1, T2 | references/evidence.md; SKILL.md + references/compress.md |
-| doc-writer-B | T3 | plugins/compress/README.md |
-| tester-A | T4, T5 | (grep battery + budget sentinel — no new files) |
+| tester-A | T6 | tests/test_check_notation_legends.py |
+| doc-writer-A | T7, T8 | plugins/shared/references/notation.md; plugins/compress/skills/compress/references/glossary.md |
+| doc-writer-B | T9, T9b | plugins/dev-core/skills/shared/references/base.md, plugins/dev-core/agents/doc-writer.md, plugins/dev-core/.claude-plugin/plugin.json; SKILL.md whitelist alignment |
+| devops-A | T10 | tools/validate_plugins.py |
+| tester-B | T11, T12 | (battery + live falsification) |
 
 ## Wave Structure
 
-3 waves, max 2 ∥.
+4 waves, max 2 ∥.
 
 | Wave | Trigger | Agents | Tasks |
 |------|---------|--------|-------|
-| 1 | start | 1 | doc-writer-A: T1 |
-| 2 | T1 done | 2 ∥ | doc-writer-A: T2 · doc-writer-B: T3 |
-| 3 | Wave 2 done | 1 | tester-A: T4→T5 |
+| 1 | start | 2 ∥ | tester-A: T6 · doc-writer-A: T7 |
+| 2 | T7 done | 2 ∥ | doc-writer-A: T8 · doc-writer-B: T9→T9b |
+| 3 | T6+T7+T9b done | 1 | devops-A: T10 |
+| 4 | T10 done | 1 | tester-B: T11→T12 |
 
 ### Budget — per task
 
 | Task | Class | Est. ops | Split? |
 |------|-------|----------|--------|
-| T1 evidence.md | judgmental | 8 | — |
-| T2 SKILL.md G-rules + displacement | judgmental | 18 | — |
-| T3 README sync | trivial | 3 | — |
-| T4 grep battery + standalone demo | bounded | 8 | — |
-| T5 RED-GATE budget sentinel | bounded | 6 | — |
+| T6 RED tests | judgmental | 12 | — |
+| T7 notation.md (greps + authoring) | judgmental | 22 | — |
+| T8 glossary.md | bounded | 8 | — |
+| T9 repointing + bump | bounded | 6 | — |
+| T9b whitelist alignment | trivial | 3 | — |
+| T10 check implementation | judgmental | 14 | — |
+| T11 battery | bounded | 8 | — |
+| T12 RED-GATE live falsification | bounded | 7 | — |
 
-**Total estimated ops: 43**
+**Total estimated ops: 80**
 
 ### Budget — per agent instance
 
 | Instance | Tasks | Σ ops | Subjects | Split? |
 |----------|-------|-------|----------|--------|
-| doc-writer-A | T1, T2 | 26 | evidence, guardrails | — |
-| doc-writer-B | T3 | 3 | docs | — |
-| tester-A | T4, T5 | 14 | sweep, budget-gate | — |
+| tester-A | T6 | 12 | legends-tests | — |
+| doc-writer-A | T7, T8 | 30 | glossary-core, glossary-mode | — |
+| doc-writer-B | T9, T9b | 9 | repointing, whitelist | — |
+| devops-A | T10 | 14 | validator | — |
+| tester-B | T11, T12 | 15 | battery, falsification | — |
 
 ## Consistency Report
 
-- V1-scoped SCs covered: SC10 (T2), SC11 (T2, T4), SC12 (T2, T4), SC13 (T2, T4), SC14 (T1, T2), SC15 (T2, T4), SC16 (T1), SC17 (T2, T4 — standalone demo), SC18 (T4), SC19 (T2), SC21 (T2, T5), SC22 (process, T4 grep). 12/12 V1 criteria → ≥1 task.
-- Exempt (slice V2): SC1–SC9, SC20 (cortex_link lands with glossary.md in V2).
-- Untraced tasks: none.
+- V2-scoped SCs covered: SC1 (T7), SC2 (T7), SC3 (T7), SC4 (T7), SC5 (T7, T11), SC6 (T6, T10, T12), SC7 (T7, T11), SC8 (T7, T11), SC9 (T9, T11), SC20 (T8). 10/10 → ≥1 task.
+- Done in V1 (834ad1b): SC10–SC19, SC21, SC22 (T11 re-verifies SC21's budget + train-A checks stay green post-V2).
+- Untraced tasks: T9b (supports SC6's equality — traced to SC6).
 
 ## Micro-Tasks
 
-### Slice V1 — Wave 1
+### Slice V2 — Wave 1
 
-**T1 — Create references/evidence.md**
-- File: `plugins/compress/skills/compress/references/evidence.md`
-- Agent: doc-writer-A · Subject: evidence · Phase: GREEN · Difficulty: 2 · Est: 8 ops
-- Shape: pinned load-bearing excerpts with IDs, one section per source: Tencent arXiv 2604.07192 (controlled null result, Cliff's δ<0.01; polarity failure taxonomy 36/47 = default bias), MetaGlyph arXiv 2601.07354 (`→` 0% as transformation operator, `∈` 26%, U-curve), LILO ICLR 2024 (NL gloss/AutoDoc load-bearing), GEPA ICLR 2026 (rule derivation by reflection; non-load-bearing credit), pseudo-code ablation note. ≤60 lines; each excerpt ≤3 lines + 1-line "what it licenses" (e.g. G1 ← Tencent; G3 ← MetaGlyph+LILO). No machine-local paths.
-- Verify: `test -f plugins/compress/skills/compress/references/evidence.md && grep -c 'arXiv' plugins/compress/skills/compress/references/evidence.md && grep -q '2604.07192' plugins/compress/skills/compress/references/evidence.md && grep -q '2601.07354' plugins/compress/skills/compress/references/evidence.md && echo ok`
-- Expected: ≥4 arXiv/venue pins; `ok`
-- Spec trace: SC16, SC14
+**T6 — RED tests for check_notation_legends** `[P]`
+- File: `tests/test_check_notation_legends.py`
+- Agent: tester-A · Subject: legends-tests · Phase: RED · Difficulty: 3 · Est: 12 ops
+- Shape: pattern from `tests/test_check_skill_line_budget.py` (`_load_tool()` direct import + `run_tool()` subprocess). Fixtures in tmp_path: (a) gated file with a proper one-line pointer (contains `notation.md`) → no error; (b) gated file with a full legend line (no `notation.md`) → pointer error; (c) gated file missing → error message contains `not found at`; (d) whitelist ≡ core table → no error; (e) whitelist ⊃ core table (extra glyph) → equality error naming the diff both directions; (f) core table ⊃ whitelist → equality error; (g) empty parsed set (whitelist line absent / core table empty) → loud failure; (h) separator row skipped (fixture table with `|---|` row parses clean); (i) subprocess: `run_tool('--check', 'notation-legends')` on shipped tree → exit 0 (will pass only post-T10+T7+T9 — mark order-dependent, run in T11); injectable params `(legend_files=None, skill_path=None, glossary_path=None)`.
+- Verify: `python3 -m pytest tests/test_check_notation_legends.py -x -q`
+- Expected: FAILS (check_notation_legends undefined) — RED evidence recorded.
+- Spec trace: SC6
 
-### Slice V1 — Wave 2
+**T7 — Author notation.md (fresh greps + core + grammar + maintenance + registry)** `[P]`
+- File: `plugins/shared/references/notation.md`
+- Agent: doc-writer-A · Subject: glossary-core · Phase: GREEN · Difficulty: 5 · Est: 22 ops
+- Shape: run the fresh greps (Bootstrap Context list), record counts. **Merge contract (SC1)**: enumerate the 3 source legends by path — `plugins/compress/skills/compress/references/compress.md` `## Symbols` line, `plugins/dev-core/skills/shared/references/base.md:16`, `plugins/dev-core/agents/doc-writer.md:51` — and give EVERY entry of each a recorded disposition ∈ {core-active row, registry entry, adjudicated (cell), deprecated → maintenance section}. Non-whitelist legend entries that must survive the repointing: `≥/≤` threshold, `✓/✗` pass/fail, `S*` next-step variable, `¬do-x` compound-negation idiom, `∅` null, `Σ` state dict, `⇒` implies — none may silently vanish (T9 deletes both source lines). Structure: intro (writer-side disclaimer VERBATIM per D9) → `## Core Table` (5-col schema; active rows = SKILL.md whitelist ∪ adjudicated-active glyphs ∪ surviving legend entries; fidelity-warned glyphs (`→`, `∈`, `∩` per MetaGlyph) flagged mandatory-gloss in `gloss?`; adjudication cells for `⟺` and `⇒` w/ counts+outcome+rationale+date) → `## Disambiguation Grammar` (4 → senses from classified samples w/ counts; ¬ modal registers; separator hierarchy `/`,`,` < `·` < `|` < `;` < newline < heading) → `## Maintenance Policy` (add/deprecate/version; extension human-gated via present-choice; deprecated glyphs listed HERE not in core) → `## Reserved-Variable Registry` (`| var | binding(s) | grep counts | status |`; σ 4-way, Ω dominant/minority, α/β/ω/μ, τ/φ/Δ/Σ/π w/ π+Σ collisions; `(local)` re-binding rule) → aspirational note (Latin/Greek register rule, corpus-scoped, ssot out-of-corpus). NO per-glyph token-cost column (D8). Core table section ≤ ~150 lines. No machine-local paths.
+- Verify: `test -f plugins/shared/references/notation.md && grep -q '^## Core Table' plugins/shared/references/notation.md && grep -q 'writer-side tooling' plugins/shared/references/notation.md && grep -q 'Reserved-Variable Registry' plugins/shared/references/notation.md && grep -qi 'aspirational' plugins/shared/references/notation.md && ! grep -qi 'token cost' plugins/shared/references/notation.md && grep -qF 'S*' plugins/shared/references/notation.md && grep -qF '✓' plugins/shared/references/notation.md && grep -qF '≥' plugins/shared/references/notation.md && grep -qF '¬do-x' plugins/shared/references/notation.md && echo ok`
+- Expected: `ok`; counts recorded in the file
+- Spec trace: SC1, SC2, SC3, SC4, SC5, SC7, SC8
 
-**T2 — SKILL.md guardrails + whitelist + wiring + displacement**
-- Files: `plugins/compress/skills/compress/SKILL.md`, `plugins/compress/skills/compress/references/compress.md`
-- Agent: doc-writer-A · Subject: guardrails · Phase: GREEN · Difficulty: 4 · Est: 18 ops · blockedBy: T1
-- Shape (SKILL.md): replace the Safety-section adjacency with a `## Guardrails` block: G1 polarity (`¬use Y` → `use Z (¬Y)` iff concrete Z; never invent Z; else flag literal **`needs external verification`** + Phase 4 flag block `{constraint | polarity | alternative-exists | verification-method}`, fixed format, vault optional); G2 no-free-coinage (symbols ∈ whitelist; NO hardcoded token tiers anywhere; NO tokenizer-relative glyph rule; token-neutrality principle verbatim: *glyph substitution is token-neutral at best; choose glyphs for register/precision, never for economy; measured savings come from prose pruning*; optional measurement procedure: API count, tokenizer + date); G3 gloss trigger verbatim `(predicate ∨ O-block ∨ Let-bind) ∨ (symbol ∉ whitelist) ∨ (chain > 3 operators)` → `— …` gloss ≤1 line; bare non-whitelist symbols forbidden; G4 verbatim floor (commands, tool names, spawn templates, safety rules) citing evidence.md inline. Add `Whitelist:` anchor line (D9 format; seed from compress.md:7 legend union). Add R1 break-even inequality `(T_phrase − T_var) × occ > T_letline (≈8–10)` + R5/R6/R7 = primary economic transform + "G1/G3 spend tokens to buy compliance". Phase 0 + existence-gated glossary load line (`plugins/shared/references/notation.md` ∃ → load `## Core Table`; ∄ → whitelist only); Phase 3 collision-check line (registry if glossary ∃, else whitelist domain — D11 wording); Phase 5 assert emitted symbols ∈ whitelist/core-table ∨ Let-defined. Displace (D10): Phase 5 append command block → compress.md (Phase 5 keeps a 1-line pointer); mode-specific Edge Cases rows → compress.md. ≤110 lines HARD.
-  (compress.md): receive displaced blocks; replace `¬compress` line :32 with pointer "superseded by SKILL.md G1–G4"; fix the R1 example (registry-clean vars — e.g. `κ(f)` conf, `θ` threshold; NOT φ/τ/γ); keep Symbols legend + measured rationale.
-- Verify: `wc -l < plugins/compress/skills/compress/SKILL.md` ≤110 ∧ `python3 tools/validate_plugins.py | grep 'line budget'` PASS ∧ `grep -q '^Whitelist:' plugins/compress/skills/compress/SKILL.md` ∧ `grep -q 'never for economy' plugins/compress/skills/compress/SKILL.md` ∧ `grep -qF '(predicate ∨ O-block ∨ Let-bind) ∨ (symbol ∉ whitelist) ∨ (chain > 3 operators)' plugins/compress/skills/compress/SKILL.md` ∧ `grep -q 'T_letline' plugins/compress/skills/compress/SKILL.md` ∧ `grep -q 'evidence.md' plugins/compress/skills/compress/SKILL.md` ∧ `! grep -q 'φ.*findings' plugins/compress/skills/compress/references/compress.md` ∧ echo ok
-- Expected: all green; `ok`
-- Spec trace: SC10, SC11, SC12, SC13, SC14, SC15, SC17, SC19, SC21
+### Slice V2 — Wave 2
 
-**T3 — README doc sync** `[P]`
-- File: `plugins/compress/README.md`
-- Agent: doc-writer-B · Subject: docs · Phase: GREEN · Difficulty: 1 · Est: 3 ops · blockedBy: T1
-- Shape: add a short "Fidelity guardrails" paragraph (G1–G4 one-liners) + note the canonical whitelist / optional shared glossary.
-- Verify: `grep -q 'G1' plugins/compress/README.md && grep -qi 'guardrail' plugins/compress/README.md && echo ok`
+**T8 — Glossary mode body**
+- File: `plugins/compress/skills/compress/references/glossary.md`
+- Agent: doc-writer-A · Subject: glossary-mode · Phase: GREEN · Difficulty: 2 · Est: 8 ops · blockedBy: T7
+- Shape: mode body per house reference style (compress.md as template): pipeline for add/deprecate/version glossary entries; loads notation.md grammar + maintenance sections (the lazy halves); extension human-gated (`→ present choice`); collision protocol vs registry; cortex_link one-liner: closed-vocabulary governance mechanics only, no ADR-009 claim, no derivation. Train-A's mode-exists gate now dispatches `/compress glossary` to this body.
+- Verify: `test -f plugins/compress/skills/compress/references/glossary.md && grep -q 'present choice' plugins/compress/skills/compress/references/glossary.md && grep -qi 'mechanics only\|governance mechanics' plugins/compress/skills/compress/references/glossary.md && ! grep -q 'ADR-009' plugins/compress/skills/compress/references/glossary.md && echo ok`
 - Expected: `ok`
-- Spec trace: SC11 (docs), SC17
+- Spec trace: SC20 (+SC1 glossary-mode load path)
 
-### Slice V1 — Wave 3
+**T9 — Legend repointing + dev-core bump** `[P]`
+- Files: `plugins/dev-core/skills/shared/references/base.md`, `plugins/dev-core/agents/doc-writer.md`, `plugins/dev-core/.claude-plugin/plugin.json`
+- Agent: doc-writer-B · Subject: repointing · Phase: GREEN · Difficulty: 2 · Est: 6 ops · blockedBy: T7
+- Shape: base.md:16 legend line → one-line pointer (D9 wording, keep the line's `## Notation`-context voice); doc-writer.md:51 `**Compressed notation:**` line → one-line pointer (keep the **bold-label** voice; line :53's `∃ X ⇒ do Y` usage examples stay — they are usage, not a legend). plugin.json `"version": "0.8.13"` → `"0.8.14"`.
+- Verify: `grep -c 'notation.md' plugins/dev-core/skills/shared/references/base.md plugins/dev-core/agents/doc-writer.md` (≥1 each) ∧ `python3 -c "import json; assert json.load(open('plugins/dev-core/.claude-plugin/plugin.json'))['version']=='0.8.14'; print('ok')"` ∧ `bash scripts/check-skill-version.sh && echo gate-ok`
+- Expected: pointers present; `ok`; `gate-ok`
+- Spec trace: SC9
 
-**T4 — Grep battery + standalone demo**
-- Files: none (read-only sweep + demo evidence)
-- Agent: tester-A · Subject: sweep · Phase: GREEN · Difficulty: 2 · Est: 8 ops · blockedBy: T2, T3
-- Shape: battery — lint mentions all gated (`grep -in 'lint' plugins/compress/skills/compress/SKILL.md plugins/compress/skills/compress/references/compress.md` → every hit ∈ {description trigger :3, μ set :18, Entry example :29, Phase-0 halt list :45-46} or equivalent post-edit lines; zero references to an unshipped lint body/behavior); negative grep: no hardcoded token-tier rule (no "= 1 token"/"= 2 tokens" tier claims; the only sanctioned numeric forms are the break-even inequality and its practical thresholds) and no tokenizer-relative glyph rule; `needs external verification` literal present; no `decision-presentation`/`AskUserQuestion`; `--level|--verify` still absent; standalone demo: assert `plugins/shared/references/notation.md` does NOT exist yet (V1 tree) → the Phase 0 existence-gate text covers it and no SKILL.md path hard-requires the file; sample-output check: compose a 5-line sample compression per the G-rules and verify no bare non-whitelist symbol (each symbol ∈ Whitelist line ∨ Let-defined w/ gloss); self-containment grep on shipped surface.
-- Verify: scripted battery above
-- Expected: all clean; demo evidence recorded
-- Spec trace: SC11, SC12, SC13, SC15, SC17, SC18, SC22
+**T9b — Whitelist alignment for adjudicated glyphs**
+- File: `plugins/compress/skills/compress/SKILL.md`
+- Agent: doc-writer-B · Subject: whitelist · Phase: GREEN · Difficulty: 1 · Est: 3 ops · blockedBy: T7, T9
+- Shape: if T7's adjudications activate glyphs beyond the current 22 (expected: `⇒`), append them to the `Whitelist:` line so whitelist ≡ core-table active rows. Line count must stay ≤110 (in-line append, no new line).
+- Verify: `wc -l < plugins/compress/skills/compress/SKILL.md` ≤110 ∧ whitelist spans == core-table active glyph set (manual diff of the two parsed sets)
+- Expected: equality holds; 109 lines
+- Spec trace: SC6
 
-**T5 — RED-GATE: budget sentinel on the grown SKILL.md**
-- Files: temp copy of SKILL.md (restored)
-- Agent: tester-A · Subject: budget-gate · Phase: RED-GATE · Difficulty: 2 · Est: 6 ops · blockedBy: T4
-- Shape: cp SKILL.md to scratch → append filler >110 → `python3 tools/validate_plugins.py` FAILS naming compress → mv back → PASSES → `git status` unchanged. Record outputs.
+### Slice V2 — Wave 3
+
+**T10 — Implement check_notation_legends**
+- File: `tools/validate_plugins.py`
+- Agent: devops-A · Subject: validator · Phase: GREEN · Difficulty: 3 · Est: 14 ops · blockedBy: T6, T7, T9b
+- Shape: module consts `NOTATION_LEGEND_FILES = [the two gated dev-core files]`, `NOTATION_GLOSSARY = 'plugins/shared/references/notation.md'`, `COMPRESS_SKILL = 'plugins/compress/skills/compress/SKILL.md'`; `def check_notation_legends(legend_files=None, skill_path=None, glossary_path=None) -> list[str]` — D9 contract: gate (a) each legend file has exactly one legend line and it contains `notation.md` (missing file → `... not found at ...`); gate (b) parse whitelist spans (line starting `Whitelist:`) + core-table column-1 backtick spans (rows between `## Core Table` and next `##`, skipping separator rows) → assert non-empty both, set-equality with both-direction diffs in the error. Register `('Notation legends', check_notation_legends)` in main() checks + add `'notation-legends'` to `--check` choices with the standard dispatch block (exit 2 on `_is_io_error`, else 1). Docstring per house style.
+- Verify: `python3 -m pytest tests/test_check_notation_legends.py -q && python3 tools/validate_plugins.py && python3 tools/validate_plugins.py --check notation-legends && echo all-ok`
+- Expected: pytest green; both invocations exit 0; `all-ok`
+- Spec trace: SC6
+
+### Slice V2 — Wave 4
+
+**T11 — Post-integration battery**
+- Files: none (read-only)
+- Agent: tester-B · Subject: battery · Phase: GREEN · Difficulty: 2 · Est: 8 ops · blockedBy: T10
+- Shape: `python3 tools/validate_plugins.py` all PASS (incl. line budget + notation-legends); `python3 -m pytest tests/ -q` (only pre-existing test_browser failures); shipped-tree `run_tool('--check','notation-legends')` exit 0; **SC1 merge spot-check**: `S*`, `✓/✗`, `≥/≤`, `¬do-x`, `∅`, `⇒` all accounted for in notation.md (core/registry/maintenance); SC5 grep (fidelity-warned glyphs carry gloss flags; disclaimer verbatim); SC7 (no token-cost column); SC8 (SKILL.md Phase 0 references `## Core Table` only; grammar/maintenance referenced only from glossary.md); SC3 (aspirational note); SC20 (`! grep -q 'ADR-009' glossary.md`); self-containment grep shipped surface (now includes plugins/shared/ + dev-core files).
+- Verify: scripted battery
+- Expected: all green
+- Spec trace: SC5, SC7, SC8, SC9, SC21
+
+**T12 — RED-GATE: live seeded violations**
+- Files: temp edits (restored)
+- Agent: tester-B · Subject: falsification · Phase: RED-GATE · Difficulty: 2 · Est: 7 ops · blockedBy: T11
+- Shape: (1) cp base.md to scratch → replace its pointer line with a fake full legend → `--check notation-legends` FAILS (pointer gate) → restore → PASSES. (2) cp SKILL.md → drop one whitelist glyph → check FAILS (set-equality, both-direction diff named) → restore → PASSES. `git status` unchanged after. Record all outputs.
 - Verify: scripted sequence
-- Expected: FAIL over budget → PASS restored
-- Spec trace: SC21
+- Expected: FAIL/FAIL on seeds, PASS restored, zero residue
+- Spec trace: SC6
 
 ## Task Seeding Blueprint
 
 <!-- Format: T{n} | agent-instance | blockedBy | subject -->
 
-### Wave 1 — no deps, 1 agent
+### Wave 1 — no deps, 2 agents ∥
 
 | Task | Agent instance | blockedBy | Subject |
 |------|---------------|-----------|---------|
-| T1 | doc-writer-A | — | evidence |
+| T6 | tester-A | — | legends-tests |
+| T7 | doc-writer-A | — | glossary-core |
 
-### Wave 2 — after T1, 2 agents ∥
-
-| Task | Agent instance | blockedBy | Subject |
-|------|---------------|-----------|---------|
-| T2 | doc-writer-A | T1 | guardrails |
-| T3 | doc-writer-B | T1 | docs |
-
-### Wave 3 — after Wave 2, 1 agent
+### Wave 2 — after T7, 2 agents ∥
 
 | Task | Agent instance | blockedBy | Subject |
 |------|---------------|-----------|---------|
-| T4 | tester-A | T2, T3 | sweep |
-| T5 | tester-A | T4 | budget-gate |
+| T8 | doc-writer-A | T7 | glossary-mode |
+| T9 | doc-writer-B | T7 | repointing |
+| T9b | doc-writer-B | T7, T9 | whitelist |
+
+### Wave 3 — after T6, T7, T9b
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T10 | devops-A | T6, T7, T9b | validator |
+
+### Wave 4 — after T10
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T11 | tester-B | T10 | battery |
+| T12 | tester-B | T11 | falsification |
 
 ## Task IDs
 
-<!-- Generated by /plan (slice V1). -->
-- T1: 29 — evidence
-- T2: 30 — guardrails
-- T3: 31 — docs
-- T4: 32 — sweep
-- T5: 33 — budget-gate
+<!-- Generated by /plan (slice V2). V1 IDs 29-33 completed. -->
+- T6: 34 — legends-tests
+- T7: 35 — glossary-core
+- T8: 36 — glossary-mode
+- T9: 37 — repointing
+- T9b: 38 — whitelist
+- T10: 39 — validator
+- T11: 40 — battery
+- T12: 41 — falsification

--- a/artifacts/plans/310-notation-glossary-guardrails-plan.mdx
+++ b/artifacts/plans/310-notation-glossary-guardrails-plan.mdx
@@ -1,0 +1,155 @@
+---
+title: 'Plan: compress v2 train B — slice V1 (P6 guardrails standalone)'
+issue: 310
+spec: artifacts/specs/310-notation-glossary-guardrails-spec.mdx
+complexity: 5/10
+tier: F-lite
+slice: V1 of 2
+generated: 2026-07-04
+---
+
+## Summary
+
+Slice V1 (P6): replace compress's flat `¬compress` list with guardrails G1–G4 + canonical inline whitelist + R1 demotion and break-even inequality, wire the existence-gated glossary paths (glossary absent in V1 — the standalone proof), pin the evidence in `references/evidence.md`, all within the ≤110-line budget via the Decision-10 displacement plan.
+
+## Architecture
+
+**Data flow:** [notation pipeline](../visuals/310-notation-glossary-guardrails-data-flow.html)
+**File map:** [files × sections](../visuals/310-notation-glossary-guardrails-file-map.html)
+
+(Sidecars cover both slices; generated during this V1 plan run.)
+
+## Bootstrap Context
+
+- Binding spec decisions: D9 format contracts (Whitelist anchor line, glyph domain excl. reserved vars), D10 displacement (append template + mode-specific edge rows → `references/compress.md`; G1–G4 stay in SKILL.md — cross-mode), D11 standalone Phase-3 degradation (whitelist glyph domain only, documented).
+- Current SKILL.md = 106 lines (train A v2 + fix); budget 110; est. +14–16 added by G-rules/whitelist/inequality/wiring ⇒ displace ~10–12 (D10 targets: the Phase 5 append command block SKILL.md:78-85, and ONLY the mode-specific Edge Cases row :93 "Mode-specific (…) | Per ref(μ)" — rows :91-92 "Agent (¬skill)" and "User rejects at Phase 4" are cross-mode and STAY).
+- `references/compress.md` currently holds the Symbols legend (:5-7) + R1–R10 (:13-30) + `¬compress` line (:32) + mode edge cases (:34-40) + measured rationale (:42-51). The `¬compress` line is superseded by G1–G4 → replace with a one-line pointer to SKILL.md's G-rules; keep mode-specific behaviors.
+- Whitelist seed = union of glyphs in `references/compress.md:7` legend (fresh grep at implement; expected ~20 tokens incl. `:=`, `|X|`, `↦`, `⟺`).
+- G4 citation form: `(evidence: references/evidence.md — Tencent 2604.07192)` inline.
+- Quality bar: dev-core maintainer idiom; G-rules compact (≤2 lines each + shared intro).
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|----------------|-------|-------|
+| doc-writer-A | T1, T2 | references/evidence.md; SKILL.md + references/compress.md |
+| doc-writer-B | T3 | plugins/compress/README.md |
+| tester-A | T4, T5 | (grep battery + budget sentinel — no new files) |
+
+## Wave Structure
+
+3 waves, max 2 ∥.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 1 | doc-writer-A: T1 |
+| 2 | T1 done | 2 ∥ | doc-writer-A: T2 · doc-writer-B: T3 |
+| 3 | Wave 2 done | 1 | tester-A: T4→T5 |
+
+### Budget — per task
+
+| Task | Class | Est. ops | Split? |
+|------|-------|----------|--------|
+| T1 evidence.md | judgmental | 8 | — |
+| T2 SKILL.md G-rules + displacement | judgmental | 18 | — |
+| T3 README sync | trivial | 3 | — |
+| T4 grep battery + standalone demo | bounded | 8 | — |
+| T5 RED-GATE budget sentinel | bounded | 6 | — |
+
+**Total estimated ops: 43**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| doc-writer-A | T1, T2 | 26 | evidence, guardrails | — |
+| doc-writer-B | T3 | 3 | docs | — |
+| tester-A | T4, T5 | 14 | sweep, budget-gate | — |
+
+## Consistency Report
+
+- V1-scoped SCs covered: SC10 (T2), SC11 (T2, T4), SC12 (T2, T4), SC13 (T2, T4), SC14 (T1, T2), SC15 (T2, T4), SC16 (T1), SC17 (T2, T4 — standalone demo), SC18 (T4), SC19 (T2), SC21 (T2, T5), SC22 (process, T4 grep). 12/12 V1 criteria → ≥1 task.
+- Exempt (slice V2): SC1–SC9, SC20 (cortex_link lands with glossary.md in V2).
+- Untraced tasks: none.
+
+## Micro-Tasks
+
+### Slice V1 — Wave 1
+
+**T1 — Create references/evidence.md**
+- File: `plugins/compress/skills/compress/references/evidence.md`
+- Agent: doc-writer-A · Subject: evidence · Phase: GREEN · Difficulty: 2 · Est: 8 ops
+- Shape: pinned load-bearing excerpts with IDs, one section per source: Tencent arXiv 2604.07192 (controlled null result, Cliff's δ<0.01; polarity failure taxonomy 36/47 = default bias), MetaGlyph arXiv 2601.07354 (`→` 0% as transformation operator, `∈` 26%, U-curve), LILO ICLR 2024 (NL gloss/AutoDoc load-bearing), GEPA ICLR 2026 (rule derivation by reflection; non-load-bearing credit), pseudo-code ablation note. ≤60 lines; each excerpt ≤3 lines + 1-line "what it licenses" (e.g. G1 ← Tencent; G3 ← MetaGlyph+LILO). No machine-local paths.
+- Verify: `test -f plugins/compress/skills/compress/references/evidence.md && grep -c 'arXiv' plugins/compress/skills/compress/references/evidence.md && grep -q '2604.07192' plugins/compress/skills/compress/references/evidence.md && grep -q '2601.07354' plugins/compress/skills/compress/references/evidence.md && echo ok`
+- Expected: ≥4 arXiv/venue pins; `ok`
+- Spec trace: SC16, SC14
+
+### Slice V1 — Wave 2
+
+**T2 — SKILL.md guardrails + whitelist + wiring + displacement**
+- Files: `plugins/compress/skills/compress/SKILL.md`, `plugins/compress/skills/compress/references/compress.md`
+- Agent: doc-writer-A · Subject: guardrails · Phase: GREEN · Difficulty: 4 · Est: 18 ops · blockedBy: T1
+- Shape (SKILL.md): replace the Safety-section adjacency with a `## Guardrails` block: G1 polarity (`¬use Y` → `use Z (¬Y)` iff concrete Z; never invent Z; else flag literal **`needs external verification`** + Phase 4 flag block `{constraint | polarity | alternative-exists | verification-method}`, fixed format, vault optional); G2 no-free-coinage (symbols ∈ whitelist; NO hardcoded token tiers anywhere; NO tokenizer-relative glyph rule; token-neutrality principle verbatim: *glyph substitution is token-neutral at best; choose glyphs for register/precision, never for economy; measured savings come from prose pruning*; optional measurement procedure: API count, tokenizer + date); G3 gloss trigger verbatim `(predicate ∨ O-block ∨ Let-bind) ∨ (symbol ∉ whitelist) ∨ (chain > 3 operators)` → `— …` gloss ≤1 line; bare non-whitelist symbols forbidden; G4 verbatim floor (commands, tool names, spawn templates, safety rules) citing evidence.md inline. Add `Whitelist:` anchor line (D9 format; seed from compress.md:7 legend union). Add R1 break-even inequality `(T_phrase − T_var) × occ > T_letline (≈8–10)` + R5/R6/R7 = primary economic transform + "G1/G3 spend tokens to buy compliance". Phase 0 + existence-gated glossary load line (`plugins/shared/references/notation.md` ∃ → load `## Core Table`; ∄ → whitelist only); Phase 3 collision-check line (registry if glossary ∃, else whitelist domain — D11 wording); Phase 5 assert emitted symbols ∈ whitelist/core-table ∨ Let-defined. Displace (D10): Phase 5 append command block → compress.md (Phase 5 keeps a 1-line pointer); mode-specific Edge Cases rows → compress.md. ≤110 lines HARD.
+  (compress.md): receive displaced blocks; replace `¬compress` line :32 with pointer "superseded by SKILL.md G1–G4"; fix the R1 example (registry-clean vars — e.g. `κ(f)` conf, `θ` threshold; NOT φ/τ/γ); keep Symbols legend + measured rationale.
+- Verify: `wc -l < plugins/compress/skills/compress/SKILL.md` ≤110 ∧ `python3 tools/validate_plugins.py | grep 'line budget'` PASS ∧ `grep -q '^Whitelist:' plugins/compress/skills/compress/SKILL.md` ∧ `grep -q 'never for economy' plugins/compress/skills/compress/SKILL.md` ∧ `grep -qF '(predicate ∨ O-block ∨ Let-bind) ∨ (symbol ∉ whitelist) ∨ (chain > 3 operators)' plugins/compress/skills/compress/SKILL.md` ∧ `grep -q 'T_letline' plugins/compress/skills/compress/SKILL.md` ∧ `grep -q 'evidence.md' plugins/compress/skills/compress/SKILL.md` ∧ `! grep -q 'φ.*findings' plugins/compress/skills/compress/references/compress.md` ∧ echo ok
+- Expected: all green; `ok`
+- Spec trace: SC10, SC11, SC12, SC13, SC14, SC15, SC17, SC19, SC21
+
+**T3 — README doc sync** `[P]`
+- File: `plugins/compress/README.md`
+- Agent: doc-writer-B · Subject: docs · Phase: GREEN · Difficulty: 1 · Est: 3 ops · blockedBy: T1
+- Shape: add a short "Fidelity guardrails" paragraph (G1–G4 one-liners) + note the canonical whitelist / optional shared glossary.
+- Verify: `grep -q 'G1' plugins/compress/README.md && grep -qi 'guardrail' plugins/compress/README.md && echo ok`
+- Expected: `ok`
+- Spec trace: SC11 (docs), SC17
+
+### Slice V1 — Wave 3
+
+**T4 — Grep battery + standalone demo**
+- Files: none (read-only sweep + demo evidence)
+- Agent: tester-A · Subject: sweep · Phase: GREEN · Difficulty: 2 · Est: 8 ops · blockedBy: T2, T3
+- Shape: battery — lint mentions all gated (`grep -in 'lint' plugins/compress/skills/compress/SKILL.md plugins/compress/skills/compress/references/compress.md` → every hit ∈ {description trigger :3, μ set :18, Entry example :29, Phase-0 halt list :45-46} or equivalent post-edit lines; zero references to an unshipped lint body/behavior); negative grep: no hardcoded token-tier rule (no "= 1 token"/"= 2 tokens" tier claims; the only sanctioned numeric forms are the break-even inequality and its practical thresholds) and no tokenizer-relative glyph rule; `needs external verification` literal present; no `decision-presentation`/`AskUserQuestion`; `--level|--verify` still absent; standalone demo: assert `plugins/shared/references/notation.md` does NOT exist yet (V1 tree) → the Phase 0 existence-gate text covers it and no SKILL.md path hard-requires the file; sample-output check: compose a 5-line sample compression per the G-rules and verify no bare non-whitelist symbol (each symbol ∈ Whitelist line ∨ Let-defined w/ gloss); self-containment grep on shipped surface.
+- Verify: scripted battery above
+- Expected: all clean; demo evidence recorded
+- Spec trace: SC11, SC12, SC13, SC15, SC17, SC18, SC22
+
+**T5 — RED-GATE: budget sentinel on the grown SKILL.md**
+- Files: temp copy of SKILL.md (restored)
+- Agent: tester-A · Subject: budget-gate · Phase: RED-GATE · Difficulty: 2 · Est: 6 ops · blockedBy: T4
+- Shape: cp SKILL.md to scratch → append filler >110 → `python3 tools/validate_plugins.py` FAILS naming compress → mv back → PASSES → `git status` unchanged. Record outputs.
+- Verify: scripted sequence
+- Expected: FAIL over budget → PASS restored
+- Spec trace: SC21
+
+## Task Seeding Blueprint
+
+<!-- Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | doc-writer-A | — | evidence |
+
+### Wave 2 — after T1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | doc-writer-A | T1 | guardrails |
+| T3 | doc-writer-B | T1 | docs |
+
+### Wave 3 — after Wave 2, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T4 | tester-A | T2, T3 | sweep |
+| T5 | tester-A | T4 | budget-gate |
+
+## Task IDs
+
+<!-- Generated by /plan (slice V1). -->
+- T1: 29 — evidence
+- T2: 30 — guardrails
+- T3: 31 — docs
+- T4: 32 — sweep
+- T5: 33 — budget-gate

--- a/artifacts/specs/310-notation-glossary-guardrails-spec.mdx
+++ b/artifacts/specs/310-notation-glossary-guardrails-spec.mdx
@@ -1,0 +1,156 @@
+---
+title: 'compress v2 train B — canonical notation glossary + reserved-var registry + fidelity guardrails'
+issue: 310
+status: approved
+tier: F-lite
+date: 2026-07-04
+---
+
+## Context
+
+Promoted from `artifacts/frames/310-notation-glossary-guardrails-frame.mdx` (approved). Source analysis §3-P1 + §3-P6 (adversarially verified; corrections baked into issue #310). Train B of #308; builds on train A's merged dispatch architecture (`3b8d5cf`).
+
+## Goal
+
+Give the repo one canonical notation SSoT (`plugins/shared/references/notation.md`) with a grep-seeded reserved-variable registry, repoint the two dev-core legends onto it (gated by a new validator check), and replace compress's flat `¬compress` list with evidence-based fidelity guardrails G1–G4 — while compress stays fully functional standalone.
+
+## Users
+
+- **Primary:** compress users (G1–G4 govern every output); dev-core skill authors (one legend SSoT).
+- **Secondary:** #311 read-back (G3 gloss compliance is what it tests), #312 lint (glossary = its reference), #313 derive (R12 emits glossary-compliant abstractions); cortex closed-vocabulary governance mechanics.
+
+## Decisions
+
+1. **DP drift (standing)**: glyph adjudications = measured-count decisions taken in-run; counts + outcome + rationale recorded in notation.md. Other decision points: inline present-choice idiom. Never AskUserQuestion; no decision-presentation.md references.
+2. **Slice order P6 → P1** (sanctioned by the issue's own §19: inline whitelist is canonical and autonomous): V1 ships the compress-side guardrails + whitelist + evidence.md with the glossary pointer existence-gated (pointer target absent → graceful degradation, which also proves the standalone-install path); V2 ships notation.md + glossary.md + repointing + bump + the `notation-legends` check (its set-equality gate compares against the V1 whitelist).
+3. **dev-init base.md fork**: out of scope (frame Decision 1); follow-up issue filed at PR time; the notation-legends check gates exactly `plugins/dev-core/skills/shared/references/base.md` and `plugins/dev-core/agents/doc-writer.md`.
+4. **Glyph adjudications (expected from analysis-time evidence, re-measured fresh at implement)**: retain `⟺` (analysis-time ×7 plugin files vs `⇔` ×0 in plugins/; count has already drifted to 8 — fresh grep is the source of truth); retain `⇒` as sanctioned implies/contrastive register (×33 across 8 files; live legend doc-writer.md:51; contrastive register dev:45). `⇒` is never classified as drift.
+5. **notation-legends check shape**: same injectable-params + registry-constant style as `check_skill_line_budget` (train A). Pointer gate = the legend line in each gated file must be a single line containing `notation.md`; set-equality gate = glyph set parsed from SKILL.md's inline whitelist ≡ glyph set parsed from notation.md's core table (precedent: shared-sources-sync). Registered in main() checks + `--check notation-legends` CLI choice (it needs standalone invocation for the AC's seeded-violation demonstration).
+6. **dev-core semver bump**: 0.8.13 → 0.8.14 in `plugins/dev-core/.claude-plugin/plugin.json`, same PR as the repointing (check-skill-version gate: base.md sits under `plugins/dev-core/skills/**`; doc-writer.md under `agents/` doesn't trip the gate but rides the same bump).
+7. **SKILL.md budget**: stays ≤110 (train A's gate); G1–G4 + whitelist + inequality land compact; displaced detail goes to `references/compress.md` (mode body) or notation.md — never dropped.
+8. **No token-cost appendix** in v1 of notation.md (issue offers "measured appendix or nothing" — choose nothing; the ledger (train A) is the living measurement instrument; avoids a rot surface).
+9. **Format contracts** (panel-mandated — pin before implement; the set-parse has no repo precedent, `check_class_list_sync`'s anchored-line pattern is the model):
+   - **Core-table anchor**: notation.md's core table is bounded by the exact heading `## Core Table` up to the next `##` heading. Both consumers — compress Phase 0's budgeted load and the validator's set parse — use this same anchor.
+   - **Core-table schema**: markdown table `| glyph | senses | gloss? | fidelity ⚠ | notes/adjudication |`. Glyph extraction for set-equality = backtick spans in **column 1 only** (split rows on unescaped `|`, take cell 1, findall `` `…` ``); skip the separator row (`^\s*\|[\s:-]+\|`). Multi-glyph cells (`` `∃`/`∄` ``) contribute each span to the set.
+   - **Whitelist anchor**: SKILL.md carries one line starting `Whitelist:` whose backtick spans are the whitelist set (same findall; delimiter-safe for `|X|`, `:=`, `↦`).
+   - **Equality domain**: operator/symbol glyphs only (incl. multi-char). Reserved-var Greek letters live in the registry section and are NOT part of the equality domain. Deprecated glyphs move to the maintenance section — the core table holds **active rows only**, keeping the equality well-defined.
+   - **Exit codes** (match `_is_io_error` tiers): gated file or notation.md missing → error message contains `not found at` (exit 2 via the existing sort); pointer/set drift → exit 1. Both parsed sets must be non-empty (empty ≡ empty fails loudly).
+   - **Pointer example** (one line, must contain `notation.md`): `` Notation legend → canonical glossary: `${CLAUDE_PLUGIN_ROOT}/../shared/references/notation.md` (repo: `plugins/shared/references/notation.md`) `` — adapted to each file's surrounding voice.
+   - **Registry schema**: `| var | binding(s) | grep counts | status |` (status ∈ canonical/collision/aspirational); σ row shows the 4-way collision, Ω row the dominant/minority split.
+   - **→ senses**: enumerate 4 positional senses by classifying fresh grep samples (expected classes from the analysis: then/sequence · maps-to · conditional-implication · produces/returns; final naming from corpus evidence, recorded with sample counts).
+   - **Adjudication record format**: a `notes/adjudication` cell or dedicated subsection per contested glyph: counts, outcome, rationale, date (e.g. `⇒`: retained — sanctioned implies/contrastive; ×N across M files, doc-writer legend; never drift).
+   - **Writer-side disclaimer** (verbatim sentence in notation.md): "This glossary is writer-side tooling: consumers of compressed files never need it — every emitted symbol must be self-sufficient via the whitelist or a local Let-binding with gloss."
+10. **SKILL.md ≤110 displacement plan**: G1–G4 + whitelist + inequality live in SKILL.md (cross-mode — every mode's outputs are governed); displaced to `references/compress.md` (compress-mode-only content): the ledger `append` command template block and the mode-specific Edge Cases rows (~10–12 lines). Phase 0 dispatch, Phase 1 scope, Phase 5 write mechanics stay (cross-mode).
+11. **Phase 3 standalone fallback semantics** (stated plainly): with notation.md absent, the collision-check degrades to the whitelist glyph domain only — reserved-var *binding* collisions are not checked in standalone installs; that is accepted graceful degradation, documented in SKILL.md.
+
+## Expected Behavior
+
+**notation.md (V2).** Core table (~150 lines, the only part compress loads): every glyph from the 3 source legends merged or adjudicated (adjudication = counts + outcome + rationale inline); fidelity-warned glyphs (MetaGlyph data: `→`, `∈`, `∩`…) flagged **mandatory-gloss**; declares itself writer-side tooling (consumers of compressed files never need it). Grammar section (lazy): 4 positional senses of `→`; `¬` modal registers; separator hierarchy `/`,`,` < `·` < `|` < `;` < newline < heading. Maintenance policy section (lazy): add/deprecate/version rules, extension human-gated (present-choice). Reserved-variable registry: grep-seeded counts for σ (4-way), Ω (override-file dominant), α/β/ω/μ, τ/φ/Δ/Σ/π with the π and Σ collisions recorded; `(local)` re-binding rule. The uppercase-Latin/Greek register rule appears only as an explicitly aspirational note scoped to this corpus (ssot = out-of-corpus evidence).
+
+**Legend repointing (V2).** `base.md:16` and `doc-writer.md:51` legend lines each become one line pointing at `plugins/shared/references/notation.md` (installed-context wording; keep surrounding text intact). dev-core plugin.json bumps to 0.8.14.
+
+**notation-legends check (V2).** `python3 tools/validate_plugins.py --check notation-legends` passes on the shipped tree; fails when (a) a gated legend line is not a one-line pointer, or (b) whitelist ≢ core table — both demonstrated against seeded violations in tests (tmp-dir fixtures, injectable params).
+
+**Guardrails in SKILL.md (V1).** The `¬compress` flat list is replaced by: **G1** polarity transform — `¬use Y` → `use Z (¬Y)` iff concrete Z exists; never invent Z; no alternative → flag `needs external verification`, emitting `{constraint | polarity | alternative-exists | verification-method}` as a fixed-format block in Phase 4 (vault persistence optional — completes with no vault). **G2** familiarity/no-free-coinage — new symbols ∈ inline whitelist; no free coinage of indexed vars; stated principle: *glyph substitution is token-neutral at best; choose glyphs for register/precision, never for economy; measured savings come from prose pruning*; no hardcoded token tiers; no tokenizer-relative rule; optional measurement procedure (API count, tokenizer + date recorded). **G3** decidable gloss trigger — `(predicate ∨ O-block ∨ Let-bind) ∨ (symbol ∉ whitelist) ∨ (chain > 3 operators)` → mandatory `— …` gloss ≤1 line; bare non-whitelist symbols forbidden in output. **G4** verbatim floor — commands, tool names, spawn templates, safety rules stay in words; cites `references/evidence.md` inline.
+
+**Realignment (V1).** R1 demoted to a disambiguation rule; break-even inequality `(T_phrase − T_var) × occ > T_letline (≈8–10)` stated in SKILL.md (practical forms: phrase ≥3 tokens ∧ occ ≥4, or ≥4 ∧ ≥3); R5/R6/R7 labeled the primary economic transform; R1 example rewritten with zero house-binding collisions (no φ/τ/γ misuse — pick unbound vars per the registry); skill text states G1/G3 spend tokens to buy compliance.
+
+**Wiring (V1 + V2).** Phase 0: existence-gated glossary load — `notation.md` present → load core table; absent → inline whitelist only (standalone path). Phase 3: every new `Let:` var collision-checked against the registry (glossary present) or whitelist (absent). Phase 5: assert every emitted symbol ∈ core table ∨ locally Let-defined. `glossary` mode body ships in `references/glossary.md` (mode-exists gate from train A now dispatches it): add/deprecate/version entries, human-gated extension, loads grammar + maintenance sections. cortex_link wording: vocabulary-governance mechanics only. Every lint-mode mention fully specified or absent. README doc sync.
+
+## Data Model & Consumers
+
+**Data structure:** [notation SSoT data model](../visuals/310-notation-glossary-guardrails-data-model.html)
+**Consumer map:** [notation.md consumers](../visuals/310-notation-glossary-guardrails-consumers.html)
+
+| Consumer | Fields consumed | When | Status |
+|----------|-----------------|------|--------|
+| compress Phase 0 | core table (existence-gated) | every run | this issue |
+| compress Phase 3 | reserved-var registry | every Let-bind | this issue |
+| compress Phase 5 | core table ∪ local Let set | every write | this issue |
+| base.md / doc-writer.md | pointer only | always-on surfaces | this issue |
+| `validate_plugins.py --check notation-legends` | pointer lines + whitelist/core-table sets | CI + lefthook | this issue |
+| #311 read-back | G3 gloss mandate | train C | future |
+| #312 lint | glossary + grammar sections | train D | future |
+| #313 derive R12 | whitelist + registry | train E | future |
+| dev-init base.md | pointer (follow-up issue) | post-train | future |
+
+## Breadboard
+
+| ID | Affordance | Handler | Data |
+|----|-----------|---------|------|
+| S1 | `notation.md` core table (+ adjudications w/ counts) | shared reference | glyph rows: symbol, senses, gloss-flag, fidelity-warning |
+| S2 | Disambiguation grammar + maintenance policy (lazy sections) | shared reference | → senses, ¬ registers, separators; add/deprecate/version |
+| S3 | Reserved-var registry (grep-seeded counts, `(local)` rule) | shared reference | var → binding(s) + counts |
+| S4 | `references/glossary.md` (glossary-mode body) | lazy-loaded mode | mode pipeline |
+| S5 | `references/evidence.md` (pinned excerpts + arXiv IDs) | reference | Tencent, MetaGlyph, LILO, GEPA |
+| S6 | G1–G4 + inline whitelist + break-even inequality + honest rationale | SKILL.md | guardrail text |
+| S7 | Phase 0 existence-gated load; Phase 3 collision-check; Phase 5 symbol assert | SKILL.md wiring | registry + whitelist |
+| S8 | Legend pointers (base.md:16, doc-writer.md:51) | dev-core files | one-line pointer |
+| S9 | dev-core plugin.json 0.8.14 | manifest | semver |
+| S10 | `--check notation-legends` (pointer + set-equality, injectable, CLI choice) | validate_plugins.py | gated files + parsed sets |
+| S11 | README doc sync | docs | glossary/guardrail mention |
+| S12 | Fixed R1 example (no house-binding collisions) | SKILL.md/references | example text |
+
+Wiring: S6/S7 (V1) stand alone via whitelist; S1–S5, S8–S10 (V2) close the loop; S10 reads S8 + (S6 ↔ S1) equality.
+
+## Slices
+
+| # | Slice | Contains | Demo |
+|---|-------|----------|------|
+| 1 | P6 — guardrails standalone | S5, S6, S7 (whitelist-only paths), S12, S11 | With `plugins/shared/references/notation.md` ABSENT: compress loads, G1–G4 active, whitelist canonical, no bare non-whitelist symbol in a sample output, R1 example clean, evidence.md cited; SKILL.md ≤110; validate_plugins (train-A checks) green |
+| 2 | P1 — glossary SSoT + gates | S1, S2, S3, S4, S7 (glossary-present paths), S8, S9, S10 | notation.md present → Phase 0 loads core; `--check notation-legends` passes shipped / fails seeded violations; base.md + doc-writer.md are pointers; dev-core 0.8.14; check-skill-version green |
+
+## Constraints
+
+- Marketplace self-containment (whitelist canonical; existence-gated pointer; no ssot paths).
+- Same-PR dev-core bump; base.md churn → rebase early/often.
+- SKILL.md ≤110 lines (train-A gate).
+- No hardcoded token tiers; no tokenizer-relative rules; never invent Z; registry counts from fresh grep.
+- Edit repo source only; no `--force`/`--hard`/`--amend`; specific-file staging.
+- No new CI workflow/deps — the check rides validate_plugins.py.
+
+## Non-goals
+
+- dev-init base.md repointing (follow-up issue at PR time).
+- Lint mode (#312), read-back/levels (#311), derive (#313).
+- Corpus migration; per-glyph token-cost data; ADR-009 claims.
+
+## Edge Cases
+
+| Scenario | Handling |
+|----------|----------|
+| `plugins/shared/references/notation.md` absent (standalone install) | Phase 0 existence test fails → inline whitelist only; all G-rules still bind |
+| Glossary present but core table unparseable | Treat as absent + warn (degrade, never crash the skill flow) |
+| New Let var collides with registry entry | Phase 3 flags; `(local)` re-binding allowed with explicit `(local)` marker |
+| Symbol not in whitelist and not Let-defined | Phase 5 blocks emission (G3); gloss or rewrite |
+| `¬` constraint with no concrete alternative Z | G1 flag block in Phase 4 (4-field schema); never invent Z |
+| Chain > 3 operators | G3 mandatory gloss |
+| Gated legend file missing at check time | notation-legends check reports error naming the file (fail, not crash) |
+| Whitelist/core-table parse yields empty set | Check fails loudly (empty ≡ empty must not vacuously pass — assert non-empty) |
+| doc-writer.md line drifts again | Pointer gate greps for the pointer pattern, not a line number |
+| glossary mode invoked (train-A dispatch) | `references/glossary.md` now exists → mode runs; grammar+maintenance sections load |
+
+## Success Criteria
+
+- [ ] SC1 `notation.md` exists; every entry of the 3 source legends present/merged/adjudicated (recorded); grammar covers `→`×4 senses, `¬` registers, separator hierarchy
+- [ ] SC2 Registry entries carry grep-measured counts (σ 4-way, Ω dominant, α/β/ω/μ, τ/φ/Δ/Σ/π with π+Σ collisions); `(local)` rule stated
+- [ ] SC3 Latin/Greek register rule = explicitly aspirational note, corpus-scoped, ssot out-of-corpus
+- [ ] SC4 `⇒`/`→` and `⟺`/`⇔` each resolved via measured counts; outcomes + counts in notation.md; `⇒` nowhere classified as drift
+- [ ] SC5 Every fidelity-warned glyph flagged mandatory-gloss; Phase 5 asserts emitted symbols ∈ core table ∨ Let-defined; notation.md declares itself writer-side
+- [ ] SC6 `--check notation-legends` passes shipped tree AND fails on seeded violations of both gates (pointer, set-equality) — demonstrated in tests
+- [ ] SC7 No per-glyph token-cost column anywhere in notation.md
+- [ ] SC8 Phase 0 loads only the core in compress mode; grammar/maintenance load only in glossary (and future lint) modes
+- [ ] SC9 dev-core plugin.json = 0.8.14; `bash scripts/check-skill-version.sh` passes on the branch
+- [ ] SC10 R1 example rewritten, zero collisions vs house bindings
+- [ ] SC11 G1 complete: concrete-Z-only rewrite, never-invent-Z stated, 4-field flag schema in Phase 4, fixed-format flag block, completes with no vault
+- [ ] SC12 G2: no hardcoded token tiers, no tokenizer-relative rule; token-neutrality principle stated verbatim-checkable (the italicized sentence of Expected Behavior appears as written) + optional measurement procedure
+- [ ] SC13 G3 trigger predicate verbatim `(predicate ∨ O-block ∨ Let-bind) ∨ (symbol ∉ whitelist) ∨ (chain > 3 operators)`; sample output contains no bare non-whitelist symbol
+- [ ] SC14 G4 enumerates commands, tool names, spawn templates, safety rules; cites evidence.md inline
+- [ ] SC15 Break-even inequality in SKILL.md; R5/R6/R7 labeled primary economic transform
+- [ ] SC16 `references/evidence.md` exists w/ Tencent 2604.07192, MetaGlyph 2601.07354, LILO, GEPA excerpts + IDs
+- [ ] SC17 Whitelist canonical; glossary pointer existence-gated; skill functions with notation.md absent (standalone path demonstrated in slice-1 demo)
+- [ ] SC18 No dangling lint references in compress text
+- [ ] SC19 Skill text states G1/G3 spend tokens to buy compliance
+- [ ] SC20 cortex_link = governance mechanics only; no ADR-009 claim; no derivation
+- [ ] SC21 SKILL.md ≤110 lines; all train-A checks still green; self-containment grep (shipped surface) empty
+- [ ] SC22 Process hygiene: zero plugin-cache edits; no `--force`/`--hard`/`--amend` in the branch history; in-flow decisions use the inline present-choice idiom (grep: no `AskUserQuestion`, no `decision-presentation` in shipped files)

--- a/artifacts/visuals/310-notation-glossary-guardrails-consumers.html
+++ b/artifacts/visuals/310-notation-glossary-guardrails-consumers.html
@@ -1,0 +1,2637 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="diagram:title" content="notation.md consumers — compress phases · legend pointers · legends gate · future trains (#310)">
+<meta name="diagram:category" content="architecture">
+<meta name="diagram:color" content="#22d3ee">
+<meta name="diagram:engine" content="fd-engine">
+<meta name="diagram:type" content="architecture">
+<title>notation.md consumers — compress phases · legend pointers · legends gate · future trains (#310)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+/* reset */
+*,*::before,*::after{box-sizing:border-box}
+html,body{margin:0;padding:0}
+ul,ol{list-style:none;margin:0;padding:0}
+button{cursor:pointer;font-family:inherit}
+
+/* ══════════════════════════════════════════════════════════════════
+   lyra-v2.css — Lyra brand aesthetic · v2 (GitHub-dark variant)
+   Used by: lyra, voicecli (v2-styled artifacts only)
+
+   Difference vs lyra.css (v1 "Forge Floor"):
+   - Surfaces rebased on GitHub-dark (#0d1117 family) with an explicit
+     elevation ladder: bg < bg-cell < bg-panel < bg-card
+   - Adds --border-hi for stronger dividers in dense data grids
+   - Accent alphas pushed (dim 0.08→0.12, glow 0.22→0.40) for more
+     "live ember" feel on cards and nodes
+   - Drops the forge-floor body chrome (spark particles + 42px grid)
+     — v2 docs are flat, data-dense, GitHub-network-graph style
+   - Adds lane palette (lane-a1..i, status-ready/blocked/done) so
+     dep-graph / kernel-arch / swimlane docs share one token set
+
+   Reference implementations:
+   - lyra-v2-dependency-graph-v5.1.html
+   - lyra-kernel-architecture-v5.html
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Brand Tokens — Dark (default, v2 only exists in dark) ── */
+:root, [data-theme="dark"] {
+  color-scheme: dark;
+
+  /* Surface elevation ladder (darkest → lightest) */
+  --bg:           #0d1117;  /* page */
+  --bg-cell:      #0f141a;  /* grid cell / recessed surface inside panel */
+  --bg-panel:     #13191f;  /* section / wrapper */
+  --bg-card:      #161b22;  /* card / raised surface inside panel */
+
+  /* Legacy aliases — keep v1 variable names working in v2 docs */
+  --surface:      #13191f;  /* alias → bg-panel */
+  --surface2:     #161b22;  /* alias → bg-card */
+
+  /* Dividers */
+  --border:       #21262d;
+  --border-hi:    #30363d;
+  --border-bright:#30363d;  /* alias → border-hi */
+
+  /* Text ramp */
+  --text:         #fafafa;
+  --text-muted:   #8b93a1;
+  --text-dim:     #6b7280;
+
+  /* Forge orange — same hue as v1, stronger alphas */
+  --accent:       #e85d04;
+  --accent-2:     #f97316;
+  --accent-dim:   rgba(232,93,4,0.12);
+  --accent-glow:  rgba(232,93,4,0.40);
+  --error:        #ef4444;
+
+  /* Extended lane palette — shared by dep-graph, kernel-arch, swimlanes */
+  --teal:    #06b6d4;  --teal-dim:   rgba(6,182,212,0.10);
+  --amber:   #f59e0b;  --amber-dim:  rgba(245,158,11,0.10);
+  --green:   #10b981;  --green-dim:  rgba(16,185,129,0.10);
+  --cyan:    #22d3ee;
+  --purple:  #c084fc;
+  --pink:    #ec4899;  --pink-dim:   rgba(236,72,153,0.10);
+  --plum:    #a855f7;  --plum-dim:   rgba(168,85,247,0.10);
+  --red:     #ef4444;  --red-dim:    rgba(239,68,68,0.10);
+
+  /* Issue / task status — for plan artifacts */
+  --status-ready:   #22c55e;
+  --status-blocked: #f97316;
+  --status-done:    #475569;
+
+  /* Lane tones — for multi-lane swim/DAG views */
+  --lane-a1: #22c55e;
+  --lane-a2: #6366f1;
+  --lane-a3: #8b5cf6;
+  --lane-b:  #3b82f6;
+  --lane-c1: #a855f7;
+  --lane-c2: #d946ef;
+  --lane-c3: #ec4899;
+  --lane-d:  #06b6d4;
+  --lane-e:  #eab308;
+  --lane-f:  #10b981;
+  --lane-g:  #f97316;
+  --lane-h:  #f59e0b;
+  --lane-i:  #14b8a6;
+}
+
+/* v2 is dark-only by design. If a doc needs a light mode, use lyra.css v1. */
+
+/* ══════════════════════════════════════════════════════════════════
+   Base page chrome — flat body, 24px gutter, 12px base type
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 body,
+body.lyra-v2 {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', system-ui, sans-serif;
+  padding: 24px;
+  min-height: 100vh;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Page header primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 header.page-header,
+body.lyra-v2 header.page-header {
+  max-width: 100%;
+  margin: 0 auto 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.lyra-v2 header.page-header h1,
+body.lyra-v2 header.page-header h1 {
+  font-family: 'Outfit', sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.lyra-v2 header.page-header h1 .accent,
+body.lyra-v2 header.page-header h1 .accent { color: var(--accent); }
+.lyra-v2 .subtitle,
+body.lyra-v2 .subtitle {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin-top: 6px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Section / panel primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 .section,
+body.lyra-v2 .section {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 18px 20px 20px;
+  position: relative;
+  overflow: hidden;
+}
+.lyra-v2 .section-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.lyra-v2 .section-title {
+  font-family: 'Outfit', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--text);
+  margin-bottom: 4px;
+  letter-spacing: -0.02em;
+}
+.lyra-v2 .section-title .accent { color: var(--accent); }
+.lyra-v2 .section-subtitle {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+  line-height: 1.45;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Card primitive — raised surface with border-left tone stripe
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 .card {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 9px 11px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-hi);
+  border-left: 3px solid currentColor;
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--text);
+  transition: background 0.15s, border-color 0.15s, transform 0.12s;
+}
+.lyra-v2 .card:hover {
+  background: var(--bg-panel);
+  border-color: currentColor;
+  transform: translateX(1px);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Footer primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 footer.page-footer {
+  margin-top: 18px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+}
+.lyra-v2 footer.page-footer a { color: var(--accent); text-decoration: none; }
+.lyra-v2 footer.page-footer a:hover { text-decoration: underline; }
+
+/* ══════════════════════════════════════════════════════════════════
+   Slide mode — lyra-v2 aesthetic (forge-slides)
+   Same flame-gradient as v1, but on the GitHub-dark ladder.
+   ══════════════════════════════════════════════════════════════════ */
+.deck.lyra-v2 .slide--title,
+.lyra-v2 .deck .slide--title {
+  background-image:
+    radial-gradient(ellipse at 50% 30%, var(--accent-glow) 0%, transparent 55%),
+    linear-gradient(135deg, var(--bg) 0%, var(--bg-panel) 100%);
+}
+.lyra-v2 .deck .slide--title .slide__display {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--title .slide__subtitle { color: var(--text-muted); }
+.lyra-v2 .deck .slide--content .slide__label { color: var(--accent); }
+.lyra-v2 .deck .slide--content .slide__heading {
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+.lyra-v2 .deck .slide--content li::before { color: var(--accent); }
+.lyra-v2 .deck .slide--section .slide__number {
+  color: var(--accent);
+  opacity: 0.1;
+}
+.lyra-v2 .deck .slide--closing {
+  background-image:
+    radial-gradient(ellipse at 50% 70%, var(--accent-glow) 0%, transparent 60%),
+    linear-gradient(to top, var(--bg), var(--bg-panel));
+}
+.lyra-v2 .deck .slide--closing .slide__heading {
+  color: var(--accent);
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--closing .cta {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+  border: none;
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--quote .slide__quote-mark { color: var(--accent); }
+.lyra-v2 .deck .slide--comparison .slide__col.accent {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+}
+
+
+/* fd-engine.css — static rules for the fd-engine canvas, nodes, edges, card variants
+ * Inlined into generated HTML output at generation time (not linked at runtime).
+ * No viewBox / no preserveAspectRatio on the SVG overlay (AC-10).
+ * Self-bootstrapping: the :root block below maps each internal short-name token to a
+ *   universal forge aesthetic token with a hard fallback. Works on lyra-v2, cool-dark,
+ *   editorial, and all other aesthetics — no per-aesthetic shim needed.
+ * Plane CSS vars (--fd-plane-{name}) default below; aesthetic layer may override.
+ */
+
+/* ---- Token contract: self-bootstrapping short-name aliases ---- */
+/* fd-engine.css is inlined AFTER the aesthetic, so these :root declarations run last.
+ *
+ * Two mapping strategies:
+ *   A) fd short-name ≠ aesthetic token name → var(--universal-name, #hex)
+ *      The aesthetic's universal token wins; hard hex = lyra-v2 dark fallback.
+ *   B) fd short-name = aesthetic token name (--cyan, --amber, --slate, …) →
+ *      hard hex fallback only (no self-referential var()); aesthetics that already
+ *      declare the token will have their value replaced by the same hex here — safe
+ *      because we target the same colour. Aesthetics that omit the token get the
+ *      fallback, which is what we want.
+ *
+ * Regression note for roxabi.css (defines --panel:#13191f, no --bg-panel):
+ *   --panel → var(--bg-panel, #13191f) → bg-panel absent → #13191f = unchanged. ✓ */
+:root {
+  /* Strategy A: fd name ≠ aesthetic universal name */
+  --panel:  var(--bg-panel,   #13191f);
+  --panel2: var(--bg-card,    #161b22);
+  --bd2:    var(--border-hi,  #30363d);
+  --mut:    var(--text-muted, #8b93a1);
+  --mut2:   var(--text-dim,   #6b7280);
+  --mono:   var(--font-mono,  "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+  --sans:   var(--font-sans,  "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif);
+  --vio:    var(--plum,       #a855f7);
+  --emer:   var(--green,      #10b981);
+  /* Strategy B: fd name = aesthetic token name — hard fallback, no self-ref var() */
+  --slate:  #64748b;
+  --amber:  #f59e0b;
+  --cyan:   #22d3ee;
+  --sky:    #58a6ff;
+  --orng:   #fb923c;
+  --rose:   #fb7185;
+}
+
+/* ---- Plane color defaults (overridden by aesthetic inlines) ---- */
+:root {
+  --fd-plane-control:  #38bdf8;
+  --fd-plane-write:    #34d399;
+  --fd-plane-read:     #64748b;
+  --fd-plane-data:     #a78bfa;
+  --fd-plane-async:    #fb923c;
+  --fd-plane-feedback: #fb7185;
+  --fd-plane-message:  #38bdf8;
+  --fd-plane-media:    #fbbf24;
+  --fd-plane-llm:      #a78bfa;
+  --fd-canvas-h:       720px;
+}
+
+/* ---- Canvas container ---- */
+.fd-canvas {
+  position: relative;
+  width: 100%;
+  height: var(--fd-canvas-h, 720px);
+}
+
+/* ---- SVG overlay (AC-10: no viewBox, no preserveAspectRatio) ---- */
+.fd-edges {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+  z-index: 1;
+}
+
+/* ---- Edge path base rules ---- */
+.fd-edges path {
+  fill: none;
+  stroke-width: 1.8;
+  opacity: .62;
+  transition: opacity .15s, stroke-width .15s;
+}
+
+/* ---- Per-plane stroke colors ---- */
+.fd-edges path.control  { stroke: var(--fd-plane-control);  }
+.fd-edges path.write    { stroke: var(--fd-plane-write);    }
+.fd-edges path.read     { stroke: var(--fd-plane-read);     }
+.fd-edges path.data     { stroke: var(--fd-plane-data);     }
+.fd-edges path.async    { stroke: var(--fd-plane-async);    }
+.fd-edges path.feedback { stroke: var(--fd-plane-feedback); }
+.fd-edges path.message  { stroke: var(--fd-plane-message);  }
+.fd-edges path.media    { stroke: var(--fd-plane-media);    }
+.fd-edges path.llm      { stroke: var(--fd-plane-llm);      }
+
+/* ---- Edge state classes (dimmed / hot) ---- */
+.fd-edges path.hot {
+  opacity: 1;
+  stroke-width: 3;
+}
+.fd-canvas.dimmed .fd-edges path:not(.hot) {
+  opacity: .06;
+}
+
+/* ---- Use-case edge states ---- */
+.fd-edges path.uc-active {
+  opacity: 1 !important;
+  stroke-width: 2.8 !important;
+}
+.fd-edges path.uc-done {
+  opacity: .48 !important;
+  stroke-width: 2 !important;
+}
+
+/* ---- Edge label ---- */
+.fd-elabel {
+  font-family: var(--mono);
+  font-size: 9px;
+  fill: var(--mut);
+  opacity: 0;
+}
+.fd-elabel.hot {
+  opacity: 1;
+}
+
+/* ---- Particle dot wrapper ---- */
+.fd-edges g.fd-particle-wrap {
+  filter: drop-shadow(0 0 6px var(--pcol, #38bdf8));
+}
+
+/* ---- Node base (.fd-node extends fgraph-base .fgraph-node conventions) ---- */
+/* % coordinate system: --x and --y in 0..100 range, matching fgraph-base.css */
+.fd-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  left: calc(var(--x) * 1%);
+  top: calc(var(--y) * 1%);
+  z-index: 2;
+}
+
+/* ---- Premium card (.fd-card-premium) ---- */
+/* Extracted and generalized from lyra-stack-v2.html lines 135-195.
+ * Applied to nodes with cardStyle:"premium" (architecture / hub-spoke types by default). */
+.fd-card-premium {
+  width: 154px;
+  background: linear-gradient(180deg, var(--panel), var(--panel2));
+  border: 1px solid var(--bd2);
+  border-radius: 11px;
+  padding: 9px 11px 9px 13px;
+  cursor: default;
+  transition: transform .12s, box-shadow .15s, border-color .15s;
+  box-shadow: 0 3px 14px #00000055;
+}
+
+/* Keep canvas placement — .fd-card-premium must not override .fd-node absolute coords */
+.fd-node.fd-card-premium {
+  position: absolute;
+}
+
+.fd-card-premium:hover {
+  transform: translate(-50%, -50%) translateY(-2px);
+  border-color: #3d567a;
+  box-shadow: 0 8px 26px #000a;
+}
+
+/* Accent bar (.fd-accent) — left side color stripe */
+.fd-card-premium .fd-accent {
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--slate);
+}
+
+/* Node header row */
+.fd-card-premium .fd-nh {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+/* Node name — cards.js emits .fd-title; .fd-nn kept for legacy reference output.
+   Sans title + Mono subtitle = the dual-font craft primitive (matches the
+   lyra-diagram gold standard: IBM Plex Sans title / Mono descriptor). */
+.fd-card-premium .fd-title,
+.fd-card-premium .fd-nn {
+  font-weight: 700;
+  font-size: 12px;
+  font-family: var(--sans);
+  letter-spacing: -.2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Subtitle / image line (.fd-sub) */
+.fd-card-premium .fd-sub {
+  color: var(--mut);
+  font-size: 10px;
+  font-family: var(--mono);
+  margin-top: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Description line */
+.fd-card-premium .fd-desc {
+  color: var(--mut2);
+  font-size: 10px;
+  margin-top: 3px;
+  line-height: 1.3;
+}
+
+/* Tag badge (.fd-tag) */
+.fd-tag {
+  font-size: 8.5px;
+  font-family: var(--mono);
+  font-weight: 700;
+  padding: 1.5px 5px;
+  border-radius: 5px;
+  white-space: nowrap;
+}
+
+/* Tag color variants (plane-aware) */
+.fd-tag-control  { background: #38bdf822; color: var(--fd-plane-control,  #38bdf8); }
+.fd-tag-write    { background: #34d39922; color: var(--fd-plane-write,    #34d399); }
+.fd-tag-read     { background: #64748b22; color: #9fb3cc; }
+.fd-tag-data     { background: #a78bfa22; color: var(--fd-plane-data,     #a78bfa); }
+.fd-tag-async    { background: #fb923c22; color: var(--fd-plane-async,    #fb923c); }
+.fd-tag-feedback { background: #fb718522; color: var(--fd-plane-feedback, #fb7185); }
+.fd-tag-message  { background: #38bdf822; color: var(--fd-plane-message,  #38bdf8); }
+.fd-tag-media    { background: #fbbf2422; color: var(--fd-plane-media,    #fbbf24); }
+.fd-tag-llm      { background: #a78bfa22; color: var(--fd-plane-llm,      #a78bfa); }
+.fd-tag-base     { background: #34d39922; color: var(--emer); }
+.fd-tag-base-svc { background: #38bdf822; color: var(--sky);  }
+.fd-tag-ml-base  { background: #a78bfa22; color: var(--vio);  }
+.fd-tag-cuda     { background: #fb923c22; color: var(--orng); }
+.fd-tag-upstream { background: #64748b22; color: #9fb3cc;     }
+.fd-tag-internal { background: #38bdf814; color: #7dd3fc; border: 1px solid #38bdf822; }
+
+/* Host badge (.fd-host) — bottom-right corner */
+.fd-host {
+  position: absolute;
+  right: 7px;
+  bottom: 6px;
+  font-size: 8px;
+  font-family: var(--mono);
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 20px;
+}
+.fd-host.M1 { background: #34d39915; color: var(--emer); }
+.fd-host.M2 { background: #fbbf2415; color: var(--amber); border: 1px dashed #fbbf2255; }
+
+/* ---- Node state classes ---- */
+.fd-card-premium.hot {
+  border-color: #fff3;
+  box-shadow: 0 0 0 1px #ffffff22, 0 10px 30px #000c;
+}
+
+.fd-canvas.dimmed .fd-card-premium:not(.hot) {
+  opacity: .28;
+}
+
+/* Use-case node states */
+.fd-card-premium.uc-active {
+  border-color: var(--amber) !important;
+  box-shadow: 0 0 0 2px #fbbf2444, 0 0 22px #fbbf2433, 0 6px 24px #000c !important;
+  z-index: 5;
+}
+.fd-card-premium.uc-done {
+  border-color: #fbbf2466 !important;
+  opacity: 1 !important;
+}
+
+/* Dormant node */
+.fd-card-premium.dormant {
+  opacity: .62;
+}
+.fd-card-premium.dormant .fd-title::after,
+.fd-card-premium.dormant .fd-nn::after {
+  content: " ⊘";
+  color: var(--rose);
+}
+
+/* ---- Node kind variants ---- */
+
+/* Bus node (wide horizontal bar) */
+.fd-card-premium.fd-kind-bus {
+  width: 62%;
+  max-width: 820px;
+  background: linear-gradient(90deg, #0e2233, #10283c, #0e2233);
+  border: 1.5px solid #2a6b8f;
+  box-shadow: 0 0 26px #38bdf820, inset 0 0 30px #38bdf80f;
+  padding: 11px 18px;
+}
+.fd-card-premium.fd-kind-bus .fd-accent { display: none; }
+.fd-card-premium.fd-kind-bus .fd-title,
+.fd-card-premium.fd-kind-bus .fd-nn { font-size: 13px; color: var(--cyan); }
+.fd-card-premium.fd-kind-bus .fd-nh { justify-content: flex-start; gap: 9px; }
+.fd-card-premium.fd-kind-bus .fd-subj {
+  color: var(--mut);
+  font-size: 9.5px;
+  font-family: var(--mono);
+  margin-top: 5px;
+  letter-spacing: .2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fd-card-premium.fd-kind-bus .fd-subj b { color: #bfe6ff; font-weight: 600; }
+
+/* Store node */
+.fd-card-premium.fd-kind-store {
+  width: 142px;
+  background: linear-gradient(180deg, #140e24, #110c20);
+  border-color: #2d1e4a;
+}
+.fd-card-premium.fd-kind-store .fd-accent { background: var(--vio); }
+
+/* Hub-interior sub-node */
+.fd-card-premium.fd-kind-hub-int {
+  width: 136px;
+  padding: 7px 9px 7px 11px;
+  background: linear-gradient(180deg, #0d1a2e, #0b1526);
+  border-color: #1e3555;
+}
+.fd-card-premium.fd-kind-hub-int .fd-accent { background: var(--hub-c, var(--cyan)); }
+.fd-card-premium.fd-kind-hub-int .fd-title,
+.fd-card-premium.fd-kind-hub-int .fd-nn { font-size: 11px; }
+.fd-card-premium.fd-kind-hub-int .fd-desc { font-size: 9.5px; }
+
+/* External / cloud node */
+.fd-card-premium.fd-kind-ext {
+  width: 154px;
+  background: repeating-linear-gradient(
+    135deg,
+    #0e1420, #0e1420 7px,
+    #101826 7px, #101826 14px
+  );
+  border: 1.5px dashed var(--bd2);
+}
+.fd-card-premium.fd-kind-ext .fd-accent { display: none; }
+.fd-card-premium.fd-kind-ext .fd-title,
+.fd-card-premium.fd-kind-ext .fd-nn { color: #cbd6e6; }
+
+/* ---- Zone regions ---- */
+.fd-zone {
+  position: absolute;
+  z-index: 0;
+  border-radius: 14px;
+  border: 1px dashed;
+  pointer-events: none;
+}
+.fd-zone .fd-zone-label {
+  position: absolute;
+  top: 7px;
+  left: 11px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   CRAFT QUALITY BAR — additive primitives (Phase 1)
+   Mirror of fgraph-base craft block, scoped to the fd-engine card grammar.
+   ════════════════════════════════════════════════════════════════════ */
+
+/* Ambient edge-flow — slow marching dashes (passive data/async). Self-contained
+   keyframe so fd-engine.css stays bootstrappable on its own. */
+@keyframes fg-flow { to { stroke-dashoffset: -200px; } }
+.fd-edges path.flow { stroke-dasharray: 6 4; animation: fg-flow 20s linear infinite; }
+
+/* Accent glow — add the .fd-glow modifier to a hub / hero node.
+   --glow-radius declared here too (mirror of fgraph-base) so fd-engine.css
+   bootstraps standalone; harmless duplicate when both are inlined together. */
+:root { --glow-radius: 40px; }
+.fd-card-premium.fd-glow {
+  box-shadow: 0 0 var(--glow-radius, 40px) var(--accent-glow, #38bdf833), 0 3px 14px #00000055;
+}
+
+/* Node icon slot — inline SVG glyph in the premium card header (.fd-nh). */
+.fd-card-premium .fd-ico { width: 18px; height: 18px; flex: none; color: currentColor; }
+.fd-card-premium .fd-ico svg { width: 100%; height: 100%; display: block; }
+
+
+/* fd-page-shell.css — layout chrome for gen-fd.py output (header, bar, diagram-row, sidebar) */
+
+html,
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans, "Inter", ui-sans-serif, system-ui, sans-serif);
+  -webkit-font-smoothing: antialiased;
+  line-height: 1.4;
+}
+
+.page {
+  padding: 22px 22px 60px;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 18px;
+  justify-content: space-between;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 18px;
+}
+
+.htitle h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}
+
+.htitle h1 b {
+  color: var(--cyan);
+}
+
+.htitle p {
+  margin: 5px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
+.badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 3px 9px;
+  border-radius: 20px;
+  border: 1px solid var(--border-hi);
+  color: var(--text-muted);
+}
+
+.badge.cyan {
+  border-color: rgba(34, 211, 238, 0.3);
+  background: rgba(34, 211, 238, 0.06);
+  color: var(--cyan);
+}
+
+.badge.amber {
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.06);
+  color: var(--amber);
+}
+
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.lg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 3px 9px;
+  font-family: var(--mono);
+}
+
+.lln {
+  width: 16px;
+  height: 0;
+  border-top: 2.5px solid;
+  border-radius: 2px;
+}
+
+.ctl-group {
+  display: flex;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+.ctl {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 5px 10px;
+  transition: 0.15s;
+}
+
+.ctl:hover {
+  border-color: var(--cyan);
+}
+
+.ctl.off {
+  opacity: 0.35;
+  text-decoration: line-through;
+}
+
+.uc-bar {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.uc-label {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.uc-btn {
+  cursor: pointer;
+  user-select: none;
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+}
+
+.uc-btn:hover {
+  border-color: var(--amber);
+  color: var(--text);
+}
+
+.uc-btn.active {
+  background: rgba(245, 158, 11, 0.06);
+  border-color: rgba(245, 158, 11, 0.4);
+  color: var(--amber);
+}
+
+.uc-play {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--green);
+  background: rgba(16, 185, 129, 0.06);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+}
+
+.uc-play:hover {
+  border-color: var(--green);
+}
+
+.uc-play:disabled {
+  opacity: 0.38;
+  cursor: default;
+}
+
+.uc-reset {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+  display: none;
+}
+
+.uc-reset.visible {
+  display: inline-block;
+}
+
+.uc-reset:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.diagram-row {
+  display: flex;
+  gap: 0;
+  align-items: stretch;
+  margin-bottom: 22px;
+}
+
+.stage-wrap {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+  border: 1px solid var(--border);
+  border-radius: 12px 0 0 12px;
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-cell));
+  overflow: auto;
+}
+
+.sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  border: 1px solid var(--border-hi);
+  border-left: none;
+  border-radius: 0 12px 12px 0;
+  background: var(--bg-cell);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar.hidden {
+  display: none;
+}
+
+.stage-wrap.full-width {
+  border-radius: 12px;
+}
+
+.sb-header {
+  padding: 12px 13px 9px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sb-header h4 {
+  margin: 0 0 2px;
+  font-size: 12.5px;
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+.sb-header .fd-img {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 9.5px;
+  margin-bottom: 6px;
+  word-break: break-all;
+}
+
+.sb-header dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 8px;
+}
+
+.sb-header dt {
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 9.5px;
+}
+
+.sb-header dd {
+  margin: 0;
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+.sb-header .hint {
+  color: var(--text-dim);
+  font-size: 10px;
+  font-style: italic;
+  line-height: 1.5;
+}
+
+.sb-uc {
+  padding: 11px 13px;
+  border-top: 1px solid var(--border);
+  flex: 1;
+  overflow: auto;
+  display: none;
+}
+
+.sb-uc.visible {
+  display: block;
+}
+
+.sb-uc .uc-title {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin-bottom: 7px;
+}
+
+.uc-steps-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.uc-steps-list li {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 4px 7px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  color: var(--text-dim);
+  transition: 0.15s;
+  line-height: 1.4;
+}
+
+.uc-steps-list li.step-done {
+  color: var(--green);
+  border-color: rgba(16, 185, 129, 0.15);
+  background: rgba(16, 185, 129, 0.05);
+}
+
+.uc-steps-list li.step-active {
+  color: var(--amber);
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.06);
+  box-shadow: 0 0 8px rgba(245, 158, 11, 0.12);
+}
+
+.uc-steps-list li .sn {
+  font-size: 8.5px;
+  opacity: 0.5;
+  margin-right: 4px;
+}
+
+.sb-uc .uc-desc {
+  margin-top: 9px;
+  font-size: 10px;
+  color: var(--text-muted);
+  line-height: 1.55;
+  padding-top: 9px;
+  border-top: 1px dashed var(--border);
+}
+
+.sb-uc .uc-desc b {
+  color: var(--text);
+}
+
+.fd-net-label {
+  position: absolute;
+  left: 14px;
+  top: 10px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.zone-m1 {
+  border-color: rgba(16, 185, 129, 0.25);
+  background: rgba(16, 185, 129, 0.03);
+}
+
+.zone-m1 .fd-zone-label {
+  color: rgba(16, 185, 129, 0.6);
+}
+
+.zone-m2 {
+  border-color: rgba(245, 158, 11, 0.25);
+  background: rgba(245, 158, 11, 0.04);
+}
+
+.zone-m2 .fd-zone-label {
+  color: rgba(245, 158, 11, 0.6);
+}
+
+.zone-hub {
+  border-color: rgba(56, 189, 248, 0.2);
+  background: rgba(56, 189, 248, 0.04);
+  border-style: solid;
+  border-radius: 16px;
+}
+
+.zone-hub .fd-zone-label {
+  color: rgba(56, 189, 248, 0.55);
+}
+
+.zone-stores {
+  border-color: rgba(167, 139, 250, 0.2);
+  background: rgba(167, 139, 250, 0.04);
+}
+
+.zone-stores .fd-zone-label {
+  color: rgba(167, 139, 250, 0.55);
+}
+
+.fd-canvas.hide-control .fd-edges path.control,
+.fd-canvas.hide-write .fd-edges path.write,
+.fd-canvas.hide-read .fd-edges path.read,
+.fd-canvas.hide-data .fd-edges path.data,
+.fd-canvas.hide-async .fd-edges path.async,
+.fd-canvas.hide-feedback .fd-edges path.feedback,
+.fd-canvas.hide-message .fd-edges path.message,
+.fd-canvas.hide-media .fd-edges path.media,
+.fd-canvas.hide-llm .fd-edges path.llm {
+  opacity: 0.06;
+}
+</style>
+</head>
+<body>
+<div class="page">
+
+  <header>
+    <div class="htitle">
+      <h1><b>notation.md consumers</b> — compress phases · legend pointers · legends gate · future trains (#310)</h1>
+      <p>fd-engine · architecture · lyra-v2 · declarative · 12 nodes · 11 edges · DOM-measured bezier edges</p>
+    </div>
+    <div class="badges">
+      <span class="badge cyan">fd-engine</span>
+      <span class="badge amber">architecture</span>
+      <span class="badge">lyra-v2</span>
+      <span class="badge">file:// safe</span>
+    </div>
+  </header>
+
+  <div class="bar">
+    <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center">
+      <div class="legend"><span class="lg"><span class="lln" style="border-color:var(--purple)"></span>read</span><span class="lg"><span class="lln" style="border-color:var(--cyan)"></span>control</span><span class="lg"><span class="lln" style="border-color:var(--green)"></span>write</span></div>
+      <div class="ctl-group"><span class="ctl" id="ctl-read" data-plane="read">read</span><span class="ctl" id="ctl-control" data-plane="control">control</span><span class="ctl" id="ctl-write" data-plane="write">write</span></div>
+    </div>
+    
+  </div>
+
+  <div class="diagram-row">
+    <div class="stage-wrap">
+      <div class="fd-canvas" id="fd-canvas">
+        
+        <div class="fd-zone zone-core" id="zoneCore"><span class="fd-zone-label">canonical SSoT</span></div>
+        <div class="fd-zone zone-now" id="zoneNow"><span class="fd-zone-label">this issue · #310</span></div>
+        <div class="fd-zone zone-future" id="zoneFuture"><span class="fd-zone-label">future · dashed</span></div>
+        <svg class="fd-edges" id="fd-edges" aria-hidden="true"><defs></defs></svg>
+      </div>
+    </div>
+
+    <div class="sidebar" id="fd-sidebar">
+      <div class="sb-header" id="sbHeader">
+        <h4>Hover = detail</h4>
+        <div class="hint">Hover a node to isolate its edges and see image / host / role.<br>Select a use case to animate the flow.</div>
+      </div>
+      <div class="sb-uc" id="sbUc">
+        <div class="uc-title" id="ucTitle"></div>
+        <ul class="uc-steps-list" id="ucStepsList"></ul>
+        <div class="uc-desc" id="ucDesc"></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<script type="application/json" id="fd-data">
+{
+  "type": "architecture",
+  "title": "notation.md consumers — compress phases · legend pointers · legends gate · future trains (#310)",
+  "theme": "lyra-v2",
+  "layout": "declarative",
+  "canvas": {
+    "height": 1040
+  },
+  "options": {
+    "particles": false,
+    "spotlight": true,
+    "sidebar": true
+  },
+  "nodes": [
+    {
+      "id": "notation",
+      "x": 50,
+      "y": 52,
+      "kind": "bus",
+      "n": "notation.md",
+      "img": "shared/references",
+      "d": "canonical notation glossary — always-loaded core table + lazy grammar & maintenance + reserved-variable registry",
+      "plane": "data",
+      "h": "EX",
+      "cardStyle": "premium",
+      "glow": true,
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003crect x='3' y='3' width='18' height='18' rx='2'/>\u003cpath d='M3 9h18M3 15h18M9 3v18'/>\u003c/svg>"
+    },
+    {
+      "id": "p0",
+      "x": 8.5,
+      "y": 10,
+      "kind": "default",
+      "n": "Phase 0",
+      "img": "compress",
+      "d": "existence-gated core-table load at skill invocation — no file, no glyph budget",
+      "plane": "read",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M13 2L3 14h9l-1 8 10-12h-9l1-8z'/>\u003c/svg>"
+    },
+    {
+      "id": "p3",
+      "x": 25,
+      "y": 10,
+      "kind": "default",
+      "n": "Phase 3",
+      "img": "compress",
+      "d": "Let-variable collision check against the reserved-variable registry (σ · Ω · α · β · ω · μ · τ · φ · Δ · Σ · π)",
+      "plane": "control",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003ccircle cx='12' cy='12' r='10'/>\u003cpath d='M12 8v4l3 3'/>\u003c/svg>"
+    },
+    {
+      "id": "p5",
+      "x": 41.5,
+      "y": 10,
+      "kind": "default",
+      "n": "Phase 5",
+      "img": "compress",
+      "d": "assert every emitted symbol ∈ core table ∨ Let-defined — no free coinage escapes",
+      "plane": "control",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M9 11l3 3L22 4'/>\u003cpath d='M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11'/>\u003c/svg>"
+    },
+    {
+      "id": "base",
+      "x": 58.5,
+      "y": 10,
+      "kind": "default",
+      "n": "base.md:16",
+      "img": "dev-core",
+      "d": "agent legend replaced by a one-line pointer to notation.md",
+      "plane": "read",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'/>\u003cpath d='M14 2v6h6'/>\u003c/svg>"
+    },
+    {
+      "id": "docw",
+      "x": 75,
+      "y": 10,
+      "kind": "default",
+      "n": "doc-writer",
+      "img": "dev-core :51",
+      "d": "doc-writer.md legend replaced by a one-line pointer to notation.md",
+      "plane": "read",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 20h9'/>\u003cpath d='M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z'/>\u003c/svg>"
+    },
+    {
+      "id": "vp",
+      "x": 91.5,
+      "y": 10,
+      "kind": "default",
+      "n": "legends gate",
+      "img": "validate_plugins",
+      "d": "--check notation-legends — gate a: both legends are one-line pointers; gate b: SKILL.md whitelist ≡ core table",
+      "plane": "control",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M22 11.08V12a10 10 0 1 1-5.93-9.14'/>\u003cpath d='M22 4L12 14.01l-3-3'/>\u003c/svg>"
+    },
+    {
+      "id": "t311",
+      "x": 10,
+      "y": 88,
+      "kind": "default",
+      "n": "#311 gloss",
+      "img": "read-back",
+      "d": "read-back gloss compliance — enforce mandatory-gloss markers on decompression",
+      "plane": "read",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z'/>\u003ccircle cx='12' cy='12' r='3'/>\u003c/svg>"
+    },
+    {
+      "id": "t312",
+      "x": 30,
+      "y": 88,
+      "kind": "default",
+      "n": "#312 lint",
+      "img": "lint mode",
+      "d": "lint vs glossary — flag notation drift between documents and the glossary",
+      "plane": "read",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003ccircle cx='11' cy='11' r='8'/>\u003cpath d='M21 21l-4.35-4.35'/>\u003c/svg>"
+    },
+    {
+      "id": "t313",
+      "x": 50,
+      "y": 88,
+      "kind": "default",
+      "n": "#313 derive",
+      "img": "R12",
+      "d": "derive R12 emissions — new-glyph proposals routed through the maintenance policy",
+      "plane": "write",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 5v14M5 12l7 7 7-7'/>\u003c/svg>"
+    },
+    {
+      "id": "dinit",
+      "x": 70,
+      "y": 88,
+      "kind": "default",
+      "n": "dev-init",
+      "img": "follow-up",
+      "d": "dev-init base.md legend repointing — tracked as a follow-up issue",
+      "plane": "read",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003ccircle cx='12' cy='12' r='10'/>\u003cpath d='M12 8v8M8 12h8'/>\u003c/svg>"
+    },
+    {
+      "id": "cortex",
+      "x": 90,
+      "y": 88,
+      "kind": "ext",
+      "n": "cortex",
+      "img": "roxabi-cortex",
+      "d": "vocabulary-governance mechanics — future alignment with the exocortex",
+      "plane": "read",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003ccircle cx='12' cy='12' r='9'/>\u003cpath d='M12 3a9 9 0 0 0 0 18M3.5 9h17M3.5 15h17'/>\u003c/svg>"
+    }
+  ],
+  "edges": [
+    {
+      "f": "p0",
+      "t": "notation",
+      "plane": "read",
+      "label": "existence-gated core load"
+    },
+    {
+      "f": "p3",
+      "t": "notation",
+      "plane": "control",
+      "label": "Let collision vs registry"
+    },
+    {
+      "f": "p5",
+      "t": "notation",
+      "plane": "control",
+      "label": "symbol ∈ core ∨ Let"
+    },
+    {
+      "f": "base",
+      "t": "notation",
+      "plane": "read",
+      "label": "one-line pointer"
+    },
+    {
+      "f": "docw",
+      "t": "notation",
+      "plane": "read",
+      "label": "one-line pointer"
+    },
+    {
+      "f": "vp",
+      "t": "notation",
+      "plane": "control",
+      "label": "gates a + b"
+    },
+    {
+      "f": "t311",
+      "t": "notation",
+      "plane": "read",
+      "label": "gloss compliance",
+      "flow": true
+    },
+    {
+      "f": "t312",
+      "t": "notation",
+      "plane": "read",
+      "label": "lint vs glossary",
+      "flow": true
+    },
+    {
+      "f": "t313",
+      "t": "notation",
+      "plane": "write",
+      "label": "R12 emissions → maintenance",
+      "flow": true
+    },
+    {
+      "f": "dinit",
+      "t": "notation",
+      "plane": "read",
+      "label": "legend repoint",
+      "flow": true
+    },
+    {
+      "f": "cortex",
+      "t": "notation",
+      "plane": "read",
+      "label": "vocabulary governance",
+      "flow": true
+    }
+  ],
+  "zones": [
+    {
+      "id": "zoneCore",
+      "nodes": [
+        "notation"
+      ],
+      "class": "zone-core",
+      "label": "canonical SSoT",
+      "padding": {
+        "top": 48
+      }
+    },
+    {
+      "id": "zoneNow",
+      "nodes": [
+        "p0",
+        "p3",
+        "p5",
+        "base",
+        "docw",
+        "vp"
+      ],
+      "class": "zone-now",
+      "label": "this issue · #310",
+      "padding": {
+        "top": 48
+      }
+    },
+    {
+      "id": "zoneFuture",
+      "nodes": [
+        "t311",
+        "t312",
+        "t313",
+        "dinit",
+        "cortex"
+      ],
+      "class": "zone-future",
+      "label": "future · dashed",
+      "padding": {
+        "top": 48
+      }
+    }
+  ]
+}
+</script>
+
+<script>
+(function(){
+'use strict'
+
+/* ── fd/core.js ── */
+// fd/core.js — geometry core: rect, pairKey, faceFor, portAnchor, stubLen
+// Lifted verbatim from lyra-stack-v2.html lines 492-534 and generalized for
+// descriptor-driven fd-engine contract.
+// Concat order: core.js FIRST (edges.js depends on names defined here).
+// NOTE: all vars/functions here are intentionally "unused" in isolation —
+// they are consumed by edges.js and other fd/ modules via bundler concat.
+
+var nodeEl = {} // id → DOM element map, populated by initEngine
+var canvas = null // .fd-canvas element ref
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var svg = null // .fd-edges SVG overlay element ref
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var paths = [] // one SVG <path> per deduped pair
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var pathByPair = new Map() // pairKey → SVG <path>
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var DESCRIPTOR = null // full descriptor object set by initEngine
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var NS = 'http://www.w3.org/2000/svg'
+
+// ---- Geometry helpers (verbatim lift from lyra-stack-v2.html l.492-534) ----
+
+// l.492-495: canvas-relative rect for a node by id
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function rect(id) {
+  var el = nodeEl[id]
+  var cr = canvas.getBoundingClientRect()
+  var b = el.getBoundingClientRect()
+  return { cx: b.left - cr.left + b.width / 2, cy: b.top - cr.top + b.height / 2, w: b.width, h: b.height }
+}
+
+// l.498: canonical (unordered) key for a node pair
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function pairKey(a, b) {
+  return [a, b].sort().join('|')
+}
+
+// l.501-514: face selection — source exits toward target, target enters from opposite
+// Keeps srcFace / dstFace per-edge overrides from descriptor
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function faceFor(dx, dy, isSource, edge) {
+  if (edge) {
+    if (isSource && edge.srcFace) return edge.srcFace
+    if (!isSource && edge.dstFace) return edge.dstFace
+  }
+  if (Math.abs(dy) >= Math.abs(dx)) {
+    if (isSource) return dy > 0 ? 'bottom' : 'top'
+    else return dy > 0 ? 'top' : 'bottom'
+  } else {
+    if (isSource) return dx > 0 ? 'right' : 'left'
+    else return dx > 0 ? 'left' : 'right'
+  }
+}
+
+// l.516-528: port anchor — spreads slots evenly across the chosen face
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function portAnchor(r, face, slotIdx, slotCount) {
+  var cx = r.cx,
+    cy = r.cy,
+    w = r.w,
+    h = r.h
+  var hw = w / 2,
+    hh = h / 2
+  var faceLen = face === 'top' || face === 'bottom' ? w : h
+  var spread = Math.min(faceLen * 0.55, slotCount * 16)
+  var step = slotCount > 1 ? spread / (slotCount - 1) : 0
+  var offset = slotCount > 1 ? -spread / 2 + slotIdx * step : 0
+  switch (face) {
+    case 'top':
+      return { x: cx + offset, y: cy - hh, nx: 0, ny: -1 }
+    case 'bottom':
+      return { x: cx + offset, y: cy + hh, nx: 0, ny: 1 }
+    case 'left':
+      return { x: cx - hw, y: cy + offset, nx: -1, ny: 0 }
+    case 'right':
+      return { x: cx + hw, y: cy + offset, nx: 1, ny: 0 }
+  }
+}
+
+// l.531-534: proportional bezier offset — clamp(dist * 0.35, 30, 220)
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function stubLen(dx, dy) {
+  var dist = Math.sqrt(dx * dx + dy * dy)
+  return Math.max(30, Math.min(220, dist * 0.35))
+}
+
+// ---- Engine initializer ----
+// Called once at DOMContentLoaded by the generated output script.
+// descriptor: parsed fd-data JSON
+// canvasEl:   .fd-canvas DOM element
+// svgEl:      .fd-edges SVG overlay element
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — entry point called by generated HTML */
+function initEngine(descriptor, canvasEl, svgEl) {
+  DESCRIPTOR = descriptor
+  canvas = canvasEl
+  svg = svgEl
+  nodeEl = {}
+  paths = []
+  pathByPair = new Map()
+
+  // Apply canvas height from descriptor (default 720px via CSS --fd-canvas-h)
+  if (descriptor.canvas?.height) {
+    canvasEl.style.setProperty('--fd-canvas-h', `${descriptor.canvas.height}px`)
+  }
+}
+
+
+/* ── fd/edges.js ── */
+// fd/edges.js — edge drawing layer: draw(), redraw(), initMarkers(), ResizeObserver
+// Lifted verbatim and generalized from lyra-stack-v2.html lines 537-626 + l.960.
+// Depends on names from core.js (concat order: core.js MUST precede this file).
+// Plane colors: derived from descriptor.edges[i].plane via CSS vars --fd-plane-{name},
+// never hardcoded hex.
+
+// ---- Marker injection ----
+// Creates one <marker id="fd-arr-{plane}"> per unique semantic plane.
+// fill uses an injected SVG <style> rule binding CSS var per plane.
+// planes: array of unique plane name strings (e.g. ['message','llm','media'])
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function initMarkers(planes) {
+  var defs = svg.querySelector('defs')
+  if (!defs) {
+    defs = document.createElementNS(NS, 'defs')
+    svg.insertBefore(defs, svg.firstChild)
+  }
+  // Inject a <style> block into the SVG for plane fill vars (one per plane)
+  var styleEl = document.createElementNS(NS, 'style')
+  var cssRules = planes.map((pl) => `#fd-arr-${pl} path { fill: var(--fd-plane-${pl}, #8aa0bd); }`).join('\n')
+  styleEl.textContent = cssRules
+  defs.appendChild(styleEl)
+
+  planes.forEach((pl) => {
+    // Skip if marker already exists (idempotent re-init guard)
+    if (svg.querySelector(`#fd-arr-${pl}`)) return
+    var marker = document.createElementNS(NS, 'marker')
+    marker.setAttribute('id', `fd-arr-${pl}`)
+    marker.setAttribute('markerWidth', '9')
+    marker.setAttribute('markerHeight', '9')
+    marker.setAttribute('refX', '7')
+    marker.setAttribute('refY', '3')
+    marker.setAttribute('orient', 'auto')
+    // NO preserveAspectRatio — AC-10 compliance (no viewBox either)
+    var arrow = document.createElementNS(NS, 'path')
+    arrow.setAttribute('d', 'M0,0 L7,3 L0,6 Z')
+    // fill resolved via the injected CSS var rule above
+    marker.appendChild(arrow)
+    defs.appendChild(marker)
+  })
+}
+
+// ---- Full edge pass ----
+// Verbatim-adapted from lyra-stack-v2.html l.537-626.
+// Reads DESCRIPTOR.edges (set by initEngine). Uses nodeEl, canvas, svg, paths,
+// pathByPair from core.js module scope.
+function draw() {
+  // Clear all existing paths, labels, circles from the SVG overlay
+  svg.querySelectorAll(':scope > path, :scope > text, :scope > circle, :scope > g').forEach((n) => {
+    n.remove()
+  })
+  paths = []
+  pathByPair.clear()
+
+  var EDGES = DESCRIPTOR.edges || []
+
+  // --- Step 1: deduplicate EDGES into unique pairs -------------------------
+  // For each unordered pair keep: plane of first occurrence, label if any,
+  // canonical source (f), for slot allocation.
+  var seenPairs = new Map() // pairKey → {f, t, plane, lab, edge, edgeIndices:[]}
+  var i, e, k
+  for (i = 0; i < EDGES.length; i++) {
+    e = EDGES[i]
+    k = pairKey(e.f, e.t)
+    if (!seenPairs.has(k)) {
+      seenPairs.set(k, {
+        f: e.f,
+        t: e.t,
+        plane: e.plane,
+        lab: e.label || null,
+        edge: e,
+        flow: !!e.flow,
+        edgeIndices: [i],
+      })
+    } else {
+      seenPairs.get(k).edgeIndices.push(i)
+      // upgrade label if this occurrence has one and first didn't
+      if (e.label && !seenPairs.get(k).lab) seenPairs.get(k).lab = e.label
+      // upgrade flow if ANY occurrence of the pair requests it (dedup keeps the first edge only)
+      if (e.flow) seenPairs.get(k).flow = true
+    }
+  }
+  var dedupedEdges = Array.from(seenPairs.values()) // array of unique pairs
+
+  // --- Step 2: build port maps over deduped edges -------------------------
+  // Key: "nodeId:face" → [pairIdx in dedupedEdges]
+  var portMap = new Map()
+  var ref, f, t, edge, rf, rt, dx, dy, fFace, tFace, fk, tk
+  for (i = 0; i < dedupedEdges.length; i++) {
+    ref = dedupedEdges[i]
+    f = ref.f
+    t = ref.t
+    edge = ref.edge
+    rf = rect(f)
+    rt = rect(t)
+    dx = rt.cx - rf.cx
+    dy = rt.cy - rf.cy
+    fFace = faceFor(dx, dy, true, edge)
+    tFace = faceFor(dx, dy, false, edge)
+    fk = `${f}:${fFace}`
+    tk = `${t}:${tFace}`
+    if (!portMap.has(fk)) portMap.set(fk, [])
+    if (!portMap.has(tk)) portMap.set(tk, [])
+    portMap.get(fk).push(i)
+    portMap.get(tk).push(i)
+  }
+
+  // --- Step 3: draw one path per deduplicated pair ------------------------
+  var plane, lab, fSlots, tSlots, fi, ti, pu1, pu2, stb, c1x, c1y, c2x, c2y, dStr, p, tx2, mx, my
+  for (i = 0; i < dedupedEdges.length; i++) {
+    ref = dedupedEdges[i]
+    f = ref.f
+    t = ref.t
+    plane = ref.plane
+    lab = ref.lab
+    edge = ref.edge
+    rf = rect(f)
+    rt = rect(t)
+    dx = rt.cx - rf.cx
+    dy = rt.cy - rf.cy
+
+    fFace = faceFor(dx, dy, true, edge)
+    tFace = faceFor(dx, dy, false, edge)
+    fk = `${f}:${fFace}`
+    tk = `${t}:${tFace}`
+
+    fSlots = portMap.get(fk)
+    tSlots = portMap.get(tk)
+    fi = fSlots.indexOf(i)
+    ti = tSlots.indexOf(i)
+
+    pu1 = portAnchor(rf, fFace, fi, fSlots.length)
+    pu2 = portAnchor(rt, tFace, ti, tSlots.length)
+
+    // Proportional stub: longer links curve more (verbatim l.592-598)
+    stb = stubLen(dx, dy)
+    c1x = pu1.x + pu1.nx * stb
+    c1y = pu1.y + pu1.ny * stb
+    c2x = pu2.x + pu2.nx * stb
+    c2y = pu2.y + pu2.ny * stb
+
+    dStr =
+      `M${pu1.x.toFixed(1)},${pu1.y.toFixed(1)}` +
+      ` C${c1x.toFixed(1)},${c1y.toFixed(1)}` +
+      ` ${c2x.toFixed(1)},${c2y.toFixed(1)}` +
+      ` ${pu2.x.toFixed(1)},${pu2.y.toFixed(1)}`
+
+    p = document.createElementNS(NS, 'path')
+    p.setAttribute('d', dStr)
+    // CSS class = plane name → stroke resolved via .fd-edges path.{plane} in fd-engine.css
+    // edge.flow → append .flow for the ambient marching-dash animation (craft bar).
+    // ref.flow is set if ANY occurrence of the deduped pair requested flow.
+    p.setAttribute('class', ref.flow ? `${plane} flow` : plane)
+    // Arrowhead marker per plane — no hardcoded hex, color via CSS var in marker's injected style
+    p.setAttribute('marker-end', `url(#fd-arr-${plane})`)
+    // Data attributes for spotlight + particle matching
+    p.dataset.f = f
+    p.dataset.t = t
+    p.dataset.pk = pairKey(f, t)
+    svg.appendChild(p)
+    paths.push(p)
+    pathByPair.set(pairKey(f, t), p)
+
+    // Edge label (de Casteljau midpoint — verbatim l.613-624)
+    if (lab) {
+      tx2 = document.createElementNS(NS, 'text')
+      mx = 0.125 * pu1.x + 0.375 * c1x + 0.375 * c2x + 0.125 * pu2.x
+      my = 0.125 * pu1.y + 0.375 * c1y + 0.375 * c2y + 0.125 * pu2.y
+      tx2.setAttribute('x', mx.toFixed(1))
+      tx2.setAttribute('y', (my - 4).toFixed(1))
+      tx2.setAttribute('text-anchor', 'middle')
+      tx2.setAttribute('class', 'fd-elabel')
+      tx2.dataset.pk = pairKey(f, t)
+      tx2.textContent = lab
+      svg.appendChild(tx2)
+    }
+  }
+}
+
+// ---- Redraw: re-runs full edge pass + optional zone placement ----
+// Called by ResizeObserver and any layout-changing event.
+function redraw() {
+  draw()
+  // If a placeZones function is defined (by architecture.js type module), call it
+  if (typeof placeZones === 'function') placeZones(DESCRIPTOR)
+}
+
+// ---- ResizeObserver wiring ----
+// Called from initEngine after DOM is ready.
+// Verbatim from lyra-stack-v2.html l.960 — adapted to fd-engine naming.
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function wireResize() {
+  new ResizeObserver(redraw).observe(canvas)
+}
+
+// ---- Unique plane list helper ----
+// Derives the set of plane names from descriptor.edges for initMarkers call.
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function uniquePlanes() {
+  var planes = []
+  var seen = {}
+  var EDGES = DESCRIPTOR?.edges || []
+  var i, pl
+  for (i = 0; i < EDGES.length; i++) {
+    pl = EDGES[i].plane
+    if (pl && !seen[pl]) {
+      seen[pl] = true
+      planes.push(pl)
+    }
+  }
+  return planes
+}
+
+
+/* ── fd/cards.js ── */
+// fd/cards.js — Layer 1: node renderer
+// Concat order: core.js → cards.js → architecture.js
+// Depends on: nodeEl (map), canvas (element) — declared in core.js scope
+
+// ── kind → fgraph-base.css shape class mapping ────────────────────────
+const KIND_SHAPE = {
+  bus: 'pill',
+  broker: 'pill',
+  router: 'pill',
+  agent: 'hexagon',
+  worker: 'hexagon',
+  trigger: 'circle',
+  event: 'circle',
+  database: 'cylinder',
+  storage: 'cylinder',
+  store: 'cylinder',
+  queue: 'cylinder',
+  decision: 'diamond',
+  gate: 'diamond',
+  file: 'folded',
+  config: 'folded',
+  document: 'folded',
+}
+
+// ── kind → tone class mapping (fgraph-base.css tone modifiers) ────────
+const KIND_TONE = {
+  bus: 'cyan',
+  broker: 'cyan',
+  router: 'cyan',
+  agent: 'amber',
+  worker: 'amber',
+  trigger: 'green',
+  event: 'green',
+  database: 'purple',
+  storage: 'purple',
+  store: 'purple',
+  queue: 'purple',
+  decision: 'red',
+  gate: 'red',
+  // hub-int accent defaults to --hub-c (cyan fallback) per fd-engine.css line 290
+  'hub-int': 'cyan',
+}
+
+// ── host badge label normalisation ────────────────────────────────────
+function hostLabel(raw) {
+  if (!raw) return null
+  if (raw === 'M1') return 'M₁'
+  if (raw === 'M2') return 'M₂'
+  if (raw === 'EX') return 'External'
+  return raw
+}
+
+// ── premium card HTML ──────────────────────────────────────────────────
+// .fd-card-premium structure:
+//   .fd-accent  — left accent bar (color via --fd-plane-{plane} or --fd-tone-{kind})
+//   .fd-nh      — flex header row: .fd-title + .fd-tag (plane-coloured badge)
+//   .fd-sub     — node.d  (subtitle / description, optional)
+//   .fd-host    — node.h  (host badge, optional; 'EX' = external, no badge per SKILL.md)
+function buildPremiumCard(node) {
+  const accentVar = node.plane
+    ? `var(--fd-plane-${node.plane}, var(--fd-tone-${node.kind || 'default'}, var(--text-dim)))`
+    : `var(--fd-tone-${node.kind || 'default'}, var(--text-dim))`
+
+  const tagPlane = node.plane || 'control'
+  // node.img holds the tag badge text; emits fd-tag-{plane} for colour variant
+  const tag = node.img ? `<div class="fd-tag fd-tag-${tagPlane}">${node.img}</div>` : ''
+  const sub = node.d ? `<div class="fd-sub">${node.d}</div>` : ''
+  // node.icon holds an inline <svg> string — rendered in the header icon slot (craft bar)
+  const ico = node.icon ? `<span class="fd-ico">${node.icon}</span>` : ''
+  // h='EX' = external, no badge (SKILL.md spec)
+  const hb = node.h && node.h !== 'EX' ? `<div class="fd-host ${node.h}">${hostLabel(node.h)}</div>` : ''
+
+  return (
+    `<span class="fd-accent" style="background:${accentVar}"></span>` +
+    `<div class="fd-nh">${ico}<div class="fd-title">${node.n}</div>${tag}</div>` +
+    sub +
+    hb
+  )
+}
+
+// ── simple card HTML ───────────────────────────────────────────────────
+function buildSimpleCard(node) {
+  const sub = node.d ? `<div class="fd-sub">${node.d}</div>` : ''
+  return `<div class="fd-title">${node.n}</div>${sub}`
+}
+
+// ── renderNode ────────────────────────────────────────────────────────
+// node        — descriptor node object
+// typeDefault — 'premium' | 'simple' | undefined (from types/{type}.js CARD_DEFAULT)
+// Returns the created element (also populates nodeEl[node.id]).
+function renderNode(node, typeDefault) {
+  const el = document.createElement('div')
+
+  // base classes
+  let cls = 'fgraph-node fd-node'
+
+  // fd-kind-{kind} class — used by fd-engine.css kind-variant rules
+  if (node.kind) cls += ` fd-kind-${node.kind}`
+
+  // shape class from kind
+  const shape = KIND_SHAPE[node.kind]
+  if (shape) cls += ` ${shape}`
+
+  // tone class from kind
+  const tone = KIND_TONE[node.kind]
+  if (tone) cls += ` ${tone}`
+
+  el.className = cls
+  el.dataset.id = node.id
+
+  // position: CSS var convention matching fgraph-base.css (--x, --y in 0..100 % space)
+  el.style.setProperty('--x', node.x)
+  el.style.setProperty('--y', node.y)
+
+  // card style resolution: per-node override (highest) → typeDefault → 'simple' fallback (RD-3)
+  const style = node.cardStyle || typeDefault || 'simple'
+
+  if (style === 'premium') {
+    el.classList.add('fd-card-premium')
+    // node.glow → accent halo on hub / hero cards (craft bar)
+    if (node.glow) el.classList.add('fd-glow')
+    el.innerHTML = buildPremiumCard(node)
+  } else {
+    el.innerHTML = buildSimpleCard(node)
+  }
+
+  // register in shared nodeEl map (declared in core.js scope)
+  nodeEl[node.id] = el
+
+  return el
+}
+
+// ── renderNodes ───────────────────────────────────────────────────────
+// descriptor — full fd-data descriptor object
+// typeDefault comes from types/{type}.js via the init() call
+// biome-ignore lint/correctness/noUnusedVariables: called by core.js in concat bundle
+function renderNodes(descriptor, typeDefault) {
+  const nodes = descriptor.nodes || []
+  for (const node of nodes) {
+    const el = renderNode(node, typeDefault)
+    canvas.appendChild(el)
+  }
+}
+
+
+/* ── fd/particles.js ── */
+// fd/particles.js — Layer 4: rAF particle engine
+// Lifted verbatim from lyra-stack-v2.html lines 628-691 and adapted for
+// the fd-engine descriptor-driven contract (RD-2).
+//
+// Opt-in contract (RD-2):
+//   descriptor.options.particles === false (default) → particles OFF (AC-9)
+//   descriptor.options.particles === true  → one-shot per edge on hover/UC trigger
+//   descriptor.options.particles === "loop" → continuous: spawnParticle() loops on active edges
+//
+// Concat order: core.js → edges.js → cards.js → particles.js → [interactions.js] → types/{type}.js
+// Depends on: NS, svg, pathByPair, pairKey — declared in core.js / edges.js scope.
+//
+// Guard: zero occurrences of the banned lowercase token in this file.
+// Self-check: grep -rn '\bmermaid\b' plugins/forge/ must be empty.
+
+function easeInOutCubic(t) {
+  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2
+}
+
+// Active particle state — one particle at a time (one-shot mode)
+// Loop mode tracks multiple particles via loopParticles[]
+let _particleEl = null
+let _particleRAF = null
+let _loopParticles = [] // [{wrapper, rafId}] — loop mode only
+
+function clearParticle() {
+  if (_particleRAF) {
+    cancelAnimationFrame(_particleRAF)
+    _particleRAF = null
+  }
+  if (_particleEl) {
+    _particleEl.remove()
+    _particleEl = null
+  }
+}
+
+// clearLoopParticles: stop all loop-mode particles
+function clearLoopParticles() {
+  for (let i = 0; i < _loopParticles.length; i++) {
+    const lp = _loopParticles[i]
+    if (lp.rafId) cancelAnimationFrame(lp.rafId)
+    if (lp.wrapper) lp.wrapper.remove()
+  }
+  _loopParticles = []
+}
+
+// ── spawnParticle ─────────────────────────────────────────────────────────
+// Lifted verbatim from lyra-stack-v2.html l.640-691, adapted for fd-engine:
+//   - plane color resolved via CSS var --fd-plane-{plane} (AC-6, never hardcoded hex)
+//   - particle wrapper class: fd-particle-wrap (matches fd-architecture.html CSS)
+//   - forward direction: pathEl.dataset.f === edgeF (verbatim from source)
+//
+// edgeF, edgeT: node ids of the edge endpoints (directional for forward/reverse)
+// plane:        semantic plane string ('control', 'write', etc.)
+// duration:     animation duration in ms (default 750, per spec)
+// onDone:       optional callback invoked when animation completes (for loop scheduling)
+//
+function spawnParticle(edgeF, edgeT, plane, duration, onDone) {
+  const dur = duration || 750
+  const pk = pairKey(edgeF, edgeT)
+  const pathEl = pathByPair.get(pk)
+  if (!pathEl) return null
+
+  // Resolve color from CSS var (theme-aware, AC-6)
+  // Fallback chain: --fd-plane-{plane} → #8aa0bd (muted default)
+  let col = '#8aa0bd'
+  const tmp = document.documentElement
+  const resolved = getComputedStyle(tmp).getPropertyValue(`--fd-plane-${plane}`).trim()
+  if (resolved) col = resolved
+
+  const forward = pathEl.dataset.f === edgeF
+  const len = pathEl.getTotalLength()
+
+  // Build halo + core inside a <g class="fd-particle-wrap"> (verbatim structure l.664-673)
+  const wrapper = document.createElementNS(NS, 'g')
+  wrapper.setAttribute('class', 'fd-particle-wrap')
+  wrapper.style.setProperty('--pcol', col)
+
+  const halo = document.createElementNS(NS, 'circle')
+  halo.setAttribute('r', '9')
+  halo.setAttribute('fill', col)
+  halo.setAttribute('opacity', '0.22')
+
+  const core = document.createElementNS(NS, 'circle')
+  core.setAttribute('r', '5')
+  core.setAttribute('fill', col)
+
+  wrapper.appendChild(halo)
+  wrapper.appendChild(core)
+  svg.appendChild(wrapper)
+
+  const start = performance.now()
+
+  function frame(now) {
+    const u = Math.min((now - start) / dur, 1)
+    const e = easeInOutCubic(u)
+    const d = forward ? e * len : (1 - e) * len
+    const pt = pathEl.getPointAtLength(d)
+    halo.setAttribute('cx', pt.x)
+    halo.setAttribute('cy', pt.y)
+    core.setAttribute('cx', pt.x)
+    core.setAttribute('cy', pt.y)
+    if (u < 1) {
+      return requestAnimationFrame(frame)
+    }
+    if (typeof onDone === 'function') onDone()
+    return null
+  }
+
+  const rafId = requestAnimationFrame(frame)
+  return { wrapper, rafId }
+}
+
+// ── startParticles / stopParticles (loop mode) ────────────────────────────
+// Called by the engine bootstrap when descriptor.options.particles === "loop".
+// Runs spawnParticle() continuously on all active edges, recycling on completion.
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function startParticles(descriptor) {
+  clearLoopParticles()
+  const edges = descriptor?.edges || []
+  if (!edges.length) return
+
+  // Loop: spawn one particle per edge in sequence, recycling each on completion
+  function spawnLoop(edgeIdx) {
+    const e = edges[edgeIdx % edges.length]
+    const plane = e.plane || 'control'
+    const lp = { wrapper: null, rafId: null }
+    _loopParticles.push(lp)
+
+    function onDone() {
+      if (lp.wrapper) lp.wrapper.remove()
+      // Re-spawn after a brief gap (50ms), cycling through edges
+      setTimeout(() => {
+        const nextIdx = (edgeIdx + 1) % edges.length
+        spawnLoop(nextIdx)
+      }, 50)
+    }
+
+    const result = spawnParticle(e.f, e.t, plane, 750, onDone)
+    if (result) {
+      lp.wrapper = result.wrapper
+      lp.rafId = result.rafId
+    }
+  }
+
+  // Stagger initial spawns across edges
+  edges.forEach((_e, i) => {
+    setTimeout(() => {
+      spawnLoop(i)
+    }, i * 180)
+  })
+}
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function stopParticles() {
+  clearParticle()
+  clearLoopParticles()
+}
+
+
+/* ── fd/interactions.js ── */
+// fd/interactions.js — Layer 5: spotlight, use-case step sequencer, sidebar
+// Lifted from lyra-stack-v2.html lines 720-974 and adapted for the
+// fd-engine descriptor-driven contract.
+//
+// Spotlight (hover): dimmed class on canvas, hot class on touched edges + neighbor nodes.
+// Use-case animation: descriptor.useCases[] → step sequencer (play/pause/reset/replay).
+// Sidebar: optional (descriptor.options.sidebar); falls back gracefully when absent.
+//
+// Concat order: core.js → edges.js → cards.js → particles.js → interactions.js → types/{type}.js
+// Depends on: canvas, nodeEl, paths, pathByPair, pairKey, svg — core.js/edges.js scope.
+//             spawnParticle, clearParticle — particles.js scope.
+//             DESCRIPTOR — core.js scope.
+//
+// Guard: zero occurrences of the banned lowercase token in this file.
+
+// ── spotlight (hover) ─────────────────────────────────────────────────────
+// Adapted from lyra-stack-v2.html l.720-751.
+// sidebar: optional; nodeData: the node descriptor object for the hovered node.
+
+function spotlight(nodeData) {
+  canvas.classList.add('dimmed')
+  const id = nodeData.id
+  const neigh = {}
+  neigh[id] = true
+
+  paths.forEach((p) => {
+    const on = p.dataset.f === id || p.dataset.t === id
+    p.classList.toggle('hot', on)
+    if (on) {
+      neigh[p.dataset.f] = true
+      neigh[p.dataset.t] = true
+    }
+  })
+
+  // edge labels follow their path
+  svg.querySelectorAll('text[data-pk]').forEach((t) => {
+    const pk = t.dataset.pk
+    const p = pathByPair.get(pk)
+    t.classList.toggle('hot', p?.classList.contains('hot') ?? false)
+  })
+
+  Object.keys(nodeEl).forEach((k) => {
+    nodeEl[k].classList.toggle('hot', !!neigh[k])
+  })
+
+  // sidebar header: update if sidebar exists
+  const sbHeader = document.getElementById('sbHeader')
+  if (sbHeader) {
+    const hostStr = !nodeData.h || nodeData.h === 'EX' ? 'external' : nodeData.h === 'M1' ? 'M&#x2081;' : 'M&#x2082;'
+    sbHeader.innerHTML =
+      `<h4>${nodeData.n}</h4>` +
+      (nodeData.img ? `<div class="fd-img">${nodeData.img}</div>` : '') +
+      `<dl><dt>plane</dt><dd>${nodeData.plane || '&#x2014;'}</dd>` +
+      `<dt>host</dt><dd>${hostStr}</dd>` +
+      `<dt>role</dt><dd>${nodeData.d || '&#x2014;'}</dd></dl>`
+  }
+}
+
+function clearSpot() {
+  canvas.classList.remove('dimmed')
+  paths.forEach((p) => {
+    p.classList.remove('hot')
+  })
+  svg.querySelectorAll('text').forEach((t) => {
+    t.classList.remove('hot')
+  })
+  Object.values(nodeEl).forEach((el) => {
+    el.classList.remove('hot')
+  })
+
+  // reset sidebar header to default hint
+  const sbHeader = document.getElementById('sbHeader')
+  if (sbHeader) {
+    sbHeader.innerHTML =
+      '<h4>Hover = detail</h4>' +
+      '<div class="hint">Hover a node to isolate its edges and see image / host / role.<br>Select a use case to animate the flow.</div>'
+  }
+}
+
+// ── use-case step sequencer ───────────────────────────────────────────────
+// Adapted from lyra-stack-v2.html l.770-974.
+// State machine: 'none' | 'ready' | 'playing' | 'paused' | 'done'
+// Only wired when descriptor.useCases is present.
+
+let _ucActiveIdx = null
+let _ucState = 'none'
+let _ucTimer = null
+let _ucStepIdx = 0
+
+function _syncUcButtons() {
+  const ucPlay = document.getElementById('ucPlay')
+  const ucReset = document.getElementById('ucReset')
+  if (!ucPlay) return
+  switch (_ucState) {
+    case 'none':
+      ucPlay.textContent = '▶ play'
+      ucPlay.disabled = true
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'ready':
+      ucPlay.textContent = '▶ play'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'playing':
+      ucPlay.textContent = '⏸ pause'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'paused':
+      ucPlay.textContent = '▶ resume'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.add('visible')
+      break
+    case 'done':
+      ucPlay.textContent = '↺ replay'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+  }
+}
+
+function _resetUcVisuals() {
+  Object.values(nodeEl).forEach((el) => {
+    el.classList.remove('uc-active', 'uc-done')
+  })
+  paths.forEach((p) => {
+    p.classList.remove('uc-active', 'uc-done')
+  })
+  canvas.classList.remove('dimmed')
+  // clear particle (particles.js)
+  if (typeof clearParticle === 'function') clearParticle()
+
+  const ucStepsList = document.getElementById('ucStepsList')
+  if (ucStepsList) {
+    ucStepsList.querySelectorAll('li').forEach((li) => {
+      li.classList.remove('step-active', 'step-done')
+    })
+  }
+}
+
+function _stopUcTimer() {
+  if (_ucTimer) {
+    clearTimeout(_ucTimer)
+    _ucTimer = null
+  }
+}
+
+function _selectUc(idx) {
+  _stopUcTimer()
+  _resetUcVisuals()
+  _ucActiveIdx = idx
+  _ucStepIdx = 0
+  _ucState = 'ready'
+
+  const uc = DESCRIPTOR.useCases[idx]
+  const ucTitle = document.getElementById('ucTitle')
+  const ucDesc = document.getElementById('ucDesc')
+  const ucStepsList = document.getElementById('ucStepsList')
+  const sbUc = document.getElementById('sbUc')
+
+  if (ucTitle) ucTitle.textContent = uc.title
+  if (ucDesc) ucDesc.innerHTML = uc.desc
+  if (ucStepsList) {
+    ucStepsList.innerHTML = ''
+    uc.steps.forEach((s, i) => {
+      const li = document.createElement('li')
+      li.innerHTML = `<span class="sn">${String(i + 1).padStart(2, '0')}</span>${s.label}`
+      ucStepsList.appendChild(li)
+    })
+  }
+  if (sbUc) sbUc.classList.add('visible')
+
+  document.querySelectorAll('.uc-btn').forEach((b) => {
+    b.classList.toggle('active', Number(b.dataset.uc) === idx)
+  })
+  _syncUcButtons()
+}
+
+function _applyUcStep(stepIdx) {
+  const uc = DESCRIPTOR.useCases[_ucActiveIdx]
+  if (stepIdx >= uc.steps.length) {
+    _ucState = 'done'
+    _syncUcButtons()
+    return
+  }
+  _ucStepIdx = stepIdx
+  const step = uc.steps[stepIdx]
+  canvas.classList.add('dimmed')
+
+  // mark previous steps done (verbatim from lyra-stack-v2)
+  for (let i = 0; i < stepIdx; i++) {
+    uc.steps[i].nodes.forEach((id) => {
+      if (nodeEl[id]) {
+        nodeEl[id].classList.remove('uc-active')
+        nodeEl[id].classList.add('uc-done')
+      }
+    })
+    if (uc.steps[i].edge) {
+      const prevEf = uc.steps[i].edge[0]
+      const prevEt = uc.steps[i].edge[1]
+      const prevPp = pathByPair.get(pairKey(prevEf, prevEt))
+      if (prevPp) {
+        prevPp.classList.remove('uc-active')
+        prevPp.classList.add('uc-done')
+      }
+    }
+  }
+
+  // activate current step nodes
+  step.nodes.forEach((id) => {
+    if (nodeEl[id]) nodeEl[id].classList.add('uc-active', 'hot')
+  })
+
+  // activate edge + spawn particle if particles opt-in
+  if (typeof clearParticle === 'function') clearParticle()
+  if (step.edge) {
+    const ef = step.edge[0]
+    const et = step.edge[1]
+    const pp = pathByPair.get(pairKey(ef, et))
+    if (pp) {
+      pp.classList.add('uc-active', 'hot')
+      // spawn particle if particles enabled and spawnParticle available
+      if (typeof spawnParticle === 'function' && DESCRIPTOR.options && DESCRIPTOR.options.particles !== false) {
+        // Find plane from edges
+        const edges = DESCRIPTOR.edges || []
+        let edgeDef = null
+        for (let j = 0; j < edges.length; j++) {
+          const ed = edges[j]
+          if ((ed.f === ef && ed.t === et) || (ed.f === et && ed.t === ef)) {
+            edgeDef = ed
+            break
+          }
+        }
+        const plane = edgeDef ? edgeDef.plane : 'control'
+        spawnParticle(ef, et, plane, 750, null)
+      }
+    }
+  }
+
+  // update step list
+  const ucStepsList = document.getElementById('ucStepsList')
+  if (ucStepsList) {
+    const items = ucStepsList.querySelectorAll('li')
+    items.forEach((li, i) => {
+      li.classList.remove('step-active', 'step-done')
+      if (i < stepIdx) li.classList.add('step-done')
+      if (i === stepIdx) li.classList.add('step-active')
+    })
+  }
+
+  // sidebar header: show step label
+  const sbHeader = document.getElementById('sbHeader')
+  const firstId = step.nodes[0]
+  if (firstId && nodeEl[firstId] && sbHeader) {
+    const nodes = DESCRIPTOR.nodes || []
+    let nd = null
+    for (let k = 0; k < nodes.length; k++) {
+      if (nodes[k].id === firstId) {
+        nd = nodes[k]
+        break
+      }
+    }
+    if (nd && _ucState !== 'playing') {
+      spotlight(nd)
+    } else {
+      sbHeader.innerHTML = `<h4>${step.label}</h4>`
+    }
+  } else if (sbHeader) {
+    sbHeader.innerHTML = `<h4>${step.label}</h4>`
+  }
+
+  _ucTimer = setTimeout(() => {
+    _applyUcStep(stepIdx + 1)
+  }, 900)
+}
+
+// ── wireUseCaseUI ─────────────────────────────────────────────────────────
+// Called from the engine bootstrap when descriptor.useCases is present.
+// Wires up .uc-btn, #ucPlay, #ucReset DOM controls.
+// Safe to call even when some controls are absent (sidebar-less mode).
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function wireUseCaseUI() {
+  document.querySelectorAll('.uc-btn').forEach((b) => {
+    b.addEventListener('click', () => {
+      _selectUc(Number(b.dataset.uc))
+    })
+  })
+
+  const ucPlay = document.getElementById('ucPlay')
+  const ucReset = document.getElementById('ucReset')
+
+  if (ucPlay) {
+    ucPlay.addEventListener('click', () => {
+      if (_ucActiveIdx === null) return
+      if (_ucState === 'playing') {
+        _stopUcTimer()
+        _ucState = 'paused'
+        _syncUcButtons()
+      } else if (_ucState === 'done' || _ucState === 'ready') {
+        _resetUcVisuals()
+        _ucStepIdx = 0
+        _ucState = 'playing'
+        _syncUcButtons()
+        _applyUcStep(0)
+      } else if (_ucState === 'paused') {
+        _ucState = 'playing'
+        _syncUcButtons()
+        _applyUcStep(_ucStepIdx)
+      }
+    })
+  }
+
+  if (ucReset) {
+    ucReset.addEventListener('click', () => {
+      _stopUcTimer()
+      _resetUcVisuals()
+      _ucStepIdx = 0
+      _ucState = 'ready'
+      _syncUcButtons()
+    })
+  }
+}
+
+// ── wireHoverSpotlight ────────────────────────────────────────────────────
+// Adds mouseenter/mouseleave listeners to all rendered .fd-node elements.
+// Called once after renderNodes(), before draw().
+// Skips spotlight during playing state (verbatim from lyra-stack-v2 l.480-482).
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function wireHoverSpotlight() {
+  const nodes = DESCRIPTOR.nodes || []
+  nodes.forEach((nd) => {
+    const el = nodeEl[nd.id]
+    if (!el) return
+    el.addEventListener('mouseenter', () => {
+      if (_ucState !== 'playing') spotlight(nd)
+    })
+    el.addEventListener('mouseleave', () => {
+      if (_ucState !== 'playing') clearSpot()
+    })
+  })
+}
+
+
+/* ── fd/architecture.js ── */
+// fd/types/architecture.js — declarative layout handler + zone placement
+// Glob-discovery: bundler.js discovers this file via glob('fd/types/*.js').
+// Exports TYPE so bundler can key it: window.__fdTypes[TYPE] = { CARD_DEFAULT, placeZones, init }
+
+const TYPE = 'architecture'
+const CARD_DEFAULT = 'premium' // RD-3: architecture/hub-spoke default is premium
+
+// ── placeZones ────────────────────────────────────────────────────────
+// Generalised from lyra-stack-v2.html placeZone() lines 693–718.
+// Parametric over descriptor.zones[] instead of hardcoded ids.
+//
+// For each zone:
+//   1. Collect rect() measurements for all member nodes.
+//   2. Compute union bounding box (min/max of cx±w/2, cy±h/2) + padding.
+//   3. Apply left/top/width/height to zone div#{zone.id} (bare id — no prefix added).
+//   4. Create the zone div if absent (class: fd-zone + zone.class).
+//
+// Zone descriptor id == HTML element id: zone.id = "zone-forge" → getElementById("zone-forge").
+// rect() is declared in core.js scope (concat order: core.js, cards.js, architecture.js).
+function zonePadding(zone) {
+  const p = zone.padding || {}
+  if (zone.class === 'zone-hub') {
+    return { x: p.x ?? 14, yt: p.top ?? 36, yb: p.bottom ?? 12 }
+  }
+  if (zone.class === 'zone-stores') {
+    return { x: p.x ?? 14, yt: p.top ?? 20, yb: p.bottom ?? 10 }
+  }
+  if (zone.class === 'zone-m2') {
+    return { x: p.x ?? 16, yt: p.top ?? 20, yb: p.bottom ?? 12 }
+  }
+  return { x: p.x ?? 16, yt: p.top ?? 20, yb: p.bottom ?? 12 }
+}
+
+function placeZones(descriptor) {
+  const zones = descriptor.zones
+  if (!zones || zones.length === 0) return
+
+  for (const zone of zones) {
+    // resolve or create zone div — bare zone.id, no prefix added
+    let zEl = document.getElementById(zone.id)
+    if (!zEl) {
+      zEl = document.createElement('div')
+      zEl.id = zone.id
+      let cls = 'fd-zone'
+      if (zone.class) cls += ` ${zone.class}`
+      zEl.className = cls
+
+      // inject zone label if provided
+      if (zone.label) {
+        const lbl = document.createElement('span')
+        lbl.className = 'fd-zone-label'
+        lbl.textContent = zone.label
+        zEl.appendChild(lbl)
+      }
+
+      canvas.insertBefore(zEl, canvas.firstChild)
+    }
+
+    // measure member nodes — guard against unknown ids (node not yet rendered or missing)
+    const memberIds = zone.nodes || []
+    if (memberIds.length === 0) continue
+
+    const rects = memberIds.map((id) => (nodeEl[id] ? rect(id) : null)).filter(Boolean)
+    if (rects.length === 0) continue
+
+    // union bounding box
+    const xMin = Math.min(...rects.map((r) => r.cx - r.w / 2))
+    const xMax = Math.max(...rects.map((r) => r.cx + r.w / 2))
+    const yMin = Math.min(...rects.map((r) => r.cy - r.h / 2))
+    const yMax = Math.max(...rects.map((r) => r.cy + r.h / 2))
+
+    // Per-zone padding — mirrors lyra-stack-v2.html placeZone() (hub 26/18/14, stores 18/14/10)
+    const pad = zonePadding(zone)
+    const padX = pad.x
+    const padYT = pad.yt
+    const padYB = pad.yb
+
+    const left = xMin - padX
+    const top = yMin - padYT
+    const width = xMax + padX - left
+    const height = yMax + padYB - top
+
+    zEl.style.left = `${left}px`
+    zEl.style.top = `${top}px`
+    zEl.style.width = `${width}px`
+    zEl.style.height = `${height}px`
+  }
+}
+
+// ── init ──────────────────────────────────────────────────────────────
+// Called by the fd-engine bootstrap after parsing fd-data.
+// Returns { typeDefault, placeZones } consumed by the engine orchestrator.
+function init(descriptor) {
+  const t = descriptor.type
+  if (t !== 'architecture' && t !== 'hub-spoke') {
+    console.warn('[fd] architecture.js init() called with unexpected type:', t)
+  }
+  // layout is declarative — no elk step; x/y already in descriptor
+  return {
+    typeDefault: CARD_DEFAULT,
+    placeZones,
+  }
+}
+
+// ── glob-discovery registration ───────────────────────────────────────
+// bundler.js discovers fd/types/*.js and concatenates them into the
+// inline <script>. At runtime each type module self-registers here.
+window.__fdTypes = window.__fdTypes || {}
+window.__fdTypes[TYPE] = { CARD_DEFAULT, placeZones, init }
+// 'hub-spoke' is an alias for 'architecture'
+window.__fdTypes['hub-spoke'] = window.__fdTypes[TYPE]
+
+
+/* ── __fd window entry (generated by bundler.js) ── */
+window.__fd = {
+  initEngine: initEngine,
+  renderNodes: renderNodes,
+  draw: draw,
+  wireResize: wireResize,
+  uniquePlanes: typeof uniquePlanes !== 'undefined' ? uniquePlanes : null,
+  initMarkers: typeof initMarkers !== 'undefined' ? initMarkers : null,
+}
+})()
+
+</script>
+
+<script>
+// fd-bootstrap.js — universal runtime bootstrap for gen-fd.py output
+// Inlined after the fd-engine IIFE bundle. Expects window.__fd + window.__fdTypes.
+
+;(() => {
+  function run() {
+    var dataEl = document.getElementById('fd-data')
+    if (!dataEl || !window.__fd) return
+
+    var descriptor = JSON.parse(dataEl.textContent)
+    var canvasEl = document.getElementById('fd-canvas')
+    var svgEl = document.getElementById('fd-edges')
+    if (!canvasEl || !svgEl) return
+
+    var type = descriptor.type || 'architecture'
+    var typeReg = window.__fdTypes && window.__fdTypes[type]
+    var typeInit = typeReg && typeof typeReg.init === 'function' ? typeReg.init(descriptor) : null
+    var typeDefault = (typeInit && typeInit.typeDefault) || (typeReg && typeReg.CARD_DEFAULT) || 'premium'
+
+    if (descriptor.canvas && descriptor.canvas.height) {
+      canvasEl.style.setProperty('--fd-canvas-h', descriptor.canvas.height + 'px')
+      canvasEl.style.height = descriptor.canvas.height + 'px'
+    }
+
+    window.__fd.initEngine(descriptor, canvasEl, svgEl)
+
+    // Chart-only types (gantt, pie, xychart) bypass node/edge engine
+    if (typeReg && typeof typeReg.renderChart === 'function') {
+      typeReg.renderChart(descriptor)
+      return
+    }
+
+    window.__fd.renderNodes(descriptor, typeDefault)
+
+    if (typeInit && typeof typeInit.positionNodes === 'function') {
+      typeInit.positionNodes(descriptor)
+    } else if (typeReg && typeof typeReg.positionNodes === 'function') {
+      typeReg.positionNodes(descriptor)
+    }
+
+    if (typeInit && typeof typeInit.applyShapes === 'function') {
+      typeInit.applyShapes(descriptor)
+    } else if (typeReg && typeof typeReg.applyShapes === 'function') {
+      typeReg.applyShapes(descriptor)
+    }
+
+    if (window.__fd.initMarkers && window.__fd.uniquePlanes) {
+      window.__fd.initMarkers(window.__fd.uniquePlanes())
+    }
+
+    window.__fd.draw()
+
+    var placeZonesFn = (typeInit && typeInit.placeZones) || (typeReg && typeReg.placeZones) || null
+    if (typeof placeZonesFn === 'function') {
+      placeZonesFn(descriptor)
+    }
+
+    window.__fd.wireResize()
+
+    if (typeof wireHoverSpotlight === 'function' && descriptor.options && descriptor.options.spotlight !== false) {
+      wireHoverSpotlight()
+    }
+
+    if (typeof wireUseCaseUI === 'function' && descriptor.useCases && descriptor.useCases.length) {
+      wireUseCaseUI()
+    }
+
+    document.querySelectorAll('.ctl[data-plane]').forEach((ctl) => {
+      ctl.addEventListener('click', () => {
+        ctl.classList.toggle('off')
+        canvasEl.classList.toggle('hide-' + ctl.dataset.plane, ctl.classList.contains('off'))
+      })
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      setTimeout(run, 80)
+    })
+  } else {
+    setTimeout(run, 80)
+  }
+})()
+
+</script>
+</body>
+</html>

--- a/artifacts/visuals/310-notation-glossary-guardrails-data-flow.html
+++ b/artifacts/visuals/310-notation-glossary-guardrails-data-flow.html
@@ -1,0 +1,2732 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="diagram:title" content="#310 notation glossary guardrails — data flow">
+<meta name="diagram:category" content="architecture">
+<meta name="diagram:color" content="#22d3ee">
+<meta name="diagram:engine" content="fd-engine">
+<meta name="diagram:type" content="architecture">
+<title>#310 notation glossary guardrails — data flow</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+/* reset */
+*,*::before,*::after{box-sizing:border-box}
+html,body{margin:0;padding:0}
+ul,ol{list-style:none;margin:0;padding:0}
+button{cursor:pointer;font-family:inherit}
+
+/* ══════════════════════════════════════════════════════════════════
+   lyra-v2.css — Lyra brand aesthetic · v2 (GitHub-dark variant)
+   Used by: lyra, voicecli (v2-styled artifacts only)
+
+   Difference vs lyra.css (v1 "Forge Floor"):
+   - Surfaces rebased on GitHub-dark (#0d1117 family) with an explicit
+     elevation ladder: bg < bg-cell < bg-panel < bg-card
+   - Adds --border-hi for stronger dividers in dense data grids
+   - Accent alphas pushed (dim 0.08→0.12, glow 0.22→0.40) for more
+     "live ember" feel on cards and nodes
+   - Drops the forge-floor body chrome (spark particles + 42px grid)
+     — v2 docs are flat, data-dense, GitHub-network-graph style
+   - Adds lane palette (lane-a1..i, status-ready/blocked/done) so
+     dep-graph / kernel-arch / swimlane docs share one token set
+
+   Reference implementations:
+   - lyra-v2-dependency-graph-v5.1.html
+   - lyra-kernel-architecture-v5.html
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Brand Tokens — Dark (default, v2 only exists in dark) ── */
+:root, [data-theme="dark"] {
+  color-scheme: dark;
+
+  /* Surface elevation ladder (darkest → lightest) */
+  --bg:           #0d1117;  /* page */
+  --bg-cell:      #0f141a;  /* grid cell / recessed surface inside panel */
+  --bg-panel:     #13191f;  /* section / wrapper */
+  --bg-card:      #161b22;  /* card / raised surface inside panel */
+
+  /* Legacy aliases — keep v1 variable names working in v2 docs */
+  --surface:      #13191f;  /* alias → bg-panel */
+  --surface2:     #161b22;  /* alias → bg-card */
+
+  /* Dividers */
+  --border:       #21262d;
+  --border-hi:    #30363d;
+  --border-bright:#30363d;  /* alias → border-hi */
+
+  /* Text ramp */
+  --text:         #fafafa;
+  --text-muted:   #8b93a1;
+  --text-dim:     #6b7280;
+
+  /* Forge orange — same hue as v1, stronger alphas */
+  --accent:       #e85d04;
+  --accent-2:     #f97316;
+  --accent-dim:   rgba(232,93,4,0.12);
+  --accent-glow:  rgba(232,93,4,0.40);
+  --error:        #ef4444;
+
+  /* Extended lane palette — shared by dep-graph, kernel-arch, swimlanes */
+  --teal:    #06b6d4;  --teal-dim:   rgba(6,182,212,0.10);
+  --amber:   #f59e0b;  --amber-dim:  rgba(245,158,11,0.10);
+  --green:   #10b981;  --green-dim:  rgba(16,185,129,0.10);
+  --cyan:    #22d3ee;
+  --purple:  #c084fc;
+  --pink:    #ec4899;  --pink-dim:   rgba(236,72,153,0.10);
+  --plum:    #a855f7;  --plum-dim:   rgba(168,85,247,0.10);
+  --red:     #ef4444;  --red-dim:    rgba(239,68,68,0.10);
+
+  /* Issue / task status — for plan artifacts */
+  --status-ready:   #22c55e;
+  --status-blocked: #f97316;
+  --status-done:    #475569;
+
+  /* Lane tones — for multi-lane swim/DAG views */
+  --lane-a1: #22c55e;
+  --lane-a2: #6366f1;
+  --lane-a3: #8b5cf6;
+  --lane-b:  #3b82f6;
+  --lane-c1: #a855f7;
+  --lane-c2: #d946ef;
+  --lane-c3: #ec4899;
+  --lane-d:  #06b6d4;
+  --lane-e:  #eab308;
+  --lane-f:  #10b981;
+  --lane-g:  #f97316;
+  --lane-h:  #f59e0b;
+  --lane-i:  #14b8a6;
+}
+
+/* v2 is dark-only by design. If a doc needs a light mode, use lyra.css v1. */
+
+/* ══════════════════════════════════════════════════════════════════
+   Base page chrome — flat body, 24px gutter, 12px base type
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 body,
+body.lyra-v2 {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', system-ui, sans-serif;
+  padding: 24px;
+  min-height: 100vh;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Page header primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 header.page-header,
+body.lyra-v2 header.page-header {
+  max-width: 100%;
+  margin: 0 auto 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.lyra-v2 header.page-header h1,
+body.lyra-v2 header.page-header h1 {
+  font-family: 'Outfit', sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.lyra-v2 header.page-header h1 .accent,
+body.lyra-v2 header.page-header h1 .accent { color: var(--accent); }
+.lyra-v2 .subtitle,
+body.lyra-v2 .subtitle {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin-top: 6px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Section / panel primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 .section,
+body.lyra-v2 .section {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 18px 20px 20px;
+  position: relative;
+  overflow: hidden;
+}
+.lyra-v2 .section-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.lyra-v2 .section-title {
+  font-family: 'Outfit', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--text);
+  margin-bottom: 4px;
+  letter-spacing: -0.02em;
+}
+.lyra-v2 .section-title .accent { color: var(--accent); }
+.lyra-v2 .section-subtitle {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+  line-height: 1.45;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Card primitive — raised surface with border-left tone stripe
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 .card {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 9px 11px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-hi);
+  border-left: 3px solid currentColor;
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--text);
+  transition: background 0.15s, border-color 0.15s, transform 0.12s;
+}
+.lyra-v2 .card:hover {
+  background: var(--bg-panel);
+  border-color: currentColor;
+  transform: translateX(1px);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Footer primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 footer.page-footer {
+  margin-top: 18px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+}
+.lyra-v2 footer.page-footer a { color: var(--accent); text-decoration: none; }
+.lyra-v2 footer.page-footer a:hover { text-decoration: underline; }
+
+/* ══════════════════════════════════════════════════════════════════
+   Slide mode — lyra-v2 aesthetic (forge-slides)
+   Same flame-gradient as v1, but on the GitHub-dark ladder.
+   ══════════════════════════════════════════════════════════════════ */
+.deck.lyra-v2 .slide--title,
+.lyra-v2 .deck .slide--title {
+  background-image:
+    radial-gradient(ellipse at 50% 30%, var(--accent-glow) 0%, transparent 55%),
+    linear-gradient(135deg, var(--bg) 0%, var(--bg-panel) 100%);
+}
+.lyra-v2 .deck .slide--title .slide__display {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--title .slide__subtitle { color: var(--text-muted); }
+.lyra-v2 .deck .slide--content .slide__label { color: var(--accent); }
+.lyra-v2 .deck .slide--content .slide__heading {
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+.lyra-v2 .deck .slide--content li::before { color: var(--accent); }
+.lyra-v2 .deck .slide--section .slide__number {
+  color: var(--accent);
+  opacity: 0.1;
+}
+.lyra-v2 .deck .slide--closing {
+  background-image:
+    radial-gradient(ellipse at 50% 70%, var(--accent-glow) 0%, transparent 60%),
+    linear-gradient(to top, var(--bg), var(--bg-panel));
+}
+.lyra-v2 .deck .slide--closing .slide__heading {
+  color: var(--accent);
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--closing .cta {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+  border: none;
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--quote .slide__quote-mark { color: var(--accent); }
+.lyra-v2 .deck .slide--comparison .slide__col.accent {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+}
+
+
+/* fd-engine.css — static rules for the fd-engine canvas, nodes, edges, card variants
+ * Inlined into generated HTML output at generation time (not linked at runtime).
+ * No viewBox / no preserveAspectRatio on the SVG overlay (AC-10).
+ * Self-bootstrapping: the :root block below maps each internal short-name token to a
+ *   universal forge aesthetic token with a hard fallback. Works on lyra-v2, cool-dark,
+ *   editorial, and all other aesthetics — no per-aesthetic shim needed.
+ * Plane CSS vars (--fd-plane-{name}) default below; aesthetic layer may override.
+ */
+
+/* ---- Token contract: self-bootstrapping short-name aliases ---- */
+/* fd-engine.css is inlined AFTER the aesthetic, so these :root declarations run last.
+ *
+ * Two mapping strategies:
+ *   A) fd short-name ≠ aesthetic token name → var(--universal-name, #hex)
+ *      The aesthetic's universal token wins; hard hex = lyra-v2 dark fallback.
+ *   B) fd short-name = aesthetic token name (--cyan, --amber, --slate, …) →
+ *      hard hex fallback only (no self-referential var()); aesthetics that already
+ *      declare the token will have their value replaced by the same hex here — safe
+ *      because we target the same colour. Aesthetics that omit the token get the
+ *      fallback, which is what we want.
+ *
+ * Regression note for roxabi.css (defines --panel:#13191f, no --bg-panel):
+ *   --panel → var(--bg-panel, #13191f) → bg-panel absent → #13191f = unchanged. ✓ */
+:root {
+  /* Strategy A: fd name ≠ aesthetic universal name */
+  --panel:  var(--bg-panel,   #13191f);
+  --panel2: var(--bg-card,    #161b22);
+  --bd2:    var(--border-hi,  #30363d);
+  --mut:    var(--text-muted, #8b93a1);
+  --mut2:   var(--text-dim,   #6b7280);
+  --mono:   var(--font-mono,  "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+  --sans:   var(--font-sans,  "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif);
+  --vio:    var(--plum,       #a855f7);
+  --emer:   var(--green,      #10b981);
+  /* Strategy B: fd name = aesthetic token name — hard fallback, no self-ref var() */
+  --slate:  #64748b;
+  --amber:  #f59e0b;
+  --cyan:   #22d3ee;
+  --sky:    #58a6ff;
+  --orng:   #fb923c;
+  --rose:   #fb7185;
+}
+
+/* ---- Plane color defaults (overridden by aesthetic inlines) ---- */
+:root {
+  --fd-plane-control:  #38bdf8;
+  --fd-plane-write:    #34d399;
+  --fd-plane-read:     #64748b;
+  --fd-plane-data:     #a78bfa;
+  --fd-plane-async:    #fb923c;
+  --fd-plane-feedback: #fb7185;
+  --fd-plane-message:  #38bdf8;
+  --fd-plane-media:    #fbbf24;
+  --fd-plane-llm:      #a78bfa;
+  --fd-canvas-h:       720px;
+}
+
+/* ---- Canvas container ---- */
+.fd-canvas {
+  position: relative;
+  width: 100%;
+  height: var(--fd-canvas-h, 720px);
+}
+
+/* ---- SVG overlay (AC-10: no viewBox, no preserveAspectRatio) ---- */
+.fd-edges {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+  z-index: 1;
+}
+
+/* ---- Edge path base rules ---- */
+.fd-edges path {
+  fill: none;
+  stroke-width: 1.8;
+  opacity: .62;
+  transition: opacity .15s, stroke-width .15s;
+}
+
+/* ---- Per-plane stroke colors ---- */
+.fd-edges path.control  { stroke: var(--fd-plane-control);  }
+.fd-edges path.write    { stroke: var(--fd-plane-write);    }
+.fd-edges path.read     { stroke: var(--fd-plane-read);     }
+.fd-edges path.data     { stroke: var(--fd-plane-data);     }
+.fd-edges path.async    { stroke: var(--fd-plane-async);    }
+.fd-edges path.feedback { stroke: var(--fd-plane-feedback); }
+.fd-edges path.message  { stroke: var(--fd-plane-message);  }
+.fd-edges path.media    { stroke: var(--fd-plane-media);    }
+.fd-edges path.llm      { stroke: var(--fd-plane-llm);      }
+
+/* ---- Edge state classes (dimmed / hot) ---- */
+.fd-edges path.hot {
+  opacity: 1;
+  stroke-width: 3;
+}
+.fd-canvas.dimmed .fd-edges path:not(.hot) {
+  opacity: .06;
+}
+
+/* ---- Use-case edge states ---- */
+.fd-edges path.uc-active {
+  opacity: 1 !important;
+  stroke-width: 2.8 !important;
+}
+.fd-edges path.uc-done {
+  opacity: .48 !important;
+  stroke-width: 2 !important;
+}
+
+/* ---- Edge label ---- */
+.fd-elabel {
+  font-family: var(--mono);
+  font-size: 9px;
+  fill: var(--mut);
+  opacity: 0;
+}
+.fd-elabel.hot {
+  opacity: 1;
+}
+
+/* ---- Particle dot wrapper ---- */
+.fd-edges g.fd-particle-wrap {
+  filter: drop-shadow(0 0 6px var(--pcol, #38bdf8));
+}
+
+/* ---- Node base (.fd-node extends fgraph-base .fgraph-node conventions) ---- */
+/* % coordinate system: --x and --y in 0..100 range, matching fgraph-base.css */
+.fd-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  left: calc(var(--x) * 1%);
+  top: calc(var(--y) * 1%);
+  z-index: 2;
+}
+
+/* ---- Premium card (.fd-card-premium) ---- */
+/* Extracted and generalized from lyra-stack-v2.html lines 135-195.
+ * Applied to nodes with cardStyle:"premium" (architecture / hub-spoke types by default). */
+.fd-card-premium {
+  width: 154px;
+  background: linear-gradient(180deg, var(--panel), var(--panel2));
+  border: 1px solid var(--bd2);
+  border-radius: 11px;
+  padding: 9px 11px 9px 13px;
+  cursor: default;
+  transition: transform .12s, box-shadow .15s, border-color .15s;
+  box-shadow: 0 3px 14px #00000055;
+}
+
+/* Keep canvas placement — .fd-card-premium must not override .fd-node absolute coords */
+.fd-node.fd-card-premium {
+  position: absolute;
+}
+
+.fd-card-premium:hover {
+  transform: translate(-50%, -50%) translateY(-2px);
+  border-color: #3d567a;
+  box-shadow: 0 8px 26px #000a;
+}
+
+/* Accent bar (.fd-accent) — left side color stripe */
+.fd-card-premium .fd-accent {
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--slate);
+}
+
+/* Node header row */
+.fd-card-premium .fd-nh {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+/* Node name — cards.js emits .fd-title; .fd-nn kept for legacy reference output.
+   Sans title + Mono subtitle = the dual-font craft primitive (matches the
+   lyra-diagram gold standard: IBM Plex Sans title / Mono descriptor). */
+.fd-card-premium .fd-title,
+.fd-card-premium .fd-nn {
+  font-weight: 700;
+  font-size: 12px;
+  font-family: var(--sans);
+  letter-spacing: -.2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Subtitle / image line (.fd-sub) */
+.fd-card-premium .fd-sub {
+  color: var(--mut);
+  font-size: 10px;
+  font-family: var(--mono);
+  margin-top: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Description line */
+.fd-card-premium .fd-desc {
+  color: var(--mut2);
+  font-size: 10px;
+  margin-top: 3px;
+  line-height: 1.3;
+}
+
+/* Tag badge (.fd-tag) */
+.fd-tag {
+  font-size: 8.5px;
+  font-family: var(--mono);
+  font-weight: 700;
+  padding: 1.5px 5px;
+  border-radius: 5px;
+  white-space: nowrap;
+}
+
+/* Tag color variants (plane-aware) */
+.fd-tag-control  { background: #38bdf822; color: var(--fd-plane-control,  #38bdf8); }
+.fd-tag-write    { background: #34d39922; color: var(--fd-plane-write,    #34d399); }
+.fd-tag-read     { background: #64748b22; color: #9fb3cc; }
+.fd-tag-data     { background: #a78bfa22; color: var(--fd-plane-data,     #a78bfa); }
+.fd-tag-async    { background: #fb923c22; color: var(--fd-plane-async,    #fb923c); }
+.fd-tag-feedback { background: #fb718522; color: var(--fd-plane-feedback, #fb7185); }
+.fd-tag-message  { background: #38bdf822; color: var(--fd-plane-message,  #38bdf8); }
+.fd-tag-media    { background: #fbbf2422; color: var(--fd-plane-media,    #fbbf24); }
+.fd-tag-llm      { background: #a78bfa22; color: var(--fd-plane-llm,      #a78bfa); }
+.fd-tag-base     { background: #34d39922; color: var(--emer); }
+.fd-tag-base-svc { background: #38bdf822; color: var(--sky);  }
+.fd-tag-ml-base  { background: #a78bfa22; color: var(--vio);  }
+.fd-tag-cuda     { background: #fb923c22; color: var(--orng); }
+.fd-tag-upstream { background: #64748b22; color: #9fb3cc;     }
+.fd-tag-internal { background: #38bdf814; color: #7dd3fc; border: 1px solid #38bdf822; }
+
+/* Host badge (.fd-host) — bottom-right corner */
+.fd-host {
+  position: absolute;
+  right: 7px;
+  bottom: 6px;
+  font-size: 8px;
+  font-family: var(--mono);
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 20px;
+}
+.fd-host.M1 { background: #34d39915; color: var(--emer); }
+.fd-host.M2 { background: #fbbf2415; color: var(--amber); border: 1px dashed #fbbf2255; }
+
+/* ---- Node state classes ---- */
+.fd-card-premium.hot {
+  border-color: #fff3;
+  box-shadow: 0 0 0 1px #ffffff22, 0 10px 30px #000c;
+}
+
+.fd-canvas.dimmed .fd-card-premium:not(.hot) {
+  opacity: .28;
+}
+
+/* Use-case node states */
+.fd-card-premium.uc-active {
+  border-color: var(--amber) !important;
+  box-shadow: 0 0 0 2px #fbbf2444, 0 0 22px #fbbf2433, 0 6px 24px #000c !important;
+  z-index: 5;
+}
+.fd-card-premium.uc-done {
+  border-color: #fbbf2466 !important;
+  opacity: 1 !important;
+}
+
+/* Dormant node */
+.fd-card-premium.dormant {
+  opacity: .62;
+}
+.fd-card-premium.dormant .fd-title::after,
+.fd-card-premium.dormant .fd-nn::after {
+  content: " ⊘";
+  color: var(--rose);
+}
+
+/* ---- Node kind variants ---- */
+
+/* Bus node (wide horizontal bar) */
+.fd-card-premium.fd-kind-bus {
+  width: 62%;
+  max-width: 820px;
+  background: linear-gradient(90deg, #0e2233, #10283c, #0e2233);
+  border: 1.5px solid #2a6b8f;
+  box-shadow: 0 0 26px #38bdf820, inset 0 0 30px #38bdf80f;
+  padding: 11px 18px;
+}
+.fd-card-premium.fd-kind-bus .fd-accent { display: none; }
+.fd-card-premium.fd-kind-bus .fd-title,
+.fd-card-premium.fd-kind-bus .fd-nn { font-size: 13px; color: var(--cyan); }
+.fd-card-premium.fd-kind-bus .fd-nh { justify-content: flex-start; gap: 9px; }
+.fd-card-premium.fd-kind-bus .fd-subj {
+  color: var(--mut);
+  font-size: 9.5px;
+  font-family: var(--mono);
+  margin-top: 5px;
+  letter-spacing: .2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fd-card-premium.fd-kind-bus .fd-subj b { color: #bfe6ff; font-weight: 600; }
+
+/* Store node */
+.fd-card-premium.fd-kind-store {
+  width: 142px;
+  background: linear-gradient(180deg, #140e24, #110c20);
+  border-color: #2d1e4a;
+}
+.fd-card-premium.fd-kind-store .fd-accent { background: var(--vio); }
+
+/* Hub-interior sub-node */
+.fd-card-premium.fd-kind-hub-int {
+  width: 136px;
+  padding: 7px 9px 7px 11px;
+  background: linear-gradient(180deg, #0d1a2e, #0b1526);
+  border-color: #1e3555;
+}
+.fd-card-premium.fd-kind-hub-int .fd-accent { background: var(--hub-c, var(--cyan)); }
+.fd-card-premium.fd-kind-hub-int .fd-title,
+.fd-card-premium.fd-kind-hub-int .fd-nn { font-size: 11px; }
+.fd-card-premium.fd-kind-hub-int .fd-desc { font-size: 9.5px; }
+
+/* External / cloud node */
+.fd-card-premium.fd-kind-ext {
+  width: 154px;
+  background: repeating-linear-gradient(
+    135deg,
+    #0e1420, #0e1420 7px,
+    #101826 7px, #101826 14px
+  );
+  border: 1.5px dashed var(--bd2);
+}
+.fd-card-premium.fd-kind-ext .fd-accent { display: none; }
+.fd-card-premium.fd-kind-ext .fd-title,
+.fd-card-premium.fd-kind-ext .fd-nn { color: #cbd6e6; }
+
+/* ---- Zone regions ---- */
+.fd-zone {
+  position: absolute;
+  z-index: 0;
+  border-radius: 14px;
+  border: 1px dashed;
+  pointer-events: none;
+}
+.fd-zone .fd-zone-label {
+  position: absolute;
+  top: 7px;
+  left: 11px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   CRAFT QUALITY BAR — additive primitives (Phase 1)
+   Mirror of fgraph-base craft block, scoped to the fd-engine card grammar.
+   ════════════════════════════════════════════════════════════════════ */
+
+/* Ambient edge-flow — slow marching dashes (passive data/async). Self-contained
+   keyframe so fd-engine.css stays bootstrappable on its own. */
+@keyframes fg-flow { to { stroke-dashoffset: -200px; } }
+.fd-edges path.flow { stroke-dasharray: 6 4; animation: fg-flow 20s linear infinite; }
+
+/* Accent glow — add the .fd-glow modifier to a hub / hero node.
+   --glow-radius declared here too (mirror of fgraph-base) so fd-engine.css
+   bootstraps standalone; harmless duplicate when both are inlined together. */
+:root { --glow-radius: 40px; }
+.fd-card-premium.fd-glow {
+  box-shadow: 0 0 var(--glow-radius, 40px) var(--accent-glow, #38bdf833), 0 3px 14px #00000055;
+}
+
+/* Node icon slot — inline SVG glyph in the premium card header (.fd-nh). */
+.fd-card-premium .fd-ico { width: 18px; height: 18px; flex: none; color: currentColor; }
+.fd-card-premium .fd-ico svg { width: 100%; height: 100%; display: block; }
+
+
+/* fd-page-shell.css — layout chrome for gen-fd.py output (header, bar, diagram-row, sidebar) */
+
+html,
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans, "Inter", ui-sans-serif, system-ui, sans-serif);
+  -webkit-font-smoothing: antialiased;
+  line-height: 1.4;
+}
+
+.page {
+  padding: 22px 22px 60px;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 18px;
+  justify-content: space-between;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 18px;
+}
+
+.htitle h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}
+
+.htitle h1 b {
+  color: var(--cyan);
+}
+
+.htitle p {
+  margin: 5px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
+.badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 3px 9px;
+  border-radius: 20px;
+  border: 1px solid var(--border-hi);
+  color: var(--text-muted);
+}
+
+.badge.cyan {
+  border-color: rgba(34, 211, 238, 0.3);
+  background: rgba(34, 211, 238, 0.06);
+  color: var(--cyan);
+}
+
+.badge.amber {
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.06);
+  color: var(--amber);
+}
+
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.lg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 3px 9px;
+  font-family: var(--mono);
+}
+
+.lln {
+  width: 16px;
+  height: 0;
+  border-top: 2.5px solid;
+  border-radius: 2px;
+}
+
+.ctl-group {
+  display: flex;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+.ctl {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 5px 10px;
+  transition: 0.15s;
+}
+
+.ctl:hover {
+  border-color: var(--cyan);
+}
+
+.ctl.off {
+  opacity: 0.35;
+  text-decoration: line-through;
+}
+
+.uc-bar {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.uc-label {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.uc-btn {
+  cursor: pointer;
+  user-select: none;
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+}
+
+.uc-btn:hover {
+  border-color: var(--amber);
+  color: var(--text);
+}
+
+.uc-btn.active {
+  background: rgba(245, 158, 11, 0.06);
+  border-color: rgba(245, 158, 11, 0.4);
+  color: var(--amber);
+}
+
+.uc-play {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--green);
+  background: rgba(16, 185, 129, 0.06);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+}
+
+.uc-play:hover {
+  border-color: var(--green);
+}
+
+.uc-play:disabled {
+  opacity: 0.38;
+  cursor: default;
+}
+
+.uc-reset {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+  display: none;
+}
+
+.uc-reset.visible {
+  display: inline-block;
+}
+
+.uc-reset:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.diagram-row {
+  display: flex;
+  gap: 0;
+  align-items: stretch;
+  margin-bottom: 22px;
+}
+
+.stage-wrap {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+  border: 1px solid var(--border);
+  border-radius: 12px 0 0 12px;
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-cell));
+  overflow: auto;
+}
+
+.sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  border: 1px solid var(--border-hi);
+  border-left: none;
+  border-radius: 0 12px 12px 0;
+  background: var(--bg-cell);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar.hidden {
+  display: none;
+}
+
+.stage-wrap.full-width {
+  border-radius: 12px;
+}
+
+.sb-header {
+  padding: 12px 13px 9px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sb-header h4 {
+  margin: 0 0 2px;
+  font-size: 12.5px;
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+.sb-header .fd-img {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 9.5px;
+  margin-bottom: 6px;
+  word-break: break-all;
+}
+
+.sb-header dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 8px;
+}
+
+.sb-header dt {
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 9.5px;
+}
+
+.sb-header dd {
+  margin: 0;
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+.sb-header .hint {
+  color: var(--text-dim);
+  font-size: 10px;
+  font-style: italic;
+  line-height: 1.5;
+}
+
+.sb-uc {
+  padding: 11px 13px;
+  border-top: 1px solid var(--border);
+  flex: 1;
+  overflow: auto;
+  display: none;
+}
+
+.sb-uc.visible {
+  display: block;
+}
+
+.sb-uc .uc-title {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin-bottom: 7px;
+}
+
+.uc-steps-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.uc-steps-list li {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 4px 7px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  color: var(--text-dim);
+  transition: 0.15s;
+  line-height: 1.4;
+}
+
+.uc-steps-list li.step-done {
+  color: var(--green);
+  border-color: rgba(16, 185, 129, 0.15);
+  background: rgba(16, 185, 129, 0.05);
+}
+
+.uc-steps-list li.step-active {
+  color: var(--amber);
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.06);
+  box-shadow: 0 0 8px rgba(245, 158, 11, 0.12);
+}
+
+.uc-steps-list li .sn {
+  font-size: 8.5px;
+  opacity: 0.5;
+  margin-right: 4px;
+}
+
+.sb-uc .uc-desc {
+  margin-top: 9px;
+  font-size: 10px;
+  color: var(--text-muted);
+  line-height: 1.55;
+  padding-top: 9px;
+  border-top: 1px dashed var(--border);
+}
+
+.sb-uc .uc-desc b {
+  color: var(--text);
+}
+
+.fd-net-label {
+  position: absolute;
+  left: 14px;
+  top: 10px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.zone-m1 {
+  border-color: rgba(16, 185, 129, 0.25);
+  background: rgba(16, 185, 129, 0.03);
+}
+
+.zone-m1 .fd-zone-label {
+  color: rgba(16, 185, 129, 0.6);
+}
+
+.zone-m2 {
+  border-color: rgba(245, 158, 11, 0.25);
+  background: rgba(245, 158, 11, 0.04);
+}
+
+.zone-m2 .fd-zone-label {
+  color: rgba(245, 158, 11, 0.6);
+}
+
+.zone-hub {
+  border-color: rgba(56, 189, 248, 0.2);
+  background: rgba(56, 189, 248, 0.04);
+  border-style: solid;
+  border-radius: 16px;
+}
+
+.zone-hub .fd-zone-label {
+  color: rgba(56, 189, 248, 0.55);
+}
+
+.zone-stores {
+  border-color: rgba(167, 139, 250, 0.2);
+  background: rgba(167, 139, 250, 0.04);
+}
+
+.zone-stores .fd-zone-label {
+  color: rgba(167, 139, 250, 0.55);
+}
+
+.fd-canvas.hide-control .fd-edges path.control,
+.fd-canvas.hide-write .fd-edges path.write,
+.fd-canvas.hide-read .fd-edges path.read,
+.fd-canvas.hide-data .fd-edges path.data,
+.fd-canvas.hide-async .fd-edges path.async,
+.fd-canvas.hide-feedback .fd-edges path.feedback,
+.fd-canvas.hide-message .fd-edges path.message,
+.fd-canvas.hide-media .fd-edges path.media,
+.fd-canvas.hide-llm .fd-edges path.llm {
+  opacity: 0.06;
+}
+</style>
+</head>
+<body>
+<div class="page">
+
+  <header>
+    <div class="htitle">
+      <h1><b>#310 notation glossary guardrails</b> — data flow</h1>
+      <p>fd-engine · architecture · lyra-v2 · declarative · 17 nodes · 20 edges · DOM-measured bezier edges</p>
+    </div>
+    <div class="badges">
+      <span class="badge cyan">fd-engine</span>
+      <span class="badge amber">architecture</span>
+      <span class="badge">lyra-v2</span>
+      <span class="badge">file:// safe</span>
+    </div>
+  </header>
+
+  <div class="bar">
+    <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center">
+      <div class="legend"><span class="lg"><span class="lln" style="border-color:var(--cyan)"></span>control</span><span class="lg"><span class="lln" style="border-color:var(--plum)"></span>data</span><span class="lg"><span class="lln" style="border-color:var(--purple)"></span>read</span><span class="lg"><span class="lln" style="border-color:var(--amber)"></span>async</span><span class="lg"><span class="lln" style="border-color:var(--green)"></span>write</span><span class="lg"><span class="lln" style="border-color:var(--accent)"></span>feedback</span></div>
+      <div class="ctl-group"><span class="ctl" id="ctl-control" data-plane="control">control</span><span class="ctl" id="ctl-data" data-plane="data">data</span><span class="ctl" id="ctl-read" data-plane="read">read</span><span class="ctl" id="ctl-async" data-plane="async">async</span><span class="ctl" id="ctl-write" data-plane="write">write</span><span class="ctl" id="ctl-feedback" data-plane="feedback">feedback</span></div>
+    </div>
+    
+  </div>
+
+  <div class="diagram-row">
+    <div class="stage-wrap full-width">
+      <div class="fd-canvas" id="fd-canvas">
+        
+        <div class="fd-zone zone-hub" id="zoneRuntime"><span class="fd-zone-label">compress runtime · SKILL.md</span></div>
+        <div class="fd-zone zone-stores" id="zoneSsot"><span class="fd-zone-label">notation SSoT · plugins/shared/references</span></div>
+        <div class="fd-zone zone-m2" id="zoneDevcore"><span class="fd-zone-label">dev-core surfaces</span></div>
+        <div class="fd-zone zone-hub" id="zoneCi"><span class="fd-zone-label">CI guards · validate_plugins.py + hooks</span></div>
+        <svg class="fd-edges" id="fd-edges" aria-hidden="true"><defs></defs></svg>
+      </div>
+    </div>
+
+    <div class="sidebar hidden" id="fd-sidebar">
+      <div class="sb-header" id="sbHeader">
+        <h4>Hover = detail</h4>
+        <div class="hint">Hover a node to isolate its edges and see image / host / role.<br>Select a use case to animate the flow.</div>
+      </div>
+      <div class="sb-uc" id="sbUc">
+        <div class="uc-title" id="ucTitle"></div>
+        <ul class="uc-steps-list" id="ucStepsList"></ul>
+        <div class="uc-desc" id="ucDesc"></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<script type="application/json" id="fd-data">
+{
+  "type": "architecture",
+  "title": "#310 notation glossary guardrails — data flow",
+  "theme": "lyra-v2",
+  "layout": "declarative",
+  "canvas": {
+    "height": 880
+  },
+  "options": {
+    "particles": false,
+    "spotlight": true,
+    "sidebar": false
+  },
+  "nodes": [
+    {
+      "id": "p0gate",
+      "x": 24,
+      "y": 12,
+      "n": "Phase 0 Gate",
+      "img": "SKILL.md · Phase 0",
+      "h": "EX",
+      "d": "existence gate — does plugins/shared/references/notation.md exist?",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 3v5M12 8l-6 6v5M12 8l6 6v5'/>\u003c/svg>"
+    },
+    {
+      "id": "wlfall",
+      "x": 13,
+      "y": 32,
+      "n": "WL Fallback",
+      "img": "SKILL.md · Phase 0",
+      "h": "EX",
+      "d": "notation.md absent → whitelist-only mode from the anchor line",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z'/>\u003c/svg>"
+    },
+    {
+      "id": "coreload",
+      "x": 35,
+      "y": 32,
+      "n": "Core Load",
+      "img": "notation.md · ## Core Table",
+      "h": "EX",
+      "d": "existence-gated load of the Core Table (glyph senses + gloss)",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 3v10m0 0l-4-4m4 4l4-4M4 17v4h16v-4'/>\u003c/svg>"
+    },
+    {
+      "id": "wlline",
+      "x": 13,
+      "y": 52,
+      "n": "Whitelist:",
+      "img": "SKILL.md anchor line",
+      "h": "EX",
+      "kind": "store",
+      "d": "canonical glyph set — single anchor line, CI-matched to Core Table",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M8 6h13M8 12h13M8 18h13M3.5 6h.01M3.5 12h.01M3.5 18h.01'/>\u003c/svg>"
+    },
+    {
+      "id": "p3col",
+      "x": 35,
+      "y": 52,
+      "n": "P3 Collide",
+      "img": "SKILL.md · Phase 3",
+      "h": "EX",
+      "d": "Let-var collision check — new vars must not shadow whitelist glyphs or reserved vars",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 3L22 21H2z'/>\u003cpath d='M12 10v5M12 18h.01'/>\u003c/svg>"
+    },
+    {
+      "id": "p5asrt",
+      "x": 13,
+      "y": 72,
+      "n": "P5 Assert",
+      "img": "SKILL.md · Phase 5",
+      "h": "EX",
+      "d": "post-write assert — every emitted symbol in whitelist or glossed set",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003ccircle cx='12' cy='12' r='9'/>\u003cpath d='M8 12l3 3 5-6'/>\u003c/svg>"
+    },
+    {
+      "id": "g1flag",
+      "x": 35,
+      "y": 72,
+      "n": "G1 Flags",
+      "img": "SKILL.md · Phase 4",
+      "h": "EX",
+      "d": "polarity transform + 4-field flag schema · R1 break-even inequality",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M5 21V4h11l-2 4 2 4H5'/>\u003c/svg>"
+    },
+    {
+      "id": "grammar",
+      "x": 57,
+      "y": 16,
+      "n": "Grammar §",
+      "img": "notation.md · lazy",
+      "h": "EX",
+      "d": "composition grammar — lazy section, outside the Core Table budget",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M4 7V5h16v2M12 5v14M9 19h6'/>\u003c/svg>"
+    },
+    {
+      "id": "coretab",
+      "x": 74,
+      "y": 16,
+      "n": "Core Table",
+      "img": "notation.md · ## Core Table",
+      "h": "EX",
+      "kind": "store",
+      "glow": true,
+      "d": "glyph | senses | gloss? | fidelity warn | notes — ~150 lines + adjudication records",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003crect x='3' y='4' width='18' height='16' rx='1'/>\u003cpath d='M3 10h18M9 4v16M15 4v16'/>\u003c/svg>"
+    },
+    {
+      "id": "registry",
+      "x": 57,
+      "y": 34,
+      "n": "Registry",
+      "img": "notation.md · reserved vars",
+      "h": "EX",
+      "kind": "store",
+      "d": "reserved-var registry table — Let-var namespace guard",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M6 3h12v18l-6-4-6 4z'/>\u003c/svg>"
+    },
+    {
+      "id": "maint",
+      "x": 74,
+      "y": 34,
+      "n": "Maintenance",
+      "img": "notation.md · lazy",
+      "h": "EX",
+      "d": "maintenance section — adjudication procedure with grep counts",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M14.7 6.3a4 4 0 0 0-5.4 5.4L4 17v3h3l5.3-5.3a4 4 0 0 0 5.4-5.4L14 12l-1.7-1.7z'/>\u003c/svg>"
+    },
+    {
+      "id": "basemd",
+      "x": 90,
+      "y": 14,
+      "n": "base.md:16",
+      "img": "dev-core agents",
+      "h": "EX",
+      "d": "notation legend replaced by a one-line pointer to notation.md",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M6 3h9l4 4v14H6z'/>\u003cpath d='M15 3v4h4'/>\u003c/svg>"
+    },
+    {
+      "id": "docwrt",
+      "x": 90,
+      "y": 32,
+      "n": "doc-writer",
+      "img": "doc-writer.md:51",
+      "h": "EX",
+      "d": "notation legend replaced by a one-line pointer to notation.md",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M6 3h9l4 4v14H6z'/>\u003cpath d='M15 3v4h4'/>\u003c/svg>"
+    },
+    {
+      "id": "pjson",
+      "x": 90,
+      "y": 50,
+      "n": "plugin.json",
+      "img": "dev-core 0.8.13 → 0.8.14",
+      "h": "EX",
+      "d": "version bump ships the legend pointer swap to installed plugins",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M4 4h6l10 10-6 6L4 10z'/>\u003ccircle cx='8.5' cy='8.5' r='1.5'/>\u003c/svg>"
+    },
+    {
+      "id": "legends",
+      "x": 57,
+      "y": 80,
+      "n": "Legends Gate",
+      "img": "check_notation_legends",
+      "h": "EX",
+      "d": "gate a: pointer lines present · gate b: whitelist ≡ core-table glyph set",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z'/>\u003cpath d='M9 12l2 2 4-4'/>\u003c/svg>"
+    },
+    {
+      "id": "budget",
+      "x": 74,
+      "y": 80,
+      "n": "Line Budget",
+      "img": "skill-line-budget",
+      "h": "EX",
+      "d": "compress SKILL.md stays within ~110-line budget after G1-G4",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M3 8h18v8H3z'/>\u003cpath d='M7 8v3M11 8v3M15 8v3M19 8v3'/>\u003c/svg>"
+    },
+    {
+      "id": "vercheck",
+      "x": 90,
+      "y": 80,
+      "n": "Ver Check",
+      "img": "check-skill-version",
+      "h": "EX",
+      "d": "pre-push hook — skill change requires the version bump",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003ccircle cx='12' cy='12' r='9'/>\u003cpath d='M12 7v5l3 3'/>\u003c/svg>"
+    }
+  ],
+  "edges": [
+    {
+      "f": "p0gate",
+      "t": "coreload",
+      "plane": "control",
+      "label": "notation.md exists → load ## Core Table"
+    },
+    {
+      "f": "p0gate",
+      "t": "wlfall",
+      "plane": "control",
+      "label": "absent → Whitelist: fallback"
+    },
+    {
+      "f": "coretab",
+      "t": "coreload",
+      "plane": "data",
+      "flow": true,
+      "label": "glyph | senses | gloss rows",
+      "srcFace": "left"
+    },
+    {
+      "f": "wlline",
+      "t": "wlfall",
+      "plane": "data",
+      "label": "canonical glyph set"
+    },
+    {
+      "f": "coreload",
+      "t": "p3col",
+      "plane": "control",
+      "label": "active set → Phase 3"
+    },
+    {
+      "f": "wlfall",
+      "t": "p3col",
+      "plane": "control",
+      "label": "fallback set → Phase 3"
+    },
+    {
+      "f": "registry",
+      "t": "p3col",
+      "plane": "read",
+      "label": "reserved Let-vars"
+    },
+    {
+      "f": "p3col",
+      "t": "g1flag",
+      "plane": "control",
+      "label": "Phase 3 → Phase 4"
+    },
+    {
+      "f": "g1flag",
+      "t": "p5asrt",
+      "plane": "control",
+      "label": "flags emitted → Phase 5"
+    },
+    {
+      "f": "wlline",
+      "t": "p5asrt",
+      "plane": "read",
+      "label": "assert glyphs in whitelist + gloss"
+    },
+    {
+      "f": "grammar",
+      "t": "coretab",
+      "plane": "async",
+      "flow": true,
+      "label": "lazy section load"
+    },
+    {
+      "f": "maint",
+      "t": "coretab",
+      "plane": "write",
+      "label": "adjudication records"
+    },
+    {
+      "f": "basemd",
+      "t": "coretab",
+      "plane": "read",
+      "flow": true,
+      "label": "one-line pointer legend"
+    },
+    {
+      "f": "docwrt",
+      "t": "coretab",
+      "plane": "read",
+      "flow": true,
+      "label": "one-line pointer legend"
+    },
+    {
+      "f": "legends",
+      "t": "basemd",
+      "plane": "feedback",
+      "label": "gate a: pointer line",
+      "dstFace": "left"
+    },
+    {
+      "f": "legends",
+      "t": "docwrt",
+      "plane": "feedback",
+      "label": "gate a: pointer line",
+      "dstFace": "left"
+    },
+    {
+      "f": "legends",
+      "t": "wlline",
+      "plane": "feedback",
+      "label": "gate b: whitelist set",
+      "srcFace": "left",
+      "dstFace": "right"
+    },
+    {
+      "f": "legends",
+      "t": "coretab",
+      "plane": "feedback",
+      "label": "gate b: col-1 backtick set-equality",
+      "srcFace": "top",
+      "dstFace": "bottom"
+    },
+    {
+      "f": "budget",
+      "t": "wlline",
+      "plane": "feedback",
+      "label": "SKILL.md ≤ 110-line budget",
+      "srcFace": "left",
+      "dstFace": "right"
+    },
+    {
+      "f": "vercheck",
+      "t": "pjson",
+      "plane": "feedback",
+      "label": "pre-push: 0.8.13 → 0.8.14"
+    }
+  ],
+  "zones": [
+    {
+      "id": "zoneRuntime",
+      "class": "zone-hub",
+      "label": "compress runtime · SKILL.md",
+      "padding": {
+        "top": 48
+      },
+      "nodes": [
+        "p0gate",
+        "wlfall",
+        "coreload",
+        "wlline",
+        "p3col",
+        "p5asrt",
+        "g1flag"
+      ]
+    },
+    {
+      "id": "zoneSsot",
+      "class": "zone-stores",
+      "label": "notation SSoT · plugins/shared/references",
+      "padding": {
+        "top": 48
+      },
+      "nodes": [
+        "grammar",
+        "coretab",
+        "registry",
+        "maint"
+      ]
+    },
+    {
+      "id": "zoneDevcore",
+      "class": "zone-m2",
+      "label": "dev-core surfaces",
+      "padding": {
+        "top": 48
+      },
+      "nodes": [
+        "basemd",
+        "docwrt",
+        "pjson"
+      ]
+    },
+    {
+      "id": "zoneCi",
+      "class": "zone-hub",
+      "label": "CI guards · validate_plugins.py + hooks",
+      "padding": {
+        "top": 48
+      },
+      "nodes": [
+        "legends",
+        "budget",
+        "vercheck"
+      ]
+    }
+  ]
+}
+</script>
+
+<script>
+(function(){
+'use strict'
+
+/* ── fd/core.js ── */
+// fd/core.js — geometry core: rect, pairKey, faceFor, portAnchor, stubLen
+// Lifted verbatim from lyra-stack-v2.html lines 492-534 and generalized for
+// descriptor-driven fd-engine contract.
+// Concat order: core.js FIRST (edges.js depends on names defined here).
+// NOTE: all vars/functions here are intentionally "unused" in isolation —
+// they are consumed by edges.js and other fd/ modules via bundler concat.
+
+var nodeEl = {} // id → DOM element map, populated by initEngine
+var canvas = null // .fd-canvas element ref
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var svg = null // .fd-edges SVG overlay element ref
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var paths = [] // one SVG <path> per deduped pair
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var pathByPair = new Map() // pairKey → SVG <path>
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var DESCRIPTOR = null // full descriptor object set by initEngine
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var NS = 'http://www.w3.org/2000/svg'
+
+// ---- Geometry helpers (verbatim lift from lyra-stack-v2.html l.492-534) ----
+
+// l.492-495: canvas-relative rect for a node by id
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function rect(id) {
+  var el = nodeEl[id]
+  var cr = canvas.getBoundingClientRect()
+  var b = el.getBoundingClientRect()
+  return { cx: b.left - cr.left + b.width / 2, cy: b.top - cr.top + b.height / 2, w: b.width, h: b.height }
+}
+
+// l.498: canonical (unordered) key for a node pair
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function pairKey(a, b) {
+  return [a, b].sort().join('|')
+}
+
+// l.501-514: face selection — source exits toward target, target enters from opposite
+// Keeps srcFace / dstFace per-edge overrides from descriptor
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function faceFor(dx, dy, isSource, edge) {
+  if (edge) {
+    if (isSource && edge.srcFace) return edge.srcFace
+    if (!isSource && edge.dstFace) return edge.dstFace
+  }
+  if (Math.abs(dy) >= Math.abs(dx)) {
+    if (isSource) return dy > 0 ? 'bottom' : 'top'
+    else return dy > 0 ? 'top' : 'bottom'
+  } else {
+    if (isSource) return dx > 0 ? 'right' : 'left'
+    else return dx > 0 ? 'left' : 'right'
+  }
+}
+
+// l.516-528: port anchor — spreads slots evenly across the chosen face
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function portAnchor(r, face, slotIdx, slotCount) {
+  var cx = r.cx,
+    cy = r.cy,
+    w = r.w,
+    h = r.h
+  var hw = w / 2,
+    hh = h / 2
+  var faceLen = face === 'top' || face === 'bottom' ? w : h
+  var spread = Math.min(faceLen * 0.55, slotCount * 16)
+  var step = slotCount > 1 ? spread / (slotCount - 1) : 0
+  var offset = slotCount > 1 ? -spread / 2 + slotIdx * step : 0
+  switch (face) {
+    case 'top':
+      return { x: cx + offset, y: cy - hh, nx: 0, ny: -1 }
+    case 'bottom':
+      return { x: cx + offset, y: cy + hh, nx: 0, ny: 1 }
+    case 'left':
+      return { x: cx - hw, y: cy + offset, nx: -1, ny: 0 }
+    case 'right':
+      return { x: cx + hw, y: cy + offset, nx: 1, ny: 0 }
+  }
+}
+
+// l.531-534: proportional bezier offset — clamp(dist * 0.35, 30, 220)
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function stubLen(dx, dy) {
+  var dist = Math.sqrt(dx * dx + dy * dy)
+  return Math.max(30, Math.min(220, dist * 0.35))
+}
+
+// ---- Engine initializer ----
+// Called once at DOMContentLoaded by the generated output script.
+// descriptor: parsed fd-data JSON
+// canvasEl:   .fd-canvas DOM element
+// svgEl:      .fd-edges SVG overlay element
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — entry point called by generated HTML */
+function initEngine(descriptor, canvasEl, svgEl) {
+  DESCRIPTOR = descriptor
+  canvas = canvasEl
+  svg = svgEl
+  nodeEl = {}
+  paths = []
+  pathByPair = new Map()
+
+  // Apply canvas height from descriptor (default 720px via CSS --fd-canvas-h)
+  if (descriptor.canvas?.height) {
+    canvasEl.style.setProperty('--fd-canvas-h', `${descriptor.canvas.height}px`)
+  }
+}
+
+
+/* ── fd/edges.js ── */
+// fd/edges.js — edge drawing layer: draw(), redraw(), initMarkers(), ResizeObserver
+// Lifted verbatim and generalized from lyra-stack-v2.html lines 537-626 + l.960.
+// Depends on names from core.js (concat order: core.js MUST precede this file).
+// Plane colors: derived from descriptor.edges[i].plane via CSS vars --fd-plane-{name},
+// never hardcoded hex.
+
+// ---- Marker injection ----
+// Creates one <marker id="fd-arr-{plane}"> per unique semantic plane.
+// fill uses an injected SVG <style> rule binding CSS var per plane.
+// planes: array of unique plane name strings (e.g. ['message','llm','media'])
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function initMarkers(planes) {
+  var defs = svg.querySelector('defs')
+  if (!defs) {
+    defs = document.createElementNS(NS, 'defs')
+    svg.insertBefore(defs, svg.firstChild)
+  }
+  // Inject a <style> block into the SVG for plane fill vars (one per plane)
+  var styleEl = document.createElementNS(NS, 'style')
+  var cssRules = planes.map((pl) => `#fd-arr-${pl} path { fill: var(--fd-plane-${pl}, #8aa0bd); }`).join('\n')
+  styleEl.textContent = cssRules
+  defs.appendChild(styleEl)
+
+  planes.forEach((pl) => {
+    // Skip if marker already exists (idempotent re-init guard)
+    if (svg.querySelector(`#fd-arr-${pl}`)) return
+    var marker = document.createElementNS(NS, 'marker')
+    marker.setAttribute('id', `fd-arr-${pl}`)
+    marker.setAttribute('markerWidth', '9')
+    marker.setAttribute('markerHeight', '9')
+    marker.setAttribute('refX', '7')
+    marker.setAttribute('refY', '3')
+    marker.setAttribute('orient', 'auto')
+    // NO preserveAspectRatio — AC-10 compliance (no viewBox either)
+    var arrow = document.createElementNS(NS, 'path')
+    arrow.setAttribute('d', 'M0,0 L7,3 L0,6 Z')
+    // fill resolved via the injected CSS var rule above
+    marker.appendChild(arrow)
+    defs.appendChild(marker)
+  })
+}
+
+// ---- Full edge pass ----
+// Verbatim-adapted from lyra-stack-v2.html l.537-626.
+// Reads DESCRIPTOR.edges (set by initEngine). Uses nodeEl, canvas, svg, paths,
+// pathByPair from core.js module scope.
+function draw() {
+  // Clear all existing paths, labels, circles from the SVG overlay
+  svg.querySelectorAll(':scope > path, :scope > text, :scope > circle, :scope > g').forEach((n) => {
+    n.remove()
+  })
+  paths = []
+  pathByPair.clear()
+
+  var EDGES = DESCRIPTOR.edges || []
+
+  // --- Step 1: deduplicate EDGES into unique pairs -------------------------
+  // For each unordered pair keep: plane of first occurrence, label if any,
+  // canonical source (f), for slot allocation.
+  var seenPairs = new Map() // pairKey → {f, t, plane, lab, edge, edgeIndices:[]}
+  var i, e, k
+  for (i = 0; i < EDGES.length; i++) {
+    e = EDGES[i]
+    k = pairKey(e.f, e.t)
+    if (!seenPairs.has(k)) {
+      seenPairs.set(k, {
+        f: e.f,
+        t: e.t,
+        plane: e.plane,
+        lab: e.label || null,
+        edge: e,
+        flow: !!e.flow,
+        edgeIndices: [i],
+      })
+    } else {
+      seenPairs.get(k).edgeIndices.push(i)
+      // upgrade label if this occurrence has one and first didn't
+      if (e.label && !seenPairs.get(k).lab) seenPairs.get(k).lab = e.label
+      // upgrade flow if ANY occurrence of the pair requests it (dedup keeps the first edge only)
+      if (e.flow) seenPairs.get(k).flow = true
+    }
+  }
+  var dedupedEdges = Array.from(seenPairs.values()) // array of unique pairs
+
+  // --- Step 2: build port maps over deduped edges -------------------------
+  // Key: "nodeId:face" → [pairIdx in dedupedEdges]
+  var portMap = new Map()
+  var ref, f, t, edge, rf, rt, dx, dy, fFace, tFace, fk, tk
+  for (i = 0; i < dedupedEdges.length; i++) {
+    ref = dedupedEdges[i]
+    f = ref.f
+    t = ref.t
+    edge = ref.edge
+    rf = rect(f)
+    rt = rect(t)
+    dx = rt.cx - rf.cx
+    dy = rt.cy - rf.cy
+    fFace = faceFor(dx, dy, true, edge)
+    tFace = faceFor(dx, dy, false, edge)
+    fk = `${f}:${fFace}`
+    tk = `${t}:${tFace}`
+    if (!portMap.has(fk)) portMap.set(fk, [])
+    if (!portMap.has(tk)) portMap.set(tk, [])
+    portMap.get(fk).push(i)
+    portMap.get(tk).push(i)
+  }
+
+  // --- Step 3: draw one path per deduplicated pair ------------------------
+  var plane, lab, fSlots, tSlots, fi, ti, pu1, pu2, stb, c1x, c1y, c2x, c2y, dStr, p, tx2, mx, my
+  for (i = 0; i < dedupedEdges.length; i++) {
+    ref = dedupedEdges[i]
+    f = ref.f
+    t = ref.t
+    plane = ref.plane
+    lab = ref.lab
+    edge = ref.edge
+    rf = rect(f)
+    rt = rect(t)
+    dx = rt.cx - rf.cx
+    dy = rt.cy - rf.cy
+
+    fFace = faceFor(dx, dy, true, edge)
+    tFace = faceFor(dx, dy, false, edge)
+    fk = `${f}:${fFace}`
+    tk = `${t}:${tFace}`
+
+    fSlots = portMap.get(fk)
+    tSlots = portMap.get(tk)
+    fi = fSlots.indexOf(i)
+    ti = tSlots.indexOf(i)
+
+    pu1 = portAnchor(rf, fFace, fi, fSlots.length)
+    pu2 = portAnchor(rt, tFace, ti, tSlots.length)
+
+    // Proportional stub: longer links curve more (verbatim l.592-598)
+    stb = stubLen(dx, dy)
+    c1x = pu1.x + pu1.nx * stb
+    c1y = pu1.y + pu1.ny * stb
+    c2x = pu2.x + pu2.nx * stb
+    c2y = pu2.y + pu2.ny * stb
+
+    dStr =
+      `M${pu1.x.toFixed(1)},${pu1.y.toFixed(1)}` +
+      ` C${c1x.toFixed(1)},${c1y.toFixed(1)}` +
+      ` ${c2x.toFixed(1)},${c2y.toFixed(1)}` +
+      ` ${pu2.x.toFixed(1)},${pu2.y.toFixed(1)}`
+
+    p = document.createElementNS(NS, 'path')
+    p.setAttribute('d', dStr)
+    // CSS class = plane name → stroke resolved via .fd-edges path.{plane} in fd-engine.css
+    // edge.flow → append .flow for the ambient marching-dash animation (craft bar).
+    // ref.flow is set if ANY occurrence of the deduped pair requested flow.
+    p.setAttribute('class', ref.flow ? `${plane} flow` : plane)
+    // Arrowhead marker per plane — no hardcoded hex, color via CSS var in marker's injected style
+    p.setAttribute('marker-end', `url(#fd-arr-${plane})`)
+    // Data attributes for spotlight + particle matching
+    p.dataset.f = f
+    p.dataset.t = t
+    p.dataset.pk = pairKey(f, t)
+    svg.appendChild(p)
+    paths.push(p)
+    pathByPair.set(pairKey(f, t), p)
+
+    // Edge label (de Casteljau midpoint — verbatim l.613-624)
+    if (lab) {
+      tx2 = document.createElementNS(NS, 'text')
+      mx = 0.125 * pu1.x + 0.375 * c1x + 0.375 * c2x + 0.125 * pu2.x
+      my = 0.125 * pu1.y + 0.375 * c1y + 0.375 * c2y + 0.125 * pu2.y
+      tx2.setAttribute('x', mx.toFixed(1))
+      tx2.setAttribute('y', (my - 4).toFixed(1))
+      tx2.setAttribute('text-anchor', 'middle')
+      tx2.setAttribute('class', 'fd-elabel')
+      tx2.dataset.pk = pairKey(f, t)
+      tx2.textContent = lab
+      svg.appendChild(tx2)
+    }
+  }
+}
+
+// ---- Redraw: re-runs full edge pass + optional zone placement ----
+// Called by ResizeObserver and any layout-changing event.
+function redraw() {
+  draw()
+  // If a placeZones function is defined (by architecture.js type module), call it
+  if (typeof placeZones === 'function') placeZones(DESCRIPTOR)
+}
+
+// ---- ResizeObserver wiring ----
+// Called from initEngine after DOM is ready.
+// Verbatim from lyra-stack-v2.html l.960 — adapted to fd-engine naming.
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function wireResize() {
+  new ResizeObserver(redraw).observe(canvas)
+}
+
+// ---- Unique plane list helper ----
+// Derives the set of plane names from descriptor.edges for initMarkers call.
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function uniquePlanes() {
+  var planes = []
+  var seen = {}
+  var EDGES = DESCRIPTOR?.edges || []
+  var i, pl
+  for (i = 0; i < EDGES.length; i++) {
+    pl = EDGES[i].plane
+    if (pl && !seen[pl]) {
+      seen[pl] = true
+      planes.push(pl)
+    }
+  }
+  return planes
+}
+
+
+/* ── fd/cards.js ── */
+// fd/cards.js — Layer 1: node renderer
+// Concat order: core.js → cards.js → architecture.js
+// Depends on: nodeEl (map), canvas (element) — declared in core.js scope
+
+// ── kind → fgraph-base.css shape class mapping ────────────────────────
+const KIND_SHAPE = {
+  bus: 'pill',
+  broker: 'pill',
+  router: 'pill',
+  agent: 'hexagon',
+  worker: 'hexagon',
+  trigger: 'circle',
+  event: 'circle',
+  database: 'cylinder',
+  storage: 'cylinder',
+  store: 'cylinder',
+  queue: 'cylinder',
+  decision: 'diamond',
+  gate: 'diamond',
+  file: 'folded',
+  config: 'folded',
+  document: 'folded',
+}
+
+// ── kind → tone class mapping (fgraph-base.css tone modifiers) ────────
+const KIND_TONE = {
+  bus: 'cyan',
+  broker: 'cyan',
+  router: 'cyan',
+  agent: 'amber',
+  worker: 'amber',
+  trigger: 'green',
+  event: 'green',
+  database: 'purple',
+  storage: 'purple',
+  store: 'purple',
+  queue: 'purple',
+  decision: 'red',
+  gate: 'red',
+  // hub-int accent defaults to --hub-c (cyan fallback) per fd-engine.css line 290
+  'hub-int': 'cyan',
+}
+
+// ── host badge label normalisation ────────────────────────────────────
+function hostLabel(raw) {
+  if (!raw) return null
+  if (raw === 'M1') return 'M₁'
+  if (raw === 'M2') return 'M₂'
+  if (raw === 'EX') return 'External'
+  return raw
+}
+
+// ── premium card HTML ──────────────────────────────────────────────────
+// .fd-card-premium structure:
+//   .fd-accent  — left accent bar (color via --fd-plane-{plane} or --fd-tone-{kind})
+//   .fd-nh      — flex header row: .fd-title + .fd-tag (plane-coloured badge)
+//   .fd-sub     — node.d  (subtitle / description, optional)
+//   .fd-host    — node.h  (host badge, optional; 'EX' = external, no badge per SKILL.md)
+function buildPremiumCard(node) {
+  const accentVar = node.plane
+    ? `var(--fd-plane-${node.plane}, var(--fd-tone-${node.kind || 'default'}, var(--text-dim)))`
+    : `var(--fd-tone-${node.kind || 'default'}, var(--text-dim))`
+
+  const tagPlane = node.plane || 'control'
+  // node.img holds the tag badge text; emits fd-tag-{plane} for colour variant
+  const tag = node.img ? `<div class="fd-tag fd-tag-${tagPlane}">${node.img}</div>` : ''
+  const sub = node.d ? `<div class="fd-sub">${node.d}</div>` : ''
+  // node.icon holds an inline <svg> string — rendered in the header icon slot (craft bar)
+  const ico = node.icon ? `<span class="fd-ico">${node.icon}</span>` : ''
+  // h='EX' = external, no badge (SKILL.md spec)
+  const hb = node.h && node.h !== 'EX' ? `<div class="fd-host ${node.h}">${hostLabel(node.h)}</div>` : ''
+
+  return (
+    `<span class="fd-accent" style="background:${accentVar}"></span>` +
+    `<div class="fd-nh">${ico}<div class="fd-title">${node.n}</div>${tag}</div>` +
+    sub +
+    hb
+  )
+}
+
+// ── simple card HTML ───────────────────────────────────────────────────
+function buildSimpleCard(node) {
+  const sub = node.d ? `<div class="fd-sub">${node.d}</div>` : ''
+  return `<div class="fd-title">${node.n}</div>${sub}`
+}
+
+// ── renderNode ────────────────────────────────────────────────────────
+// node        — descriptor node object
+// typeDefault — 'premium' | 'simple' | undefined (from types/{type}.js CARD_DEFAULT)
+// Returns the created element (also populates nodeEl[node.id]).
+function renderNode(node, typeDefault) {
+  const el = document.createElement('div')
+
+  // base classes
+  let cls = 'fgraph-node fd-node'
+
+  // fd-kind-{kind} class — used by fd-engine.css kind-variant rules
+  if (node.kind) cls += ` fd-kind-${node.kind}`
+
+  // shape class from kind
+  const shape = KIND_SHAPE[node.kind]
+  if (shape) cls += ` ${shape}`
+
+  // tone class from kind
+  const tone = KIND_TONE[node.kind]
+  if (tone) cls += ` ${tone}`
+
+  el.className = cls
+  el.dataset.id = node.id
+
+  // position: CSS var convention matching fgraph-base.css (--x, --y in 0..100 % space)
+  el.style.setProperty('--x', node.x)
+  el.style.setProperty('--y', node.y)
+
+  // card style resolution: per-node override (highest) → typeDefault → 'simple' fallback (RD-3)
+  const style = node.cardStyle || typeDefault || 'simple'
+
+  if (style === 'premium') {
+    el.classList.add('fd-card-premium')
+    // node.glow → accent halo on hub / hero cards (craft bar)
+    if (node.glow) el.classList.add('fd-glow')
+    el.innerHTML = buildPremiumCard(node)
+  } else {
+    el.innerHTML = buildSimpleCard(node)
+  }
+
+  // register in shared nodeEl map (declared in core.js scope)
+  nodeEl[node.id] = el
+
+  return el
+}
+
+// ── renderNodes ───────────────────────────────────────────────────────
+// descriptor — full fd-data descriptor object
+// typeDefault comes from types/{type}.js via the init() call
+// biome-ignore lint/correctness/noUnusedVariables: called by core.js in concat bundle
+function renderNodes(descriptor, typeDefault) {
+  const nodes = descriptor.nodes || []
+  for (const node of nodes) {
+    const el = renderNode(node, typeDefault)
+    canvas.appendChild(el)
+  }
+}
+
+
+/* ── fd/particles.js ── */
+// fd/particles.js — Layer 4: rAF particle engine
+// Lifted verbatim from lyra-stack-v2.html lines 628-691 and adapted for
+// the fd-engine descriptor-driven contract (RD-2).
+//
+// Opt-in contract (RD-2):
+//   descriptor.options.particles === false (default) → particles OFF (AC-9)
+//   descriptor.options.particles === true  → one-shot per edge on hover/UC trigger
+//   descriptor.options.particles === "loop" → continuous: spawnParticle() loops on active edges
+//
+// Concat order: core.js → edges.js → cards.js → particles.js → [interactions.js] → types/{type}.js
+// Depends on: NS, svg, pathByPair, pairKey — declared in core.js / edges.js scope.
+//
+// Guard: zero occurrences of the banned lowercase token in this file.
+// Self-check: grep -rn '\bmermaid\b' plugins/forge/ must be empty.
+
+function easeInOutCubic(t) {
+  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2
+}
+
+// Active particle state — one particle at a time (one-shot mode)
+// Loop mode tracks multiple particles via loopParticles[]
+let _particleEl = null
+let _particleRAF = null
+let _loopParticles = [] // [{wrapper, rafId}] — loop mode only
+
+function clearParticle() {
+  if (_particleRAF) {
+    cancelAnimationFrame(_particleRAF)
+    _particleRAF = null
+  }
+  if (_particleEl) {
+    _particleEl.remove()
+    _particleEl = null
+  }
+}
+
+// clearLoopParticles: stop all loop-mode particles
+function clearLoopParticles() {
+  for (let i = 0; i < _loopParticles.length; i++) {
+    const lp = _loopParticles[i]
+    if (lp.rafId) cancelAnimationFrame(lp.rafId)
+    if (lp.wrapper) lp.wrapper.remove()
+  }
+  _loopParticles = []
+}
+
+// ── spawnParticle ─────────────────────────────────────────────────────────
+// Lifted verbatim from lyra-stack-v2.html l.640-691, adapted for fd-engine:
+//   - plane color resolved via CSS var --fd-plane-{plane} (AC-6, never hardcoded hex)
+//   - particle wrapper class: fd-particle-wrap (matches fd-architecture.html CSS)
+//   - forward direction: pathEl.dataset.f === edgeF (verbatim from source)
+//
+// edgeF, edgeT: node ids of the edge endpoints (directional for forward/reverse)
+// plane:        semantic plane string ('control', 'write', etc.)
+// duration:     animation duration in ms (default 750, per spec)
+// onDone:       optional callback invoked when animation completes (for loop scheduling)
+//
+function spawnParticle(edgeF, edgeT, plane, duration, onDone) {
+  const dur = duration || 750
+  const pk = pairKey(edgeF, edgeT)
+  const pathEl = pathByPair.get(pk)
+  if (!pathEl) return null
+
+  // Resolve color from CSS var (theme-aware, AC-6)
+  // Fallback chain: --fd-plane-{plane} → #8aa0bd (muted default)
+  let col = '#8aa0bd'
+  const tmp = document.documentElement
+  const resolved = getComputedStyle(tmp).getPropertyValue(`--fd-plane-${plane}`).trim()
+  if (resolved) col = resolved
+
+  const forward = pathEl.dataset.f === edgeF
+  const len = pathEl.getTotalLength()
+
+  // Build halo + core inside a <g class="fd-particle-wrap"> (verbatim structure l.664-673)
+  const wrapper = document.createElementNS(NS, 'g')
+  wrapper.setAttribute('class', 'fd-particle-wrap')
+  wrapper.style.setProperty('--pcol', col)
+
+  const halo = document.createElementNS(NS, 'circle')
+  halo.setAttribute('r', '9')
+  halo.setAttribute('fill', col)
+  halo.setAttribute('opacity', '0.22')
+
+  const core = document.createElementNS(NS, 'circle')
+  core.setAttribute('r', '5')
+  core.setAttribute('fill', col)
+
+  wrapper.appendChild(halo)
+  wrapper.appendChild(core)
+  svg.appendChild(wrapper)
+
+  const start = performance.now()
+
+  function frame(now) {
+    const u = Math.min((now - start) / dur, 1)
+    const e = easeInOutCubic(u)
+    const d = forward ? e * len : (1 - e) * len
+    const pt = pathEl.getPointAtLength(d)
+    halo.setAttribute('cx', pt.x)
+    halo.setAttribute('cy', pt.y)
+    core.setAttribute('cx', pt.x)
+    core.setAttribute('cy', pt.y)
+    if (u < 1) {
+      return requestAnimationFrame(frame)
+    }
+    if (typeof onDone === 'function') onDone()
+    return null
+  }
+
+  const rafId = requestAnimationFrame(frame)
+  return { wrapper, rafId }
+}
+
+// ── startParticles / stopParticles (loop mode) ────────────────────────────
+// Called by the engine bootstrap when descriptor.options.particles === "loop".
+// Runs spawnParticle() continuously on all active edges, recycling on completion.
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function startParticles(descriptor) {
+  clearLoopParticles()
+  const edges = descriptor?.edges || []
+  if (!edges.length) return
+
+  // Loop: spawn one particle per edge in sequence, recycling each on completion
+  function spawnLoop(edgeIdx) {
+    const e = edges[edgeIdx % edges.length]
+    const plane = e.plane || 'control'
+    const lp = { wrapper: null, rafId: null }
+    _loopParticles.push(lp)
+
+    function onDone() {
+      if (lp.wrapper) lp.wrapper.remove()
+      // Re-spawn after a brief gap (50ms), cycling through edges
+      setTimeout(() => {
+        const nextIdx = (edgeIdx + 1) % edges.length
+        spawnLoop(nextIdx)
+      }, 50)
+    }
+
+    const result = spawnParticle(e.f, e.t, plane, 750, onDone)
+    if (result) {
+      lp.wrapper = result.wrapper
+      lp.rafId = result.rafId
+    }
+  }
+
+  // Stagger initial spawns across edges
+  edges.forEach((_e, i) => {
+    setTimeout(() => {
+      spawnLoop(i)
+    }, i * 180)
+  })
+}
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function stopParticles() {
+  clearParticle()
+  clearLoopParticles()
+}
+
+
+/* ── fd/interactions.js ── */
+// fd/interactions.js — Layer 5: spotlight, use-case step sequencer, sidebar
+// Lifted from lyra-stack-v2.html lines 720-974 and adapted for the
+// fd-engine descriptor-driven contract.
+//
+// Spotlight (hover): dimmed class on canvas, hot class on touched edges + neighbor nodes.
+// Use-case animation: descriptor.useCases[] → step sequencer (play/pause/reset/replay).
+// Sidebar: optional (descriptor.options.sidebar); falls back gracefully when absent.
+//
+// Concat order: core.js → edges.js → cards.js → particles.js → interactions.js → types/{type}.js
+// Depends on: canvas, nodeEl, paths, pathByPair, pairKey, svg — core.js/edges.js scope.
+//             spawnParticle, clearParticle — particles.js scope.
+//             DESCRIPTOR — core.js scope.
+//
+// Guard: zero occurrences of the banned lowercase token in this file.
+
+// ── spotlight (hover) ─────────────────────────────────────────────────────
+// Adapted from lyra-stack-v2.html l.720-751.
+// sidebar: optional; nodeData: the node descriptor object for the hovered node.
+
+function spotlight(nodeData) {
+  canvas.classList.add('dimmed')
+  const id = nodeData.id
+  const neigh = {}
+  neigh[id] = true
+
+  paths.forEach((p) => {
+    const on = p.dataset.f === id || p.dataset.t === id
+    p.classList.toggle('hot', on)
+    if (on) {
+      neigh[p.dataset.f] = true
+      neigh[p.dataset.t] = true
+    }
+  })
+
+  // edge labels follow their path
+  svg.querySelectorAll('text[data-pk]').forEach((t) => {
+    const pk = t.dataset.pk
+    const p = pathByPair.get(pk)
+    t.classList.toggle('hot', p?.classList.contains('hot') ?? false)
+  })
+
+  Object.keys(nodeEl).forEach((k) => {
+    nodeEl[k].classList.toggle('hot', !!neigh[k])
+  })
+
+  // sidebar header: update if sidebar exists
+  const sbHeader = document.getElementById('sbHeader')
+  if (sbHeader) {
+    const hostStr = !nodeData.h || nodeData.h === 'EX' ? 'external' : nodeData.h === 'M1' ? 'M&#x2081;' : 'M&#x2082;'
+    sbHeader.innerHTML =
+      `<h4>${nodeData.n}</h4>` +
+      (nodeData.img ? `<div class="fd-img">${nodeData.img}</div>` : '') +
+      `<dl><dt>plane</dt><dd>${nodeData.plane || '&#x2014;'}</dd>` +
+      `<dt>host</dt><dd>${hostStr}</dd>` +
+      `<dt>role</dt><dd>${nodeData.d || '&#x2014;'}</dd></dl>`
+  }
+}
+
+function clearSpot() {
+  canvas.classList.remove('dimmed')
+  paths.forEach((p) => {
+    p.classList.remove('hot')
+  })
+  svg.querySelectorAll('text').forEach((t) => {
+    t.classList.remove('hot')
+  })
+  Object.values(nodeEl).forEach((el) => {
+    el.classList.remove('hot')
+  })
+
+  // reset sidebar header to default hint
+  const sbHeader = document.getElementById('sbHeader')
+  if (sbHeader) {
+    sbHeader.innerHTML =
+      '<h4>Hover = detail</h4>' +
+      '<div class="hint">Hover a node to isolate its edges and see image / host / role.<br>Select a use case to animate the flow.</div>'
+  }
+}
+
+// ── use-case step sequencer ───────────────────────────────────────────────
+// Adapted from lyra-stack-v2.html l.770-974.
+// State machine: 'none' | 'ready' | 'playing' | 'paused' | 'done'
+// Only wired when descriptor.useCases is present.
+
+let _ucActiveIdx = null
+let _ucState = 'none'
+let _ucTimer = null
+let _ucStepIdx = 0
+
+function _syncUcButtons() {
+  const ucPlay = document.getElementById('ucPlay')
+  const ucReset = document.getElementById('ucReset')
+  if (!ucPlay) return
+  switch (_ucState) {
+    case 'none':
+      ucPlay.textContent = '▶ play'
+      ucPlay.disabled = true
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'ready':
+      ucPlay.textContent = '▶ play'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'playing':
+      ucPlay.textContent = '⏸ pause'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'paused':
+      ucPlay.textContent = '▶ resume'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.add('visible')
+      break
+    case 'done':
+      ucPlay.textContent = '↺ replay'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+  }
+}
+
+function _resetUcVisuals() {
+  Object.values(nodeEl).forEach((el) => {
+    el.classList.remove('uc-active', 'uc-done')
+  })
+  paths.forEach((p) => {
+    p.classList.remove('uc-active', 'uc-done')
+  })
+  canvas.classList.remove('dimmed')
+  // clear particle (particles.js)
+  if (typeof clearParticle === 'function') clearParticle()
+
+  const ucStepsList = document.getElementById('ucStepsList')
+  if (ucStepsList) {
+    ucStepsList.querySelectorAll('li').forEach((li) => {
+      li.classList.remove('step-active', 'step-done')
+    })
+  }
+}
+
+function _stopUcTimer() {
+  if (_ucTimer) {
+    clearTimeout(_ucTimer)
+    _ucTimer = null
+  }
+}
+
+function _selectUc(idx) {
+  _stopUcTimer()
+  _resetUcVisuals()
+  _ucActiveIdx = idx
+  _ucStepIdx = 0
+  _ucState = 'ready'
+
+  const uc = DESCRIPTOR.useCases[idx]
+  const ucTitle = document.getElementById('ucTitle')
+  const ucDesc = document.getElementById('ucDesc')
+  const ucStepsList = document.getElementById('ucStepsList')
+  const sbUc = document.getElementById('sbUc')
+
+  if (ucTitle) ucTitle.textContent = uc.title
+  if (ucDesc) ucDesc.innerHTML = uc.desc
+  if (ucStepsList) {
+    ucStepsList.innerHTML = ''
+    uc.steps.forEach((s, i) => {
+      const li = document.createElement('li')
+      li.innerHTML = `<span class="sn">${String(i + 1).padStart(2, '0')}</span>${s.label}`
+      ucStepsList.appendChild(li)
+    })
+  }
+  if (sbUc) sbUc.classList.add('visible')
+
+  document.querySelectorAll('.uc-btn').forEach((b) => {
+    b.classList.toggle('active', Number(b.dataset.uc) === idx)
+  })
+  _syncUcButtons()
+}
+
+function _applyUcStep(stepIdx) {
+  const uc = DESCRIPTOR.useCases[_ucActiveIdx]
+  if (stepIdx >= uc.steps.length) {
+    _ucState = 'done'
+    _syncUcButtons()
+    return
+  }
+  _ucStepIdx = stepIdx
+  const step = uc.steps[stepIdx]
+  canvas.classList.add('dimmed')
+
+  // mark previous steps done (verbatim from lyra-stack-v2)
+  for (let i = 0; i < stepIdx; i++) {
+    uc.steps[i].nodes.forEach((id) => {
+      if (nodeEl[id]) {
+        nodeEl[id].classList.remove('uc-active')
+        nodeEl[id].classList.add('uc-done')
+      }
+    })
+    if (uc.steps[i].edge) {
+      const prevEf = uc.steps[i].edge[0]
+      const prevEt = uc.steps[i].edge[1]
+      const prevPp = pathByPair.get(pairKey(prevEf, prevEt))
+      if (prevPp) {
+        prevPp.classList.remove('uc-active')
+        prevPp.classList.add('uc-done')
+      }
+    }
+  }
+
+  // activate current step nodes
+  step.nodes.forEach((id) => {
+    if (nodeEl[id]) nodeEl[id].classList.add('uc-active', 'hot')
+  })
+
+  // activate edge + spawn particle if particles opt-in
+  if (typeof clearParticle === 'function') clearParticle()
+  if (step.edge) {
+    const ef = step.edge[0]
+    const et = step.edge[1]
+    const pp = pathByPair.get(pairKey(ef, et))
+    if (pp) {
+      pp.classList.add('uc-active', 'hot')
+      // spawn particle if particles enabled and spawnParticle available
+      if (typeof spawnParticle === 'function' && DESCRIPTOR.options && DESCRIPTOR.options.particles !== false) {
+        // Find plane from edges
+        const edges = DESCRIPTOR.edges || []
+        let edgeDef = null
+        for (let j = 0; j < edges.length; j++) {
+          const ed = edges[j]
+          if ((ed.f === ef && ed.t === et) || (ed.f === et && ed.t === ef)) {
+            edgeDef = ed
+            break
+          }
+        }
+        const plane = edgeDef ? edgeDef.plane : 'control'
+        spawnParticle(ef, et, plane, 750, null)
+      }
+    }
+  }
+
+  // update step list
+  const ucStepsList = document.getElementById('ucStepsList')
+  if (ucStepsList) {
+    const items = ucStepsList.querySelectorAll('li')
+    items.forEach((li, i) => {
+      li.classList.remove('step-active', 'step-done')
+      if (i < stepIdx) li.classList.add('step-done')
+      if (i === stepIdx) li.classList.add('step-active')
+    })
+  }
+
+  // sidebar header: show step label
+  const sbHeader = document.getElementById('sbHeader')
+  const firstId = step.nodes[0]
+  if (firstId && nodeEl[firstId] && sbHeader) {
+    const nodes = DESCRIPTOR.nodes || []
+    let nd = null
+    for (let k = 0; k < nodes.length; k++) {
+      if (nodes[k].id === firstId) {
+        nd = nodes[k]
+        break
+      }
+    }
+    if (nd && _ucState !== 'playing') {
+      spotlight(nd)
+    } else {
+      sbHeader.innerHTML = `<h4>${step.label}</h4>`
+    }
+  } else if (sbHeader) {
+    sbHeader.innerHTML = `<h4>${step.label}</h4>`
+  }
+
+  _ucTimer = setTimeout(() => {
+    _applyUcStep(stepIdx + 1)
+  }, 900)
+}
+
+// ── wireUseCaseUI ─────────────────────────────────────────────────────────
+// Called from the engine bootstrap when descriptor.useCases is present.
+// Wires up .uc-btn, #ucPlay, #ucReset DOM controls.
+// Safe to call even when some controls are absent (sidebar-less mode).
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function wireUseCaseUI() {
+  document.querySelectorAll('.uc-btn').forEach((b) => {
+    b.addEventListener('click', () => {
+      _selectUc(Number(b.dataset.uc))
+    })
+  })
+
+  const ucPlay = document.getElementById('ucPlay')
+  const ucReset = document.getElementById('ucReset')
+
+  if (ucPlay) {
+    ucPlay.addEventListener('click', () => {
+      if (_ucActiveIdx === null) return
+      if (_ucState === 'playing') {
+        _stopUcTimer()
+        _ucState = 'paused'
+        _syncUcButtons()
+      } else if (_ucState === 'done' || _ucState === 'ready') {
+        _resetUcVisuals()
+        _ucStepIdx = 0
+        _ucState = 'playing'
+        _syncUcButtons()
+        _applyUcStep(0)
+      } else if (_ucState === 'paused') {
+        _ucState = 'playing'
+        _syncUcButtons()
+        _applyUcStep(_ucStepIdx)
+      }
+    })
+  }
+
+  if (ucReset) {
+    ucReset.addEventListener('click', () => {
+      _stopUcTimer()
+      _resetUcVisuals()
+      _ucStepIdx = 0
+      _ucState = 'ready'
+      _syncUcButtons()
+    })
+  }
+}
+
+// ── wireHoverSpotlight ────────────────────────────────────────────────────
+// Adds mouseenter/mouseleave listeners to all rendered .fd-node elements.
+// Called once after renderNodes(), before draw().
+// Skips spotlight during playing state (verbatim from lyra-stack-v2 l.480-482).
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function wireHoverSpotlight() {
+  const nodes = DESCRIPTOR.nodes || []
+  nodes.forEach((nd) => {
+    const el = nodeEl[nd.id]
+    if (!el) return
+    el.addEventListener('mouseenter', () => {
+      if (_ucState !== 'playing') spotlight(nd)
+    })
+    el.addEventListener('mouseleave', () => {
+      if (_ucState !== 'playing') clearSpot()
+    })
+  })
+}
+
+
+/* ── fd/architecture.js ── */
+// fd/types/architecture.js — declarative layout handler + zone placement
+// Glob-discovery: bundler.js discovers this file via glob('fd/types/*.js').
+// Exports TYPE so bundler can key it: window.__fdTypes[TYPE] = { CARD_DEFAULT, placeZones, init }
+
+const TYPE = 'architecture'
+const CARD_DEFAULT = 'premium' // RD-3: architecture/hub-spoke default is premium
+
+// ── placeZones ────────────────────────────────────────────────────────
+// Generalised from lyra-stack-v2.html placeZone() lines 693–718.
+// Parametric over descriptor.zones[] instead of hardcoded ids.
+//
+// For each zone:
+//   1. Collect rect() measurements for all member nodes.
+//   2. Compute union bounding box (min/max of cx±w/2, cy±h/2) + padding.
+//   3. Apply left/top/width/height to zone div#{zone.id} (bare id — no prefix added).
+//   4. Create the zone div if absent (class: fd-zone + zone.class).
+//
+// Zone descriptor id == HTML element id: zone.id = "zone-forge" → getElementById("zone-forge").
+// rect() is declared in core.js scope (concat order: core.js, cards.js, architecture.js).
+function zonePadding(zone) {
+  const p = zone.padding || {}
+  if (zone.class === 'zone-hub') {
+    return { x: p.x ?? 14, yt: p.top ?? 36, yb: p.bottom ?? 12 }
+  }
+  if (zone.class === 'zone-stores') {
+    return { x: p.x ?? 14, yt: p.top ?? 20, yb: p.bottom ?? 10 }
+  }
+  if (zone.class === 'zone-m2') {
+    return { x: p.x ?? 16, yt: p.top ?? 20, yb: p.bottom ?? 12 }
+  }
+  return { x: p.x ?? 16, yt: p.top ?? 20, yb: p.bottom ?? 12 }
+}
+
+function placeZones(descriptor) {
+  const zones = descriptor.zones
+  if (!zones || zones.length === 0) return
+
+  for (const zone of zones) {
+    // resolve or create zone div — bare zone.id, no prefix added
+    let zEl = document.getElementById(zone.id)
+    if (!zEl) {
+      zEl = document.createElement('div')
+      zEl.id = zone.id
+      let cls = 'fd-zone'
+      if (zone.class) cls += ` ${zone.class}`
+      zEl.className = cls
+
+      // inject zone label if provided
+      if (zone.label) {
+        const lbl = document.createElement('span')
+        lbl.className = 'fd-zone-label'
+        lbl.textContent = zone.label
+        zEl.appendChild(lbl)
+      }
+
+      canvas.insertBefore(zEl, canvas.firstChild)
+    }
+
+    // measure member nodes — guard against unknown ids (node not yet rendered or missing)
+    const memberIds = zone.nodes || []
+    if (memberIds.length === 0) continue
+
+    const rects = memberIds.map((id) => (nodeEl[id] ? rect(id) : null)).filter(Boolean)
+    if (rects.length === 0) continue
+
+    // union bounding box
+    const xMin = Math.min(...rects.map((r) => r.cx - r.w / 2))
+    const xMax = Math.max(...rects.map((r) => r.cx + r.w / 2))
+    const yMin = Math.min(...rects.map((r) => r.cy - r.h / 2))
+    const yMax = Math.max(...rects.map((r) => r.cy + r.h / 2))
+
+    // Per-zone padding — mirrors lyra-stack-v2.html placeZone() (hub 26/18/14, stores 18/14/10)
+    const pad = zonePadding(zone)
+    const padX = pad.x
+    const padYT = pad.yt
+    const padYB = pad.yb
+
+    const left = xMin - padX
+    const top = yMin - padYT
+    const width = xMax + padX - left
+    const height = yMax + padYB - top
+
+    zEl.style.left = `${left}px`
+    zEl.style.top = `${top}px`
+    zEl.style.width = `${width}px`
+    zEl.style.height = `${height}px`
+  }
+}
+
+// ── init ──────────────────────────────────────────────────────────────
+// Called by the fd-engine bootstrap after parsing fd-data.
+// Returns { typeDefault, placeZones } consumed by the engine orchestrator.
+function init(descriptor) {
+  const t = descriptor.type
+  if (t !== 'architecture' && t !== 'hub-spoke') {
+    console.warn('[fd] architecture.js init() called with unexpected type:', t)
+  }
+  // layout is declarative — no elk step; x/y already in descriptor
+  return {
+    typeDefault: CARD_DEFAULT,
+    placeZones,
+  }
+}
+
+// ── glob-discovery registration ───────────────────────────────────────
+// bundler.js discovers fd/types/*.js and concatenates them into the
+// inline <script>. At runtime each type module self-registers here.
+window.__fdTypes = window.__fdTypes || {}
+window.__fdTypes[TYPE] = { CARD_DEFAULT, placeZones, init }
+// 'hub-spoke' is an alias for 'architecture'
+window.__fdTypes['hub-spoke'] = window.__fdTypes[TYPE]
+
+
+/* ── __fd window entry (generated by bundler.js) ── */
+window.__fd = {
+  initEngine: initEngine,
+  renderNodes: renderNodes,
+  draw: draw,
+  wireResize: wireResize,
+  uniquePlanes: typeof uniquePlanes !== 'undefined' ? uniquePlanes : null,
+  initMarkers: typeof initMarkers !== 'undefined' ? initMarkers : null,
+}
+})()
+
+</script>
+
+<script>
+// fd-bootstrap.js — universal runtime bootstrap for gen-fd.py output
+// Inlined after the fd-engine IIFE bundle. Expects window.__fd + window.__fdTypes.
+
+;(() => {
+  function run() {
+    var dataEl = document.getElementById('fd-data')
+    if (!dataEl || !window.__fd) return
+
+    var descriptor = JSON.parse(dataEl.textContent)
+    var canvasEl = document.getElementById('fd-canvas')
+    var svgEl = document.getElementById('fd-edges')
+    if (!canvasEl || !svgEl) return
+
+    var type = descriptor.type || 'architecture'
+    var typeReg = window.__fdTypes && window.__fdTypes[type]
+    var typeInit = typeReg && typeof typeReg.init === 'function' ? typeReg.init(descriptor) : null
+    var typeDefault = (typeInit && typeInit.typeDefault) || (typeReg && typeReg.CARD_DEFAULT) || 'premium'
+
+    if (descriptor.canvas && descriptor.canvas.height) {
+      canvasEl.style.setProperty('--fd-canvas-h', descriptor.canvas.height + 'px')
+      canvasEl.style.height = descriptor.canvas.height + 'px'
+    }
+
+    window.__fd.initEngine(descriptor, canvasEl, svgEl)
+
+    // Chart-only types (gantt, pie, xychart) bypass node/edge engine
+    if (typeReg && typeof typeReg.renderChart === 'function') {
+      typeReg.renderChart(descriptor)
+      return
+    }
+
+    window.__fd.renderNodes(descriptor, typeDefault)
+
+    if (typeInit && typeof typeInit.positionNodes === 'function') {
+      typeInit.positionNodes(descriptor)
+    } else if (typeReg && typeof typeReg.positionNodes === 'function') {
+      typeReg.positionNodes(descriptor)
+    }
+
+    if (typeInit && typeof typeInit.applyShapes === 'function') {
+      typeInit.applyShapes(descriptor)
+    } else if (typeReg && typeof typeReg.applyShapes === 'function') {
+      typeReg.applyShapes(descriptor)
+    }
+
+    if (window.__fd.initMarkers && window.__fd.uniquePlanes) {
+      window.__fd.initMarkers(window.__fd.uniquePlanes())
+    }
+
+    window.__fd.draw()
+
+    var placeZonesFn = (typeInit && typeInit.placeZones) || (typeReg && typeReg.placeZones) || null
+    if (typeof placeZonesFn === 'function') {
+      placeZonesFn(descriptor)
+    }
+
+    window.__fd.wireResize()
+
+    if (typeof wireHoverSpotlight === 'function' && descriptor.options && descriptor.options.spotlight !== false) {
+      wireHoverSpotlight()
+    }
+
+    if (typeof wireUseCaseUI === 'function' && descriptor.useCases && descriptor.useCases.length) {
+      wireUseCaseUI()
+    }
+
+    document.querySelectorAll('.ctl[data-plane]').forEach((ctl) => {
+      ctl.addEventListener('click', () => {
+        ctl.classList.toggle('off')
+        canvasEl.classList.toggle('hide-' + ctl.dataset.plane, ctl.classList.contains('off'))
+      })
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      setTimeout(run, 80)
+    })
+  } else {
+    setTimeout(run, 80)
+  }
+})()
+
+</script>
+</body>
+</html>

--- a/artifacts/visuals/310-notation-glossary-guardrails-data-model.html
+++ b/artifacts/visuals/310-notation-glossary-guardrails-data-model.html
@@ -1,0 +1,2627 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="diagram:title" content="Notation glossary data model — notation.md · SKILL.md whitelist · G1-G4 · legends gate (#310)">
+<meta name="diagram:category" content="architecture">
+<meta name="diagram:color" content="#22d3ee">
+<meta name="diagram:engine" content="fd-engine">
+<meta name="diagram:type" content="architecture">
+<title>Notation glossary data model — notation.md · SKILL.md whitelist · G1-G4 · legends gate (#310)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+/* reset */
+*,*::before,*::after{box-sizing:border-box}
+html,body{margin:0;padding:0}
+ul,ol{list-style:none;margin:0;padding:0}
+button{cursor:pointer;font-family:inherit}
+
+/* ══════════════════════════════════════════════════════════════════
+   lyra-v2.css — Lyra brand aesthetic · v2 (GitHub-dark variant)
+   Used by: lyra, voicecli (v2-styled artifacts only)
+
+   Difference vs lyra.css (v1 "Forge Floor"):
+   - Surfaces rebased on GitHub-dark (#0d1117 family) with an explicit
+     elevation ladder: bg < bg-cell < bg-panel < bg-card
+   - Adds --border-hi for stronger dividers in dense data grids
+   - Accent alphas pushed (dim 0.08→0.12, glow 0.22→0.40) for more
+     "live ember" feel on cards and nodes
+   - Drops the forge-floor body chrome (spark particles + 42px grid)
+     — v2 docs are flat, data-dense, GitHub-network-graph style
+   - Adds lane palette (lane-a1..i, status-ready/blocked/done) so
+     dep-graph / kernel-arch / swimlane docs share one token set
+
+   Reference implementations:
+   - lyra-v2-dependency-graph-v5.1.html
+   - lyra-kernel-architecture-v5.html
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Brand Tokens — Dark (default, v2 only exists in dark) ── */
+:root, [data-theme="dark"] {
+  color-scheme: dark;
+
+  /* Surface elevation ladder (darkest → lightest) */
+  --bg:           #0d1117;  /* page */
+  --bg-cell:      #0f141a;  /* grid cell / recessed surface inside panel */
+  --bg-panel:     #13191f;  /* section / wrapper */
+  --bg-card:      #161b22;  /* card / raised surface inside panel */
+
+  /* Legacy aliases — keep v1 variable names working in v2 docs */
+  --surface:      #13191f;  /* alias → bg-panel */
+  --surface2:     #161b22;  /* alias → bg-card */
+
+  /* Dividers */
+  --border:       #21262d;
+  --border-hi:    #30363d;
+  --border-bright:#30363d;  /* alias → border-hi */
+
+  /* Text ramp */
+  --text:         #fafafa;
+  --text-muted:   #8b93a1;
+  --text-dim:     #6b7280;
+
+  /* Forge orange — same hue as v1, stronger alphas */
+  --accent:       #e85d04;
+  --accent-2:     #f97316;
+  --accent-dim:   rgba(232,93,4,0.12);
+  --accent-glow:  rgba(232,93,4,0.40);
+  --error:        #ef4444;
+
+  /* Extended lane palette — shared by dep-graph, kernel-arch, swimlanes */
+  --teal:    #06b6d4;  --teal-dim:   rgba(6,182,212,0.10);
+  --amber:   #f59e0b;  --amber-dim:  rgba(245,158,11,0.10);
+  --green:   #10b981;  --green-dim:  rgba(16,185,129,0.10);
+  --cyan:    #22d3ee;
+  --purple:  #c084fc;
+  --pink:    #ec4899;  --pink-dim:   rgba(236,72,153,0.10);
+  --plum:    #a855f7;  --plum-dim:   rgba(168,85,247,0.10);
+  --red:     #ef4444;  --red-dim:    rgba(239,68,68,0.10);
+
+  /* Issue / task status — for plan artifacts */
+  --status-ready:   #22c55e;
+  --status-blocked: #f97316;
+  --status-done:    #475569;
+
+  /* Lane tones — for multi-lane swim/DAG views */
+  --lane-a1: #22c55e;
+  --lane-a2: #6366f1;
+  --lane-a3: #8b5cf6;
+  --lane-b:  #3b82f6;
+  --lane-c1: #a855f7;
+  --lane-c2: #d946ef;
+  --lane-c3: #ec4899;
+  --lane-d:  #06b6d4;
+  --lane-e:  #eab308;
+  --lane-f:  #10b981;
+  --lane-g:  #f97316;
+  --lane-h:  #f59e0b;
+  --lane-i:  #14b8a6;
+}
+
+/* v2 is dark-only by design. If a doc needs a light mode, use lyra.css v1. */
+
+/* ══════════════════════════════════════════════════════════════════
+   Base page chrome — flat body, 24px gutter, 12px base type
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 body,
+body.lyra-v2 {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', system-ui, sans-serif;
+  padding: 24px;
+  min-height: 100vh;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Page header primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 header.page-header,
+body.lyra-v2 header.page-header {
+  max-width: 100%;
+  margin: 0 auto 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.lyra-v2 header.page-header h1,
+body.lyra-v2 header.page-header h1 {
+  font-family: 'Outfit', sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.lyra-v2 header.page-header h1 .accent,
+body.lyra-v2 header.page-header h1 .accent { color: var(--accent); }
+.lyra-v2 .subtitle,
+body.lyra-v2 .subtitle {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin-top: 6px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Section / panel primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 .section,
+body.lyra-v2 .section {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 18px 20px 20px;
+  position: relative;
+  overflow: hidden;
+}
+.lyra-v2 .section-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.lyra-v2 .section-title {
+  font-family: 'Outfit', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--text);
+  margin-bottom: 4px;
+  letter-spacing: -0.02em;
+}
+.lyra-v2 .section-title .accent { color: var(--accent); }
+.lyra-v2 .section-subtitle {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+  line-height: 1.45;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Card primitive — raised surface with border-left tone stripe
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 .card {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 9px 11px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-hi);
+  border-left: 3px solid currentColor;
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--text);
+  transition: background 0.15s, border-color 0.15s, transform 0.12s;
+}
+.lyra-v2 .card:hover {
+  background: var(--bg-panel);
+  border-color: currentColor;
+  transform: translateX(1px);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Footer primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 footer.page-footer {
+  margin-top: 18px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+}
+.lyra-v2 footer.page-footer a { color: var(--accent); text-decoration: none; }
+.lyra-v2 footer.page-footer a:hover { text-decoration: underline; }
+
+/* ══════════════════════════════════════════════════════════════════
+   Slide mode — lyra-v2 aesthetic (forge-slides)
+   Same flame-gradient as v1, but on the GitHub-dark ladder.
+   ══════════════════════════════════════════════════════════════════ */
+.deck.lyra-v2 .slide--title,
+.lyra-v2 .deck .slide--title {
+  background-image:
+    radial-gradient(ellipse at 50% 30%, var(--accent-glow) 0%, transparent 55%),
+    linear-gradient(135deg, var(--bg) 0%, var(--bg-panel) 100%);
+}
+.lyra-v2 .deck .slide--title .slide__display {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--title .slide__subtitle { color: var(--text-muted); }
+.lyra-v2 .deck .slide--content .slide__label { color: var(--accent); }
+.lyra-v2 .deck .slide--content .slide__heading {
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+.lyra-v2 .deck .slide--content li::before { color: var(--accent); }
+.lyra-v2 .deck .slide--section .slide__number {
+  color: var(--accent);
+  opacity: 0.1;
+}
+.lyra-v2 .deck .slide--closing {
+  background-image:
+    radial-gradient(ellipse at 50% 70%, var(--accent-glow) 0%, transparent 60%),
+    linear-gradient(to top, var(--bg), var(--bg-panel));
+}
+.lyra-v2 .deck .slide--closing .slide__heading {
+  color: var(--accent);
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--closing .cta {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+  border: none;
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--quote .slide__quote-mark { color: var(--accent); }
+.lyra-v2 .deck .slide--comparison .slide__col.accent {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+}
+
+
+/* fd-engine.css — static rules for the fd-engine canvas, nodes, edges, card variants
+ * Inlined into generated HTML output at generation time (not linked at runtime).
+ * No viewBox / no preserveAspectRatio on the SVG overlay (AC-10).
+ * Self-bootstrapping: the :root block below maps each internal short-name token to a
+ *   universal forge aesthetic token with a hard fallback. Works on lyra-v2, cool-dark,
+ *   editorial, and all other aesthetics — no per-aesthetic shim needed.
+ * Plane CSS vars (--fd-plane-{name}) default below; aesthetic layer may override.
+ */
+
+/* ---- Token contract: self-bootstrapping short-name aliases ---- */
+/* fd-engine.css is inlined AFTER the aesthetic, so these :root declarations run last.
+ *
+ * Two mapping strategies:
+ *   A) fd short-name ≠ aesthetic token name → var(--universal-name, #hex)
+ *      The aesthetic's universal token wins; hard hex = lyra-v2 dark fallback.
+ *   B) fd short-name = aesthetic token name (--cyan, --amber, --slate, …) →
+ *      hard hex fallback only (no self-referential var()); aesthetics that already
+ *      declare the token will have their value replaced by the same hex here — safe
+ *      because we target the same colour. Aesthetics that omit the token get the
+ *      fallback, which is what we want.
+ *
+ * Regression note for roxabi.css (defines --panel:#13191f, no --bg-panel):
+ *   --panel → var(--bg-panel, #13191f) → bg-panel absent → #13191f = unchanged. ✓ */
+:root {
+  /* Strategy A: fd name ≠ aesthetic universal name */
+  --panel:  var(--bg-panel,   #13191f);
+  --panel2: var(--bg-card,    #161b22);
+  --bd2:    var(--border-hi,  #30363d);
+  --mut:    var(--text-muted, #8b93a1);
+  --mut2:   var(--text-dim,   #6b7280);
+  --mono:   var(--font-mono,  "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+  --sans:   var(--font-sans,  "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif);
+  --vio:    var(--plum,       #a855f7);
+  --emer:   var(--green,      #10b981);
+  /* Strategy B: fd name = aesthetic token name — hard fallback, no self-ref var() */
+  --slate:  #64748b;
+  --amber:  #f59e0b;
+  --cyan:   #22d3ee;
+  --sky:    #58a6ff;
+  --orng:   #fb923c;
+  --rose:   #fb7185;
+}
+
+/* ---- Plane color defaults (overridden by aesthetic inlines) ---- */
+:root {
+  --fd-plane-control:  #38bdf8;
+  --fd-plane-write:    #34d399;
+  --fd-plane-read:     #64748b;
+  --fd-plane-data:     #a78bfa;
+  --fd-plane-async:    #fb923c;
+  --fd-plane-feedback: #fb7185;
+  --fd-plane-message:  #38bdf8;
+  --fd-plane-media:    #fbbf24;
+  --fd-plane-llm:      #a78bfa;
+  --fd-canvas-h:       720px;
+}
+
+/* ---- Canvas container ---- */
+.fd-canvas {
+  position: relative;
+  width: 100%;
+  height: var(--fd-canvas-h, 720px);
+}
+
+/* ---- SVG overlay (AC-10: no viewBox, no preserveAspectRatio) ---- */
+.fd-edges {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+  z-index: 1;
+}
+
+/* ---- Edge path base rules ---- */
+.fd-edges path {
+  fill: none;
+  stroke-width: 1.8;
+  opacity: .62;
+  transition: opacity .15s, stroke-width .15s;
+}
+
+/* ---- Per-plane stroke colors ---- */
+.fd-edges path.control  { stroke: var(--fd-plane-control);  }
+.fd-edges path.write    { stroke: var(--fd-plane-write);    }
+.fd-edges path.read     { stroke: var(--fd-plane-read);     }
+.fd-edges path.data     { stroke: var(--fd-plane-data);     }
+.fd-edges path.async    { stroke: var(--fd-plane-async);    }
+.fd-edges path.feedback { stroke: var(--fd-plane-feedback); }
+.fd-edges path.message  { stroke: var(--fd-plane-message);  }
+.fd-edges path.media    { stroke: var(--fd-plane-media);    }
+.fd-edges path.llm      { stroke: var(--fd-plane-llm);      }
+
+/* ---- Edge state classes (dimmed / hot) ---- */
+.fd-edges path.hot {
+  opacity: 1;
+  stroke-width: 3;
+}
+.fd-canvas.dimmed .fd-edges path:not(.hot) {
+  opacity: .06;
+}
+
+/* ---- Use-case edge states ---- */
+.fd-edges path.uc-active {
+  opacity: 1 !important;
+  stroke-width: 2.8 !important;
+}
+.fd-edges path.uc-done {
+  opacity: .48 !important;
+  stroke-width: 2 !important;
+}
+
+/* ---- Edge label ---- */
+.fd-elabel {
+  font-family: var(--mono);
+  font-size: 9px;
+  fill: var(--mut);
+  opacity: 0;
+}
+.fd-elabel.hot {
+  opacity: 1;
+}
+
+/* ---- Particle dot wrapper ---- */
+.fd-edges g.fd-particle-wrap {
+  filter: drop-shadow(0 0 6px var(--pcol, #38bdf8));
+}
+
+/* ---- Node base (.fd-node extends fgraph-base .fgraph-node conventions) ---- */
+/* % coordinate system: --x and --y in 0..100 range, matching fgraph-base.css */
+.fd-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  left: calc(var(--x) * 1%);
+  top: calc(var(--y) * 1%);
+  z-index: 2;
+}
+
+/* ---- Premium card (.fd-card-premium) ---- */
+/* Extracted and generalized from lyra-stack-v2.html lines 135-195.
+ * Applied to nodes with cardStyle:"premium" (architecture / hub-spoke types by default). */
+.fd-card-premium {
+  width: 154px;
+  background: linear-gradient(180deg, var(--panel), var(--panel2));
+  border: 1px solid var(--bd2);
+  border-radius: 11px;
+  padding: 9px 11px 9px 13px;
+  cursor: default;
+  transition: transform .12s, box-shadow .15s, border-color .15s;
+  box-shadow: 0 3px 14px #00000055;
+}
+
+/* Keep canvas placement — .fd-card-premium must not override .fd-node absolute coords */
+.fd-node.fd-card-premium {
+  position: absolute;
+}
+
+.fd-card-premium:hover {
+  transform: translate(-50%, -50%) translateY(-2px);
+  border-color: #3d567a;
+  box-shadow: 0 8px 26px #000a;
+}
+
+/* Accent bar (.fd-accent) — left side color stripe */
+.fd-card-premium .fd-accent {
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--slate);
+}
+
+/* Node header row */
+.fd-card-premium .fd-nh {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+/* Node name — cards.js emits .fd-title; .fd-nn kept for legacy reference output.
+   Sans title + Mono subtitle = the dual-font craft primitive (matches the
+   lyra-diagram gold standard: IBM Plex Sans title / Mono descriptor). */
+.fd-card-premium .fd-title,
+.fd-card-premium .fd-nn {
+  font-weight: 700;
+  font-size: 12px;
+  font-family: var(--sans);
+  letter-spacing: -.2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Subtitle / image line (.fd-sub) */
+.fd-card-premium .fd-sub {
+  color: var(--mut);
+  font-size: 10px;
+  font-family: var(--mono);
+  margin-top: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Description line */
+.fd-card-premium .fd-desc {
+  color: var(--mut2);
+  font-size: 10px;
+  margin-top: 3px;
+  line-height: 1.3;
+}
+
+/* Tag badge (.fd-tag) */
+.fd-tag {
+  font-size: 8.5px;
+  font-family: var(--mono);
+  font-weight: 700;
+  padding: 1.5px 5px;
+  border-radius: 5px;
+  white-space: nowrap;
+}
+
+/* Tag color variants (plane-aware) */
+.fd-tag-control  { background: #38bdf822; color: var(--fd-plane-control,  #38bdf8); }
+.fd-tag-write    { background: #34d39922; color: var(--fd-plane-write,    #34d399); }
+.fd-tag-read     { background: #64748b22; color: #9fb3cc; }
+.fd-tag-data     { background: #a78bfa22; color: var(--fd-plane-data,     #a78bfa); }
+.fd-tag-async    { background: #fb923c22; color: var(--fd-plane-async,    #fb923c); }
+.fd-tag-feedback { background: #fb718522; color: var(--fd-plane-feedback, #fb7185); }
+.fd-tag-message  { background: #38bdf822; color: var(--fd-plane-message,  #38bdf8); }
+.fd-tag-media    { background: #fbbf2422; color: var(--fd-plane-media,    #fbbf24); }
+.fd-tag-llm      { background: #a78bfa22; color: var(--fd-plane-llm,      #a78bfa); }
+.fd-tag-base     { background: #34d39922; color: var(--emer); }
+.fd-tag-base-svc { background: #38bdf822; color: var(--sky);  }
+.fd-tag-ml-base  { background: #a78bfa22; color: var(--vio);  }
+.fd-tag-cuda     { background: #fb923c22; color: var(--orng); }
+.fd-tag-upstream { background: #64748b22; color: #9fb3cc;     }
+.fd-tag-internal { background: #38bdf814; color: #7dd3fc; border: 1px solid #38bdf822; }
+
+/* Host badge (.fd-host) — bottom-right corner */
+.fd-host {
+  position: absolute;
+  right: 7px;
+  bottom: 6px;
+  font-size: 8px;
+  font-family: var(--mono);
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 20px;
+}
+.fd-host.M1 { background: #34d39915; color: var(--emer); }
+.fd-host.M2 { background: #fbbf2415; color: var(--amber); border: 1px dashed #fbbf2255; }
+
+/* ---- Node state classes ---- */
+.fd-card-premium.hot {
+  border-color: #fff3;
+  box-shadow: 0 0 0 1px #ffffff22, 0 10px 30px #000c;
+}
+
+.fd-canvas.dimmed .fd-card-premium:not(.hot) {
+  opacity: .28;
+}
+
+/* Use-case node states */
+.fd-card-premium.uc-active {
+  border-color: var(--amber) !important;
+  box-shadow: 0 0 0 2px #fbbf2444, 0 0 22px #fbbf2433, 0 6px 24px #000c !important;
+  z-index: 5;
+}
+.fd-card-premium.uc-done {
+  border-color: #fbbf2466 !important;
+  opacity: 1 !important;
+}
+
+/* Dormant node */
+.fd-card-premium.dormant {
+  opacity: .62;
+}
+.fd-card-premium.dormant .fd-title::after,
+.fd-card-premium.dormant .fd-nn::after {
+  content: " ⊘";
+  color: var(--rose);
+}
+
+/* ---- Node kind variants ---- */
+
+/* Bus node (wide horizontal bar) */
+.fd-card-premium.fd-kind-bus {
+  width: 62%;
+  max-width: 820px;
+  background: linear-gradient(90deg, #0e2233, #10283c, #0e2233);
+  border: 1.5px solid #2a6b8f;
+  box-shadow: 0 0 26px #38bdf820, inset 0 0 30px #38bdf80f;
+  padding: 11px 18px;
+}
+.fd-card-premium.fd-kind-bus .fd-accent { display: none; }
+.fd-card-premium.fd-kind-bus .fd-title,
+.fd-card-premium.fd-kind-bus .fd-nn { font-size: 13px; color: var(--cyan); }
+.fd-card-premium.fd-kind-bus .fd-nh { justify-content: flex-start; gap: 9px; }
+.fd-card-premium.fd-kind-bus .fd-subj {
+  color: var(--mut);
+  font-size: 9.5px;
+  font-family: var(--mono);
+  margin-top: 5px;
+  letter-spacing: .2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fd-card-premium.fd-kind-bus .fd-subj b { color: #bfe6ff; font-weight: 600; }
+
+/* Store node */
+.fd-card-premium.fd-kind-store {
+  width: 142px;
+  background: linear-gradient(180deg, #140e24, #110c20);
+  border-color: #2d1e4a;
+}
+.fd-card-premium.fd-kind-store .fd-accent { background: var(--vio); }
+
+/* Hub-interior sub-node */
+.fd-card-premium.fd-kind-hub-int {
+  width: 136px;
+  padding: 7px 9px 7px 11px;
+  background: linear-gradient(180deg, #0d1a2e, #0b1526);
+  border-color: #1e3555;
+}
+.fd-card-premium.fd-kind-hub-int .fd-accent { background: var(--hub-c, var(--cyan)); }
+.fd-card-premium.fd-kind-hub-int .fd-title,
+.fd-card-premium.fd-kind-hub-int .fd-nn { font-size: 11px; }
+.fd-card-premium.fd-kind-hub-int .fd-desc { font-size: 9.5px; }
+
+/* External / cloud node */
+.fd-card-premium.fd-kind-ext {
+  width: 154px;
+  background: repeating-linear-gradient(
+    135deg,
+    #0e1420, #0e1420 7px,
+    #101826 7px, #101826 14px
+  );
+  border: 1.5px dashed var(--bd2);
+}
+.fd-card-premium.fd-kind-ext .fd-accent { display: none; }
+.fd-card-premium.fd-kind-ext .fd-title,
+.fd-card-premium.fd-kind-ext .fd-nn { color: #cbd6e6; }
+
+/* ---- Zone regions ---- */
+.fd-zone {
+  position: absolute;
+  z-index: 0;
+  border-radius: 14px;
+  border: 1px dashed;
+  pointer-events: none;
+}
+.fd-zone .fd-zone-label {
+  position: absolute;
+  top: 7px;
+  left: 11px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   CRAFT QUALITY BAR — additive primitives (Phase 1)
+   Mirror of fgraph-base craft block, scoped to the fd-engine card grammar.
+   ════════════════════════════════════════════════════════════════════ */
+
+/* Ambient edge-flow — slow marching dashes (passive data/async). Self-contained
+   keyframe so fd-engine.css stays bootstrappable on its own. */
+@keyframes fg-flow { to { stroke-dashoffset: -200px; } }
+.fd-edges path.flow { stroke-dasharray: 6 4; animation: fg-flow 20s linear infinite; }
+
+/* Accent glow — add the .fd-glow modifier to a hub / hero node.
+   --glow-radius declared here too (mirror of fgraph-base) so fd-engine.css
+   bootstraps standalone; harmless duplicate when both are inlined together. */
+:root { --glow-radius: 40px; }
+.fd-card-premium.fd-glow {
+  box-shadow: 0 0 var(--glow-radius, 40px) var(--accent-glow, #38bdf833), 0 3px 14px #00000055;
+}
+
+/* Node icon slot — inline SVG glyph in the premium card header (.fd-nh). */
+.fd-card-premium .fd-ico { width: 18px; height: 18px; flex: none; color: currentColor; }
+.fd-card-premium .fd-ico svg { width: 100%; height: 100%; display: block; }
+
+
+/* fd-page-shell.css — layout chrome for gen-fd.py output (header, bar, diagram-row, sidebar) */
+
+html,
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans, "Inter", ui-sans-serif, system-ui, sans-serif);
+  -webkit-font-smoothing: antialiased;
+  line-height: 1.4;
+}
+
+.page {
+  padding: 22px 22px 60px;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 18px;
+  justify-content: space-between;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 18px;
+}
+
+.htitle h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}
+
+.htitle h1 b {
+  color: var(--cyan);
+}
+
+.htitle p {
+  margin: 5px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
+.badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 3px 9px;
+  border-radius: 20px;
+  border: 1px solid var(--border-hi);
+  color: var(--text-muted);
+}
+
+.badge.cyan {
+  border-color: rgba(34, 211, 238, 0.3);
+  background: rgba(34, 211, 238, 0.06);
+  color: var(--cyan);
+}
+
+.badge.amber {
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.06);
+  color: var(--amber);
+}
+
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.lg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 3px 9px;
+  font-family: var(--mono);
+}
+
+.lln {
+  width: 16px;
+  height: 0;
+  border-top: 2.5px solid;
+  border-radius: 2px;
+}
+
+.ctl-group {
+  display: flex;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+.ctl {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 5px 10px;
+  transition: 0.15s;
+}
+
+.ctl:hover {
+  border-color: var(--cyan);
+}
+
+.ctl.off {
+  opacity: 0.35;
+  text-decoration: line-through;
+}
+
+.uc-bar {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.uc-label {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.uc-btn {
+  cursor: pointer;
+  user-select: none;
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+}
+
+.uc-btn:hover {
+  border-color: var(--amber);
+  color: var(--text);
+}
+
+.uc-btn.active {
+  background: rgba(245, 158, 11, 0.06);
+  border-color: rgba(245, 158, 11, 0.4);
+  color: var(--amber);
+}
+
+.uc-play {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--green);
+  background: rgba(16, 185, 129, 0.06);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+}
+
+.uc-play:hover {
+  border-color: var(--green);
+}
+
+.uc-play:disabled {
+  opacity: 0.38;
+  cursor: default;
+}
+
+.uc-reset {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+  display: none;
+}
+
+.uc-reset.visible {
+  display: inline-block;
+}
+
+.uc-reset:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.diagram-row {
+  display: flex;
+  gap: 0;
+  align-items: stretch;
+  margin-bottom: 22px;
+}
+
+.stage-wrap {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+  border: 1px solid var(--border);
+  border-radius: 12px 0 0 12px;
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-cell));
+  overflow: auto;
+}
+
+.sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  border: 1px solid var(--border-hi);
+  border-left: none;
+  border-radius: 0 12px 12px 0;
+  background: var(--bg-cell);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar.hidden {
+  display: none;
+}
+
+.stage-wrap.full-width {
+  border-radius: 12px;
+}
+
+.sb-header {
+  padding: 12px 13px 9px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sb-header h4 {
+  margin: 0 0 2px;
+  font-size: 12.5px;
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+.sb-header .fd-img {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 9.5px;
+  margin-bottom: 6px;
+  word-break: break-all;
+}
+
+.sb-header dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 8px;
+}
+
+.sb-header dt {
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 9.5px;
+}
+
+.sb-header dd {
+  margin: 0;
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+.sb-header .hint {
+  color: var(--text-dim);
+  font-size: 10px;
+  font-style: italic;
+  line-height: 1.5;
+}
+
+.sb-uc {
+  padding: 11px 13px;
+  border-top: 1px solid var(--border);
+  flex: 1;
+  overflow: auto;
+  display: none;
+}
+
+.sb-uc.visible {
+  display: block;
+}
+
+.sb-uc .uc-title {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin-bottom: 7px;
+}
+
+.uc-steps-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.uc-steps-list li {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 4px 7px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  color: var(--text-dim);
+  transition: 0.15s;
+  line-height: 1.4;
+}
+
+.uc-steps-list li.step-done {
+  color: var(--green);
+  border-color: rgba(16, 185, 129, 0.15);
+  background: rgba(16, 185, 129, 0.05);
+}
+
+.uc-steps-list li.step-active {
+  color: var(--amber);
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.06);
+  box-shadow: 0 0 8px rgba(245, 158, 11, 0.12);
+}
+
+.uc-steps-list li .sn {
+  font-size: 8.5px;
+  opacity: 0.5;
+  margin-right: 4px;
+}
+
+.sb-uc .uc-desc {
+  margin-top: 9px;
+  font-size: 10px;
+  color: var(--text-muted);
+  line-height: 1.55;
+  padding-top: 9px;
+  border-top: 1px dashed var(--border);
+}
+
+.sb-uc .uc-desc b {
+  color: var(--text);
+}
+
+.fd-net-label {
+  position: absolute;
+  left: 14px;
+  top: 10px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.zone-m1 {
+  border-color: rgba(16, 185, 129, 0.25);
+  background: rgba(16, 185, 129, 0.03);
+}
+
+.zone-m1 .fd-zone-label {
+  color: rgba(16, 185, 129, 0.6);
+}
+
+.zone-m2 {
+  border-color: rgba(245, 158, 11, 0.25);
+  background: rgba(245, 158, 11, 0.04);
+}
+
+.zone-m2 .fd-zone-label {
+  color: rgba(245, 158, 11, 0.6);
+}
+
+.zone-hub {
+  border-color: rgba(56, 189, 248, 0.2);
+  background: rgba(56, 189, 248, 0.04);
+  border-style: solid;
+  border-radius: 16px;
+}
+
+.zone-hub .fd-zone-label {
+  color: rgba(56, 189, 248, 0.55);
+}
+
+.zone-stores {
+  border-color: rgba(167, 139, 250, 0.2);
+  background: rgba(167, 139, 250, 0.04);
+}
+
+.zone-stores .fd-zone-label {
+  color: rgba(167, 139, 250, 0.55);
+}
+
+.fd-canvas.hide-control .fd-edges path.control,
+.fd-canvas.hide-write .fd-edges path.write,
+.fd-canvas.hide-read .fd-edges path.read,
+.fd-canvas.hide-data .fd-edges path.data,
+.fd-canvas.hide-async .fd-edges path.async,
+.fd-canvas.hide-feedback .fd-edges path.feedback,
+.fd-canvas.hide-message .fd-edges path.message,
+.fd-canvas.hide-media .fd-edges path.media,
+.fd-canvas.hide-llm .fd-edges path.llm {
+  opacity: 0.06;
+}
+</style>
+</head>
+<body>
+<div class="page">
+
+  <header>
+    <div class="htitle">
+      <h1><b>Notation glossary data model</b> — notation.md · SKILL.md whitelist · G1-G4 · legends gate (#310)</h1>
+      <p>fd-engine · architecture · lyra-v2 · declarative · 11 nodes · 10 edges · DOM-measured bezier edges</p>
+    </div>
+    <div class="badges">
+      <span class="badge cyan">fd-engine</span>
+      <span class="badge amber">architecture</span>
+      <span class="badge">lyra-v2</span>
+      <span class="badge">file:// safe</span>
+    </div>
+  </header>
+
+  <div class="bar">
+    <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center">
+      <div class="legend"><span class="lg"><span class="lln" style="border-color:var(--plum)"></span>data</span><span class="lg"><span class="lln" style="border-color:var(--cyan)"></span>control</span><span class="lg"><span class="lln" style="border-color:var(--accent)"></span>feedback</span><span class="lg"><span class="lln" style="border-color:var(--purple)"></span>read</span><span class="lg"><span class="lln" style="border-color:var(--amber)"></span>async</span></div>
+      <div class="ctl-group"><span class="ctl" id="ctl-data" data-plane="data">data</span><span class="ctl" id="ctl-control" data-plane="control">control</span><span class="ctl" id="ctl-feedback" data-plane="feedback">feedback</span><span class="ctl" id="ctl-read" data-plane="read">read</span><span class="ctl" id="ctl-async" data-plane="async">async</span></div>
+    </div>
+    
+  </div>
+
+  <div class="diagram-row">
+    <div class="stage-wrap">
+      <div class="fd-canvas" id="fd-canvas">
+        
+        <div class="fd-zone zone-notation" id="zoneNotation"><span class="fd-zone-label">notation.md · canonical glossary</span></div>
+        <div class="fd-zone zone-skill" id="zoneSkill"><span class="fd-zone-label">compress SKILL.md</span></div>
+        <div class="fd-zone zone-refs" id="zoneRefs"><span class="fd-zone-label">references/</span></div>
+        <div class="fd-zone zone-guards" id="zoneGuards"><span class="fd-zone-label">guards · dev-core release</span></div>
+        <svg class="fd-edges" id="fd-edges" aria-hidden="true"><defs></defs></svg>
+      </div>
+    </div>
+
+    <div class="sidebar" id="fd-sidebar">
+      <div class="sb-header" id="sbHeader">
+        <h4>Hover = detail</h4>
+        <div class="hint">Hover a node to isolate its edges and see image / host / role.<br>Select a use case to animate the flow.</div>
+      </div>
+      <div class="sb-uc" id="sbUc">
+        <div class="uc-title" id="ucTitle"></div>
+        <ul class="uc-steps-list" id="ucStepsList"></ul>
+        <div class="uc-desc" id="ucDesc"></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<script type="application/json" id="fd-data">
+{
+  "type": "architecture",
+  "title": "Notation glossary data model — notation.md · SKILL.md whitelist · G1-G4 · legends gate (#310)",
+  "theme": "lyra-v2",
+  "layout": "declarative",
+  "canvas": {
+    "height": 1040
+  },
+  "options": {
+    "particles": false,
+    "spotlight": true,
+    "sidebar": true
+  },
+  "nodes": [
+    {
+      "id": "core",
+      "x": 12.5,
+      "y": 12,
+      "kind": "default",
+      "n": "core table",
+      "img": "always-load",
+      "d": "~150-line CORE TABLE — glyph + mandatory-gloss marker + fidelity-warning flag; the always-loaded surface",
+      "plane": "control",
+      "h": "EX",
+      "cardStyle": "premium",
+      "glow": true,
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003crect x='3' y='3' width='18' height='18' rx='2'/>\u003cpath d='M3 9h18M3 15h18M9 3v18'/>\u003c/svg>"
+    },
+    {
+      "id": "grammar",
+      "x": 37.5,
+      "y": 12,
+      "kind": "default",
+      "n": "grammar",
+      "img": "lazy",
+      "d": "DISAMBIGUATION GRAMMAR — 4 positional senses of →, ¬ modal registers, separator hierarchy; loaded only in glossary/lint modes",
+      "plane": "read",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M5 12h14M13 6l6 6-6 6'/>\u003c/svg>"
+    },
+    {
+      "id": "maint",
+      "x": 62.5,
+      "y": 12,
+      "kind": "default",
+      "n": "maintenance",
+      "img": "lazy",
+      "d": "MAINTENANCE POLICY — add/retire rules for glyphs and reserved vars; loaded only in glossary/lint modes",
+      "plane": "control",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z'/>\u003c/svg>"
+    },
+    {
+      "id": "registry",
+      "x": 87.5,
+      "y": 12,
+      "kind": "default",
+      "n": "registry",
+      "img": "grep counts",
+      "d": "RESERVED-VARIABLE REGISTRY — σ 4-way collision {spec, stack.yml, Spec doc-type, staging} · Ω override-file dominant · α agent · β branch · ω worktree · μ main · τ tier · φ frame · Δ diff · Σ state-map (collision w/ standards-test) · π plan (collision w/ test-file); ⟺ retained vs ⇔, ⇒ sanctioned implies/contrastive",
+      "plane": "data",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01'/>\u003c/svg>"
+    },
+    {
+      "id": "wl",
+      "x": 13,
+      "y": 46,
+      "kind": "default",
+      "n": "whitelist",
+      "img": "canonical",
+      "d": "INLINE WHITELIST — canonical inline set in SKILL.md; must stay set-equal to the notation.md core table",
+      "plane": "control",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M9 11l3 3L22 4'/>\u003cpath d='M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11'/>\u003c/svg>"
+    },
+    {
+      "id": "g14",
+      "x": 37,
+      "y": 46,
+      "kind": "default",
+      "n": "G1-G4",
+      "img": "guardrails",
+      "d": "G1 polarity transform w/ 4-field flag schema · G2 no-free-coinage + token-neutrality principle · G3 decidable gloss trigger · G4 verbatim floor",
+      "plane": "feedback",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z'/>\u003c/svg>"
+    },
+    {
+      "id": "r1",
+      "x": 61,
+      "y": 46,
+      "kind": "default",
+      "n": "R1 gate",
+      "img": "break-even",
+      "d": "R1 break-even inequality — a compression is admitted only when token savings exceed gloss + flag overhead",
+      "plane": "control",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M16 8l-8 8M8.5 8H16v7.5'/>\u003ccircle cx='12' cy='12' r='10'/>\u003c/svg>"
+    },
+    {
+      "id": "gloss",
+      "x": 87,
+      "y": 42,
+      "kind": "default",
+      "n": "glossary.md",
+      "img": "mode body",
+      "d": "references/glossary.md — glossary-mode body; pulls the lazy grammar + maintenance sections on demand",
+      "plane": "read",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M4 19.5A2.5 2.5 0 0 1 6.5 17H20'/>\u003cpath d='M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z'/>\u003c/svg>"
+    },
+    {
+      "id": "evid",
+      "x": 87,
+      "y": 64,
+      "kind": "default",
+      "n": "evidence.md",
+      "img": "arXiv pins",
+      "d": "references/evidence.md — pinned excerpts: Tencent 2604.07192 polarity · MetaGlyph 2601.07354 · LILO · GEPA",
+      "plane": "read",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48'/>\u003c/svg>"
+    },
+    {
+      "id": "nlcheck",
+      "x": 30,
+      "y": 86,
+      "kind": "default",
+      "n": "legends gate",
+      "img": "validate_plugins",
+      "d": "--check notation-legends — gate a: dev-core base.md:16 + doc-writer.md:51 are one-line pointers; gate b: SKILL.md whitelist ≡ core table (set-equality)",
+      "plane": "control",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M22 11.08V12a10 10 0 1 1-5.93-9.14'/>\u003cpath d='M22 4L12 14.01l-3-3'/>\u003c/svg>"
+    },
+    {
+      "id": "bump",
+      "x": 58,
+      "y": 86,
+      "kind": "default",
+      "n": "semver bump",
+      "img": "plugin.json",
+      "d": "dev-core plugin.json version bump — legend repointing ships as a semver-disciplined release",
+      "plane": "control",
+      "h": "EX",
+      "cardStyle": "premium",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z'/>\u003cpath d='M7 7h.01'/>\u003c/svg>"
+    }
+  ],
+  "edges": [
+    {
+      "f": "grammar",
+      "t": "core",
+      "plane": "data",
+      "label": "disambiguates → · ¬ · separators"
+    },
+    {
+      "f": "maint",
+      "t": "registry",
+      "plane": "control",
+      "label": "governs additions"
+    },
+    {
+      "f": "core",
+      "t": "wl",
+      "plane": "data",
+      "label": "≡ set-equal"
+    },
+    {
+      "f": "g14",
+      "t": "wl",
+      "plane": "control",
+      "label": "G2 no-free-coinage"
+    },
+    {
+      "f": "r1",
+      "t": "g14",
+      "plane": "feedback",
+      "label": "break-even admits G1"
+    },
+    {
+      "f": "evid",
+      "t": "g14",
+      "plane": "read",
+      "label": "pins G1 polarity evidence",
+      "srcFace": "left",
+      "dstFace": "bottom"
+    },
+    {
+      "f": "gloss",
+      "t": "grammar",
+      "plane": "read",
+      "label": "lazy · glossary/lint",
+      "flow": true
+    },
+    {
+      "f": "gloss",
+      "t": "maint",
+      "plane": "read",
+      "label": "lazy",
+      "flow": true
+    },
+    {
+      "f": "wl",
+      "t": "nlcheck",
+      "plane": "control",
+      "label": "gate b: set-equality"
+    },
+    {
+      "f": "nlcheck",
+      "t": "bump",
+      "plane": "async",
+      "label": "ships w/ release"
+    }
+  ],
+  "zones": [
+    {
+      "id": "zoneNotation",
+      "nodes": [
+        "core",
+        "grammar",
+        "maint",
+        "registry"
+      ],
+      "class": "zone-notation",
+      "label": "notation.md · canonical glossary",
+      "padding": {
+        "top": 48
+      }
+    },
+    {
+      "id": "zoneSkill",
+      "nodes": [
+        "wl",
+        "g14",
+        "r1"
+      ],
+      "class": "zone-skill",
+      "label": "compress SKILL.md",
+      "padding": {
+        "top": 48
+      }
+    },
+    {
+      "id": "zoneRefs",
+      "nodes": [
+        "gloss",
+        "evid"
+      ],
+      "class": "zone-refs",
+      "label": "references/",
+      "padding": {
+        "top": 48
+      }
+    },
+    {
+      "id": "zoneGuards",
+      "nodes": [
+        "nlcheck",
+        "bump"
+      ],
+      "class": "zone-guards",
+      "label": "guards · dev-core release",
+      "padding": {
+        "top": 48
+      }
+    }
+  ]
+}
+</script>
+
+<script>
+(function(){
+'use strict'
+
+/* ── fd/core.js ── */
+// fd/core.js — geometry core: rect, pairKey, faceFor, portAnchor, stubLen
+// Lifted verbatim from lyra-stack-v2.html lines 492-534 and generalized for
+// descriptor-driven fd-engine contract.
+// Concat order: core.js FIRST (edges.js depends on names defined here).
+// NOTE: all vars/functions here are intentionally "unused" in isolation —
+// they are consumed by edges.js and other fd/ modules via bundler concat.
+
+var nodeEl = {} // id → DOM element map, populated by initEngine
+var canvas = null // .fd-canvas element ref
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var svg = null // .fd-edges SVG overlay element ref
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var paths = [] // one SVG <path> per deduped pair
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var pathByPair = new Map() // pairKey → SVG <path>
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var DESCRIPTOR = null // full descriptor object set by initEngine
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var NS = 'http://www.w3.org/2000/svg'
+
+// ---- Geometry helpers (verbatim lift from lyra-stack-v2.html l.492-534) ----
+
+// l.492-495: canvas-relative rect for a node by id
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function rect(id) {
+  var el = nodeEl[id]
+  var cr = canvas.getBoundingClientRect()
+  var b = el.getBoundingClientRect()
+  return { cx: b.left - cr.left + b.width / 2, cy: b.top - cr.top + b.height / 2, w: b.width, h: b.height }
+}
+
+// l.498: canonical (unordered) key for a node pair
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function pairKey(a, b) {
+  return [a, b].sort().join('|')
+}
+
+// l.501-514: face selection — source exits toward target, target enters from opposite
+// Keeps srcFace / dstFace per-edge overrides from descriptor
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function faceFor(dx, dy, isSource, edge) {
+  if (edge) {
+    if (isSource && edge.srcFace) return edge.srcFace
+    if (!isSource && edge.dstFace) return edge.dstFace
+  }
+  if (Math.abs(dy) >= Math.abs(dx)) {
+    if (isSource) return dy > 0 ? 'bottom' : 'top'
+    else return dy > 0 ? 'top' : 'bottom'
+  } else {
+    if (isSource) return dx > 0 ? 'right' : 'left'
+    else return dx > 0 ? 'left' : 'right'
+  }
+}
+
+// l.516-528: port anchor — spreads slots evenly across the chosen face
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function portAnchor(r, face, slotIdx, slotCount) {
+  var cx = r.cx,
+    cy = r.cy,
+    w = r.w,
+    h = r.h
+  var hw = w / 2,
+    hh = h / 2
+  var faceLen = face === 'top' || face === 'bottom' ? w : h
+  var spread = Math.min(faceLen * 0.55, slotCount * 16)
+  var step = slotCount > 1 ? spread / (slotCount - 1) : 0
+  var offset = slotCount > 1 ? -spread / 2 + slotIdx * step : 0
+  switch (face) {
+    case 'top':
+      return { x: cx + offset, y: cy - hh, nx: 0, ny: -1 }
+    case 'bottom':
+      return { x: cx + offset, y: cy + hh, nx: 0, ny: 1 }
+    case 'left':
+      return { x: cx - hw, y: cy + offset, nx: -1, ny: 0 }
+    case 'right':
+      return { x: cx + hw, y: cy + offset, nx: 1, ny: 0 }
+  }
+}
+
+// l.531-534: proportional bezier offset — clamp(dist * 0.35, 30, 220)
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function stubLen(dx, dy) {
+  var dist = Math.sqrt(dx * dx + dy * dy)
+  return Math.max(30, Math.min(220, dist * 0.35))
+}
+
+// ---- Engine initializer ----
+// Called once at DOMContentLoaded by the generated output script.
+// descriptor: parsed fd-data JSON
+// canvasEl:   .fd-canvas DOM element
+// svgEl:      .fd-edges SVG overlay element
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — entry point called by generated HTML */
+function initEngine(descriptor, canvasEl, svgEl) {
+  DESCRIPTOR = descriptor
+  canvas = canvasEl
+  svg = svgEl
+  nodeEl = {}
+  paths = []
+  pathByPair = new Map()
+
+  // Apply canvas height from descriptor (default 720px via CSS --fd-canvas-h)
+  if (descriptor.canvas?.height) {
+    canvasEl.style.setProperty('--fd-canvas-h', `${descriptor.canvas.height}px`)
+  }
+}
+
+
+/* ── fd/edges.js ── */
+// fd/edges.js — edge drawing layer: draw(), redraw(), initMarkers(), ResizeObserver
+// Lifted verbatim and generalized from lyra-stack-v2.html lines 537-626 + l.960.
+// Depends on names from core.js (concat order: core.js MUST precede this file).
+// Plane colors: derived from descriptor.edges[i].plane via CSS vars --fd-plane-{name},
+// never hardcoded hex.
+
+// ---- Marker injection ----
+// Creates one <marker id="fd-arr-{plane}"> per unique semantic plane.
+// fill uses an injected SVG <style> rule binding CSS var per plane.
+// planes: array of unique plane name strings (e.g. ['message','llm','media'])
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function initMarkers(planes) {
+  var defs = svg.querySelector('defs')
+  if (!defs) {
+    defs = document.createElementNS(NS, 'defs')
+    svg.insertBefore(defs, svg.firstChild)
+  }
+  // Inject a <style> block into the SVG for plane fill vars (one per plane)
+  var styleEl = document.createElementNS(NS, 'style')
+  var cssRules = planes.map((pl) => `#fd-arr-${pl} path { fill: var(--fd-plane-${pl}, #8aa0bd); }`).join('\n')
+  styleEl.textContent = cssRules
+  defs.appendChild(styleEl)
+
+  planes.forEach((pl) => {
+    // Skip if marker already exists (idempotent re-init guard)
+    if (svg.querySelector(`#fd-arr-${pl}`)) return
+    var marker = document.createElementNS(NS, 'marker')
+    marker.setAttribute('id', `fd-arr-${pl}`)
+    marker.setAttribute('markerWidth', '9')
+    marker.setAttribute('markerHeight', '9')
+    marker.setAttribute('refX', '7')
+    marker.setAttribute('refY', '3')
+    marker.setAttribute('orient', 'auto')
+    // NO preserveAspectRatio — AC-10 compliance (no viewBox either)
+    var arrow = document.createElementNS(NS, 'path')
+    arrow.setAttribute('d', 'M0,0 L7,3 L0,6 Z')
+    // fill resolved via the injected CSS var rule above
+    marker.appendChild(arrow)
+    defs.appendChild(marker)
+  })
+}
+
+// ---- Full edge pass ----
+// Verbatim-adapted from lyra-stack-v2.html l.537-626.
+// Reads DESCRIPTOR.edges (set by initEngine). Uses nodeEl, canvas, svg, paths,
+// pathByPair from core.js module scope.
+function draw() {
+  // Clear all existing paths, labels, circles from the SVG overlay
+  svg.querySelectorAll(':scope > path, :scope > text, :scope > circle, :scope > g').forEach((n) => {
+    n.remove()
+  })
+  paths = []
+  pathByPair.clear()
+
+  var EDGES = DESCRIPTOR.edges || []
+
+  // --- Step 1: deduplicate EDGES into unique pairs -------------------------
+  // For each unordered pair keep: plane of first occurrence, label if any,
+  // canonical source (f), for slot allocation.
+  var seenPairs = new Map() // pairKey → {f, t, plane, lab, edge, edgeIndices:[]}
+  var i, e, k
+  for (i = 0; i < EDGES.length; i++) {
+    e = EDGES[i]
+    k = pairKey(e.f, e.t)
+    if (!seenPairs.has(k)) {
+      seenPairs.set(k, {
+        f: e.f,
+        t: e.t,
+        plane: e.plane,
+        lab: e.label || null,
+        edge: e,
+        flow: !!e.flow,
+        edgeIndices: [i],
+      })
+    } else {
+      seenPairs.get(k).edgeIndices.push(i)
+      // upgrade label if this occurrence has one and first didn't
+      if (e.label && !seenPairs.get(k).lab) seenPairs.get(k).lab = e.label
+      // upgrade flow if ANY occurrence of the pair requests it (dedup keeps the first edge only)
+      if (e.flow) seenPairs.get(k).flow = true
+    }
+  }
+  var dedupedEdges = Array.from(seenPairs.values()) // array of unique pairs
+
+  // --- Step 2: build port maps over deduped edges -------------------------
+  // Key: "nodeId:face" → [pairIdx in dedupedEdges]
+  var portMap = new Map()
+  var ref, f, t, edge, rf, rt, dx, dy, fFace, tFace, fk, tk
+  for (i = 0; i < dedupedEdges.length; i++) {
+    ref = dedupedEdges[i]
+    f = ref.f
+    t = ref.t
+    edge = ref.edge
+    rf = rect(f)
+    rt = rect(t)
+    dx = rt.cx - rf.cx
+    dy = rt.cy - rf.cy
+    fFace = faceFor(dx, dy, true, edge)
+    tFace = faceFor(dx, dy, false, edge)
+    fk = `${f}:${fFace}`
+    tk = `${t}:${tFace}`
+    if (!portMap.has(fk)) portMap.set(fk, [])
+    if (!portMap.has(tk)) portMap.set(tk, [])
+    portMap.get(fk).push(i)
+    portMap.get(tk).push(i)
+  }
+
+  // --- Step 3: draw one path per deduplicated pair ------------------------
+  var plane, lab, fSlots, tSlots, fi, ti, pu1, pu2, stb, c1x, c1y, c2x, c2y, dStr, p, tx2, mx, my
+  for (i = 0; i < dedupedEdges.length; i++) {
+    ref = dedupedEdges[i]
+    f = ref.f
+    t = ref.t
+    plane = ref.plane
+    lab = ref.lab
+    edge = ref.edge
+    rf = rect(f)
+    rt = rect(t)
+    dx = rt.cx - rf.cx
+    dy = rt.cy - rf.cy
+
+    fFace = faceFor(dx, dy, true, edge)
+    tFace = faceFor(dx, dy, false, edge)
+    fk = `${f}:${fFace}`
+    tk = `${t}:${tFace}`
+
+    fSlots = portMap.get(fk)
+    tSlots = portMap.get(tk)
+    fi = fSlots.indexOf(i)
+    ti = tSlots.indexOf(i)
+
+    pu1 = portAnchor(rf, fFace, fi, fSlots.length)
+    pu2 = portAnchor(rt, tFace, ti, tSlots.length)
+
+    // Proportional stub: longer links curve more (verbatim l.592-598)
+    stb = stubLen(dx, dy)
+    c1x = pu1.x + pu1.nx * stb
+    c1y = pu1.y + pu1.ny * stb
+    c2x = pu2.x + pu2.nx * stb
+    c2y = pu2.y + pu2.ny * stb
+
+    dStr =
+      `M${pu1.x.toFixed(1)},${pu1.y.toFixed(1)}` +
+      ` C${c1x.toFixed(1)},${c1y.toFixed(1)}` +
+      ` ${c2x.toFixed(1)},${c2y.toFixed(1)}` +
+      ` ${pu2.x.toFixed(1)},${pu2.y.toFixed(1)}`
+
+    p = document.createElementNS(NS, 'path')
+    p.setAttribute('d', dStr)
+    // CSS class = plane name → stroke resolved via .fd-edges path.{plane} in fd-engine.css
+    // edge.flow → append .flow for the ambient marching-dash animation (craft bar).
+    // ref.flow is set if ANY occurrence of the deduped pair requested flow.
+    p.setAttribute('class', ref.flow ? `${plane} flow` : plane)
+    // Arrowhead marker per plane — no hardcoded hex, color via CSS var in marker's injected style
+    p.setAttribute('marker-end', `url(#fd-arr-${plane})`)
+    // Data attributes for spotlight + particle matching
+    p.dataset.f = f
+    p.dataset.t = t
+    p.dataset.pk = pairKey(f, t)
+    svg.appendChild(p)
+    paths.push(p)
+    pathByPair.set(pairKey(f, t), p)
+
+    // Edge label (de Casteljau midpoint — verbatim l.613-624)
+    if (lab) {
+      tx2 = document.createElementNS(NS, 'text')
+      mx = 0.125 * pu1.x + 0.375 * c1x + 0.375 * c2x + 0.125 * pu2.x
+      my = 0.125 * pu1.y + 0.375 * c1y + 0.375 * c2y + 0.125 * pu2.y
+      tx2.setAttribute('x', mx.toFixed(1))
+      tx2.setAttribute('y', (my - 4).toFixed(1))
+      tx2.setAttribute('text-anchor', 'middle')
+      tx2.setAttribute('class', 'fd-elabel')
+      tx2.dataset.pk = pairKey(f, t)
+      tx2.textContent = lab
+      svg.appendChild(tx2)
+    }
+  }
+}
+
+// ---- Redraw: re-runs full edge pass + optional zone placement ----
+// Called by ResizeObserver and any layout-changing event.
+function redraw() {
+  draw()
+  // If a placeZones function is defined (by architecture.js type module), call it
+  if (typeof placeZones === 'function') placeZones(DESCRIPTOR)
+}
+
+// ---- ResizeObserver wiring ----
+// Called from initEngine after DOM is ready.
+// Verbatim from lyra-stack-v2.html l.960 — adapted to fd-engine naming.
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function wireResize() {
+  new ResizeObserver(redraw).observe(canvas)
+}
+
+// ---- Unique plane list helper ----
+// Derives the set of plane names from descriptor.edges for initMarkers call.
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function uniquePlanes() {
+  var planes = []
+  var seen = {}
+  var EDGES = DESCRIPTOR?.edges || []
+  var i, pl
+  for (i = 0; i < EDGES.length; i++) {
+    pl = EDGES[i].plane
+    if (pl && !seen[pl]) {
+      seen[pl] = true
+      planes.push(pl)
+    }
+  }
+  return planes
+}
+
+
+/* ── fd/cards.js ── */
+// fd/cards.js — Layer 1: node renderer
+// Concat order: core.js → cards.js → architecture.js
+// Depends on: nodeEl (map), canvas (element) — declared in core.js scope
+
+// ── kind → fgraph-base.css shape class mapping ────────────────────────
+const KIND_SHAPE = {
+  bus: 'pill',
+  broker: 'pill',
+  router: 'pill',
+  agent: 'hexagon',
+  worker: 'hexagon',
+  trigger: 'circle',
+  event: 'circle',
+  database: 'cylinder',
+  storage: 'cylinder',
+  store: 'cylinder',
+  queue: 'cylinder',
+  decision: 'diamond',
+  gate: 'diamond',
+  file: 'folded',
+  config: 'folded',
+  document: 'folded',
+}
+
+// ── kind → tone class mapping (fgraph-base.css tone modifiers) ────────
+const KIND_TONE = {
+  bus: 'cyan',
+  broker: 'cyan',
+  router: 'cyan',
+  agent: 'amber',
+  worker: 'amber',
+  trigger: 'green',
+  event: 'green',
+  database: 'purple',
+  storage: 'purple',
+  store: 'purple',
+  queue: 'purple',
+  decision: 'red',
+  gate: 'red',
+  // hub-int accent defaults to --hub-c (cyan fallback) per fd-engine.css line 290
+  'hub-int': 'cyan',
+}
+
+// ── host badge label normalisation ────────────────────────────────────
+function hostLabel(raw) {
+  if (!raw) return null
+  if (raw === 'M1') return 'M₁'
+  if (raw === 'M2') return 'M₂'
+  if (raw === 'EX') return 'External'
+  return raw
+}
+
+// ── premium card HTML ──────────────────────────────────────────────────
+// .fd-card-premium structure:
+//   .fd-accent  — left accent bar (color via --fd-plane-{plane} or --fd-tone-{kind})
+//   .fd-nh      — flex header row: .fd-title + .fd-tag (plane-coloured badge)
+//   .fd-sub     — node.d  (subtitle / description, optional)
+//   .fd-host    — node.h  (host badge, optional; 'EX' = external, no badge per SKILL.md)
+function buildPremiumCard(node) {
+  const accentVar = node.plane
+    ? `var(--fd-plane-${node.plane}, var(--fd-tone-${node.kind || 'default'}, var(--text-dim)))`
+    : `var(--fd-tone-${node.kind || 'default'}, var(--text-dim))`
+
+  const tagPlane = node.plane || 'control'
+  // node.img holds the tag badge text; emits fd-tag-{plane} for colour variant
+  const tag = node.img ? `<div class="fd-tag fd-tag-${tagPlane}">${node.img}</div>` : ''
+  const sub = node.d ? `<div class="fd-sub">${node.d}</div>` : ''
+  // node.icon holds an inline <svg> string — rendered in the header icon slot (craft bar)
+  const ico = node.icon ? `<span class="fd-ico">${node.icon}</span>` : ''
+  // h='EX' = external, no badge (SKILL.md spec)
+  const hb = node.h && node.h !== 'EX' ? `<div class="fd-host ${node.h}">${hostLabel(node.h)}</div>` : ''
+
+  return (
+    `<span class="fd-accent" style="background:${accentVar}"></span>` +
+    `<div class="fd-nh">${ico}<div class="fd-title">${node.n}</div>${tag}</div>` +
+    sub +
+    hb
+  )
+}
+
+// ── simple card HTML ───────────────────────────────────────────────────
+function buildSimpleCard(node) {
+  const sub = node.d ? `<div class="fd-sub">${node.d}</div>` : ''
+  return `<div class="fd-title">${node.n}</div>${sub}`
+}
+
+// ── renderNode ────────────────────────────────────────────────────────
+// node        — descriptor node object
+// typeDefault — 'premium' | 'simple' | undefined (from types/{type}.js CARD_DEFAULT)
+// Returns the created element (also populates nodeEl[node.id]).
+function renderNode(node, typeDefault) {
+  const el = document.createElement('div')
+
+  // base classes
+  let cls = 'fgraph-node fd-node'
+
+  // fd-kind-{kind} class — used by fd-engine.css kind-variant rules
+  if (node.kind) cls += ` fd-kind-${node.kind}`
+
+  // shape class from kind
+  const shape = KIND_SHAPE[node.kind]
+  if (shape) cls += ` ${shape}`
+
+  // tone class from kind
+  const tone = KIND_TONE[node.kind]
+  if (tone) cls += ` ${tone}`
+
+  el.className = cls
+  el.dataset.id = node.id
+
+  // position: CSS var convention matching fgraph-base.css (--x, --y in 0..100 % space)
+  el.style.setProperty('--x', node.x)
+  el.style.setProperty('--y', node.y)
+
+  // card style resolution: per-node override (highest) → typeDefault → 'simple' fallback (RD-3)
+  const style = node.cardStyle || typeDefault || 'simple'
+
+  if (style === 'premium') {
+    el.classList.add('fd-card-premium')
+    // node.glow → accent halo on hub / hero cards (craft bar)
+    if (node.glow) el.classList.add('fd-glow')
+    el.innerHTML = buildPremiumCard(node)
+  } else {
+    el.innerHTML = buildSimpleCard(node)
+  }
+
+  // register in shared nodeEl map (declared in core.js scope)
+  nodeEl[node.id] = el
+
+  return el
+}
+
+// ── renderNodes ───────────────────────────────────────────────────────
+// descriptor — full fd-data descriptor object
+// typeDefault comes from types/{type}.js via the init() call
+// biome-ignore lint/correctness/noUnusedVariables: called by core.js in concat bundle
+function renderNodes(descriptor, typeDefault) {
+  const nodes = descriptor.nodes || []
+  for (const node of nodes) {
+    const el = renderNode(node, typeDefault)
+    canvas.appendChild(el)
+  }
+}
+
+
+/* ── fd/particles.js ── */
+// fd/particles.js — Layer 4: rAF particle engine
+// Lifted verbatim from lyra-stack-v2.html lines 628-691 and adapted for
+// the fd-engine descriptor-driven contract (RD-2).
+//
+// Opt-in contract (RD-2):
+//   descriptor.options.particles === false (default) → particles OFF (AC-9)
+//   descriptor.options.particles === true  → one-shot per edge on hover/UC trigger
+//   descriptor.options.particles === "loop" → continuous: spawnParticle() loops on active edges
+//
+// Concat order: core.js → edges.js → cards.js → particles.js → [interactions.js] → types/{type}.js
+// Depends on: NS, svg, pathByPair, pairKey — declared in core.js / edges.js scope.
+//
+// Guard: zero occurrences of the banned lowercase token in this file.
+// Self-check: grep -rn '\bmermaid\b' plugins/forge/ must be empty.
+
+function easeInOutCubic(t) {
+  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2
+}
+
+// Active particle state — one particle at a time (one-shot mode)
+// Loop mode tracks multiple particles via loopParticles[]
+let _particleEl = null
+let _particleRAF = null
+let _loopParticles = [] // [{wrapper, rafId}] — loop mode only
+
+function clearParticle() {
+  if (_particleRAF) {
+    cancelAnimationFrame(_particleRAF)
+    _particleRAF = null
+  }
+  if (_particleEl) {
+    _particleEl.remove()
+    _particleEl = null
+  }
+}
+
+// clearLoopParticles: stop all loop-mode particles
+function clearLoopParticles() {
+  for (let i = 0; i < _loopParticles.length; i++) {
+    const lp = _loopParticles[i]
+    if (lp.rafId) cancelAnimationFrame(lp.rafId)
+    if (lp.wrapper) lp.wrapper.remove()
+  }
+  _loopParticles = []
+}
+
+// ── spawnParticle ─────────────────────────────────────────────────────────
+// Lifted verbatim from lyra-stack-v2.html l.640-691, adapted for fd-engine:
+//   - plane color resolved via CSS var --fd-plane-{plane} (AC-6, never hardcoded hex)
+//   - particle wrapper class: fd-particle-wrap (matches fd-architecture.html CSS)
+//   - forward direction: pathEl.dataset.f === edgeF (verbatim from source)
+//
+// edgeF, edgeT: node ids of the edge endpoints (directional for forward/reverse)
+// plane:        semantic plane string ('control', 'write', etc.)
+// duration:     animation duration in ms (default 750, per spec)
+// onDone:       optional callback invoked when animation completes (for loop scheduling)
+//
+function spawnParticle(edgeF, edgeT, plane, duration, onDone) {
+  const dur = duration || 750
+  const pk = pairKey(edgeF, edgeT)
+  const pathEl = pathByPair.get(pk)
+  if (!pathEl) return null
+
+  // Resolve color from CSS var (theme-aware, AC-6)
+  // Fallback chain: --fd-plane-{plane} → #8aa0bd (muted default)
+  let col = '#8aa0bd'
+  const tmp = document.documentElement
+  const resolved = getComputedStyle(tmp).getPropertyValue(`--fd-plane-${plane}`).trim()
+  if (resolved) col = resolved
+
+  const forward = pathEl.dataset.f === edgeF
+  const len = pathEl.getTotalLength()
+
+  // Build halo + core inside a <g class="fd-particle-wrap"> (verbatim structure l.664-673)
+  const wrapper = document.createElementNS(NS, 'g')
+  wrapper.setAttribute('class', 'fd-particle-wrap')
+  wrapper.style.setProperty('--pcol', col)
+
+  const halo = document.createElementNS(NS, 'circle')
+  halo.setAttribute('r', '9')
+  halo.setAttribute('fill', col)
+  halo.setAttribute('opacity', '0.22')
+
+  const core = document.createElementNS(NS, 'circle')
+  core.setAttribute('r', '5')
+  core.setAttribute('fill', col)
+
+  wrapper.appendChild(halo)
+  wrapper.appendChild(core)
+  svg.appendChild(wrapper)
+
+  const start = performance.now()
+
+  function frame(now) {
+    const u = Math.min((now - start) / dur, 1)
+    const e = easeInOutCubic(u)
+    const d = forward ? e * len : (1 - e) * len
+    const pt = pathEl.getPointAtLength(d)
+    halo.setAttribute('cx', pt.x)
+    halo.setAttribute('cy', pt.y)
+    core.setAttribute('cx', pt.x)
+    core.setAttribute('cy', pt.y)
+    if (u < 1) {
+      return requestAnimationFrame(frame)
+    }
+    if (typeof onDone === 'function') onDone()
+    return null
+  }
+
+  const rafId = requestAnimationFrame(frame)
+  return { wrapper, rafId }
+}
+
+// ── startParticles / stopParticles (loop mode) ────────────────────────────
+// Called by the engine bootstrap when descriptor.options.particles === "loop".
+// Runs spawnParticle() continuously on all active edges, recycling on completion.
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function startParticles(descriptor) {
+  clearLoopParticles()
+  const edges = descriptor?.edges || []
+  if (!edges.length) return
+
+  // Loop: spawn one particle per edge in sequence, recycling each on completion
+  function spawnLoop(edgeIdx) {
+    const e = edges[edgeIdx % edges.length]
+    const plane = e.plane || 'control'
+    const lp = { wrapper: null, rafId: null }
+    _loopParticles.push(lp)
+
+    function onDone() {
+      if (lp.wrapper) lp.wrapper.remove()
+      // Re-spawn after a brief gap (50ms), cycling through edges
+      setTimeout(() => {
+        const nextIdx = (edgeIdx + 1) % edges.length
+        spawnLoop(nextIdx)
+      }, 50)
+    }
+
+    const result = spawnParticle(e.f, e.t, plane, 750, onDone)
+    if (result) {
+      lp.wrapper = result.wrapper
+      lp.rafId = result.rafId
+    }
+  }
+
+  // Stagger initial spawns across edges
+  edges.forEach((_e, i) => {
+    setTimeout(() => {
+      spawnLoop(i)
+    }, i * 180)
+  })
+}
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function stopParticles() {
+  clearParticle()
+  clearLoopParticles()
+}
+
+
+/* ── fd/interactions.js ── */
+// fd/interactions.js — Layer 5: spotlight, use-case step sequencer, sidebar
+// Lifted from lyra-stack-v2.html lines 720-974 and adapted for the
+// fd-engine descriptor-driven contract.
+//
+// Spotlight (hover): dimmed class on canvas, hot class on touched edges + neighbor nodes.
+// Use-case animation: descriptor.useCases[] → step sequencer (play/pause/reset/replay).
+// Sidebar: optional (descriptor.options.sidebar); falls back gracefully when absent.
+//
+// Concat order: core.js → edges.js → cards.js → particles.js → interactions.js → types/{type}.js
+// Depends on: canvas, nodeEl, paths, pathByPair, pairKey, svg — core.js/edges.js scope.
+//             spawnParticle, clearParticle — particles.js scope.
+//             DESCRIPTOR — core.js scope.
+//
+// Guard: zero occurrences of the banned lowercase token in this file.
+
+// ── spotlight (hover) ─────────────────────────────────────────────────────
+// Adapted from lyra-stack-v2.html l.720-751.
+// sidebar: optional; nodeData: the node descriptor object for the hovered node.
+
+function spotlight(nodeData) {
+  canvas.classList.add('dimmed')
+  const id = nodeData.id
+  const neigh = {}
+  neigh[id] = true
+
+  paths.forEach((p) => {
+    const on = p.dataset.f === id || p.dataset.t === id
+    p.classList.toggle('hot', on)
+    if (on) {
+      neigh[p.dataset.f] = true
+      neigh[p.dataset.t] = true
+    }
+  })
+
+  // edge labels follow their path
+  svg.querySelectorAll('text[data-pk]').forEach((t) => {
+    const pk = t.dataset.pk
+    const p = pathByPair.get(pk)
+    t.classList.toggle('hot', p?.classList.contains('hot') ?? false)
+  })
+
+  Object.keys(nodeEl).forEach((k) => {
+    nodeEl[k].classList.toggle('hot', !!neigh[k])
+  })
+
+  // sidebar header: update if sidebar exists
+  const sbHeader = document.getElementById('sbHeader')
+  if (sbHeader) {
+    const hostStr = !nodeData.h || nodeData.h === 'EX' ? 'external' : nodeData.h === 'M1' ? 'M&#x2081;' : 'M&#x2082;'
+    sbHeader.innerHTML =
+      `<h4>${nodeData.n}</h4>` +
+      (nodeData.img ? `<div class="fd-img">${nodeData.img}</div>` : '') +
+      `<dl><dt>plane</dt><dd>${nodeData.plane || '&#x2014;'}</dd>` +
+      `<dt>host</dt><dd>${hostStr}</dd>` +
+      `<dt>role</dt><dd>${nodeData.d || '&#x2014;'}</dd></dl>`
+  }
+}
+
+function clearSpot() {
+  canvas.classList.remove('dimmed')
+  paths.forEach((p) => {
+    p.classList.remove('hot')
+  })
+  svg.querySelectorAll('text').forEach((t) => {
+    t.classList.remove('hot')
+  })
+  Object.values(nodeEl).forEach((el) => {
+    el.classList.remove('hot')
+  })
+
+  // reset sidebar header to default hint
+  const sbHeader = document.getElementById('sbHeader')
+  if (sbHeader) {
+    sbHeader.innerHTML =
+      '<h4>Hover = detail</h4>' +
+      '<div class="hint">Hover a node to isolate its edges and see image / host / role.<br>Select a use case to animate the flow.</div>'
+  }
+}
+
+// ── use-case step sequencer ───────────────────────────────────────────────
+// Adapted from lyra-stack-v2.html l.770-974.
+// State machine: 'none' | 'ready' | 'playing' | 'paused' | 'done'
+// Only wired when descriptor.useCases is present.
+
+let _ucActiveIdx = null
+let _ucState = 'none'
+let _ucTimer = null
+let _ucStepIdx = 0
+
+function _syncUcButtons() {
+  const ucPlay = document.getElementById('ucPlay')
+  const ucReset = document.getElementById('ucReset')
+  if (!ucPlay) return
+  switch (_ucState) {
+    case 'none':
+      ucPlay.textContent = '▶ play'
+      ucPlay.disabled = true
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'ready':
+      ucPlay.textContent = '▶ play'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'playing':
+      ucPlay.textContent = '⏸ pause'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'paused':
+      ucPlay.textContent = '▶ resume'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.add('visible')
+      break
+    case 'done':
+      ucPlay.textContent = '↺ replay'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+  }
+}
+
+function _resetUcVisuals() {
+  Object.values(nodeEl).forEach((el) => {
+    el.classList.remove('uc-active', 'uc-done')
+  })
+  paths.forEach((p) => {
+    p.classList.remove('uc-active', 'uc-done')
+  })
+  canvas.classList.remove('dimmed')
+  // clear particle (particles.js)
+  if (typeof clearParticle === 'function') clearParticle()
+
+  const ucStepsList = document.getElementById('ucStepsList')
+  if (ucStepsList) {
+    ucStepsList.querySelectorAll('li').forEach((li) => {
+      li.classList.remove('step-active', 'step-done')
+    })
+  }
+}
+
+function _stopUcTimer() {
+  if (_ucTimer) {
+    clearTimeout(_ucTimer)
+    _ucTimer = null
+  }
+}
+
+function _selectUc(idx) {
+  _stopUcTimer()
+  _resetUcVisuals()
+  _ucActiveIdx = idx
+  _ucStepIdx = 0
+  _ucState = 'ready'
+
+  const uc = DESCRIPTOR.useCases[idx]
+  const ucTitle = document.getElementById('ucTitle')
+  const ucDesc = document.getElementById('ucDesc')
+  const ucStepsList = document.getElementById('ucStepsList')
+  const sbUc = document.getElementById('sbUc')
+
+  if (ucTitle) ucTitle.textContent = uc.title
+  if (ucDesc) ucDesc.innerHTML = uc.desc
+  if (ucStepsList) {
+    ucStepsList.innerHTML = ''
+    uc.steps.forEach((s, i) => {
+      const li = document.createElement('li')
+      li.innerHTML = `<span class="sn">${String(i + 1).padStart(2, '0')}</span>${s.label}`
+      ucStepsList.appendChild(li)
+    })
+  }
+  if (sbUc) sbUc.classList.add('visible')
+
+  document.querySelectorAll('.uc-btn').forEach((b) => {
+    b.classList.toggle('active', Number(b.dataset.uc) === idx)
+  })
+  _syncUcButtons()
+}
+
+function _applyUcStep(stepIdx) {
+  const uc = DESCRIPTOR.useCases[_ucActiveIdx]
+  if (stepIdx >= uc.steps.length) {
+    _ucState = 'done'
+    _syncUcButtons()
+    return
+  }
+  _ucStepIdx = stepIdx
+  const step = uc.steps[stepIdx]
+  canvas.classList.add('dimmed')
+
+  // mark previous steps done (verbatim from lyra-stack-v2)
+  for (let i = 0; i < stepIdx; i++) {
+    uc.steps[i].nodes.forEach((id) => {
+      if (nodeEl[id]) {
+        nodeEl[id].classList.remove('uc-active')
+        nodeEl[id].classList.add('uc-done')
+      }
+    })
+    if (uc.steps[i].edge) {
+      const prevEf = uc.steps[i].edge[0]
+      const prevEt = uc.steps[i].edge[1]
+      const prevPp = pathByPair.get(pairKey(prevEf, prevEt))
+      if (prevPp) {
+        prevPp.classList.remove('uc-active')
+        prevPp.classList.add('uc-done')
+      }
+    }
+  }
+
+  // activate current step nodes
+  step.nodes.forEach((id) => {
+    if (nodeEl[id]) nodeEl[id].classList.add('uc-active', 'hot')
+  })
+
+  // activate edge + spawn particle if particles opt-in
+  if (typeof clearParticle === 'function') clearParticle()
+  if (step.edge) {
+    const ef = step.edge[0]
+    const et = step.edge[1]
+    const pp = pathByPair.get(pairKey(ef, et))
+    if (pp) {
+      pp.classList.add('uc-active', 'hot')
+      // spawn particle if particles enabled and spawnParticle available
+      if (typeof spawnParticle === 'function' && DESCRIPTOR.options && DESCRIPTOR.options.particles !== false) {
+        // Find plane from edges
+        const edges = DESCRIPTOR.edges || []
+        let edgeDef = null
+        for (let j = 0; j < edges.length; j++) {
+          const ed = edges[j]
+          if ((ed.f === ef && ed.t === et) || (ed.f === et && ed.t === ef)) {
+            edgeDef = ed
+            break
+          }
+        }
+        const plane = edgeDef ? edgeDef.plane : 'control'
+        spawnParticle(ef, et, plane, 750, null)
+      }
+    }
+  }
+
+  // update step list
+  const ucStepsList = document.getElementById('ucStepsList')
+  if (ucStepsList) {
+    const items = ucStepsList.querySelectorAll('li')
+    items.forEach((li, i) => {
+      li.classList.remove('step-active', 'step-done')
+      if (i < stepIdx) li.classList.add('step-done')
+      if (i === stepIdx) li.classList.add('step-active')
+    })
+  }
+
+  // sidebar header: show step label
+  const sbHeader = document.getElementById('sbHeader')
+  const firstId = step.nodes[0]
+  if (firstId && nodeEl[firstId] && sbHeader) {
+    const nodes = DESCRIPTOR.nodes || []
+    let nd = null
+    for (let k = 0; k < nodes.length; k++) {
+      if (nodes[k].id === firstId) {
+        nd = nodes[k]
+        break
+      }
+    }
+    if (nd && _ucState !== 'playing') {
+      spotlight(nd)
+    } else {
+      sbHeader.innerHTML = `<h4>${step.label}</h4>`
+    }
+  } else if (sbHeader) {
+    sbHeader.innerHTML = `<h4>${step.label}</h4>`
+  }
+
+  _ucTimer = setTimeout(() => {
+    _applyUcStep(stepIdx + 1)
+  }, 900)
+}
+
+// ── wireUseCaseUI ─────────────────────────────────────────────────────────
+// Called from the engine bootstrap when descriptor.useCases is present.
+// Wires up .uc-btn, #ucPlay, #ucReset DOM controls.
+// Safe to call even when some controls are absent (sidebar-less mode).
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function wireUseCaseUI() {
+  document.querySelectorAll('.uc-btn').forEach((b) => {
+    b.addEventListener('click', () => {
+      _selectUc(Number(b.dataset.uc))
+    })
+  })
+
+  const ucPlay = document.getElementById('ucPlay')
+  const ucReset = document.getElementById('ucReset')
+
+  if (ucPlay) {
+    ucPlay.addEventListener('click', () => {
+      if (_ucActiveIdx === null) return
+      if (_ucState === 'playing') {
+        _stopUcTimer()
+        _ucState = 'paused'
+        _syncUcButtons()
+      } else if (_ucState === 'done' || _ucState === 'ready') {
+        _resetUcVisuals()
+        _ucStepIdx = 0
+        _ucState = 'playing'
+        _syncUcButtons()
+        _applyUcStep(0)
+      } else if (_ucState === 'paused') {
+        _ucState = 'playing'
+        _syncUcButtons()
+        _applyUcStep(_ucStepIdx)
+      }
+    })
+  }
+
+  if (ucReset) {
+    ucReset.addEventListener('click', () => {
+      _stopUcTimer()
+      _resetUcVisuals()
+      _ucStepIdx = 0
+      _ucState = 'ready'
+      _syncUcButtons()
+    })
+  }
+}
+
+// ── wireHoverSpotlight ────────────────────────────────────────────────────
+// Adds mouseenter/mouseleave listeners to all rendered .fd-node elements.
+// Called once after renderNodes(), before draw().
+// Skips spotlight during playing state (verbatim from lyra-stack-v2 l.480-482).
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function wireHoverSpotlight() {
+  const nodes = DESCRIPTOR.nodes || []
+  nodes.forEach((nd) => {
+    const el = nodeEl[nd.id]
+    if (!el) return
+    el.addEventListener('mouseenter', () => {
+      if (_ucState !== 'playing') spotlight(nd)
+    })
+    el.addEventListener('mouseleave', () => {
+      if (_ucState !== 'playing') clearSpot()
+    })
+  })
+}
+
+
+/* ── fd/architecture.js ── */
+// fd/types/architecture.js — declarative layout handler + zone placement
+// Glob-discovery: bundler.js discovers this file via glob('fd/types/*.js').
+// Exports TYPE so bundler can key it: window.__fdTypes[TYPE] = { CARD_DEFAULT, placeZones, init }
+
+const TYPE = 'architecture'
+const CARD_DEFAULT = 'premium' // RD-3: architecture/hub-spoke default is premium
+
+// ── placeZones ────────────────────────────────────────────────────────
+// Generalised from lyra-stack-v2.html placeZone() lines 693–718.
+// Parametric over descriptor.zones[] instead of hardcoded ids.
+//
+// For each zone:
+//   1. Collect rect() measurements for all member nodes.
+//   2. Compute union bounding box (min/max of cx±w/2, cy±h/2) + padding.
+//   3. Apply left/top/width/height to zone div#{zone.id} (bare id — no prefix added).
+//   4. Create the zone div if absent (class: fd-zone + zone.class).
+//
+// Zone descriptor id == HTML element id: zone.id = "zone-forge" → getElementById("zone-forge").
+// rect() is declared in core.js scope (concat order: core.js, cards.js, architecture.js).
+function zonePadding(zone) {
+  const p = zone.padding || {}
+  if (zone.class === 'zone-hub') {
+    return { x: p.x ?? 14, yt: p.top ?? 36, yb: p.bottom ?? 12 }
+  }
+  if (zone.class === 'zone-stores') {
+    return { x: p.x ?? 14, yt: p.top ?? 20, yb: p.bottom ?? 10 }
+  }
+  if (zone.class === 'zone-m2') {
+    return { x: p.x ?? 16, yt: p.top ?? 20, yb: p.bottom ?? 12 }
+  }
+  return { x: p.x ?? 16, yt: p.top ?? 20, yb: p.bottom ?? 12 }
+}
+
+function placeZones(descriptor) {
+  const zones = descriptor.zones
+  if (!zones || zones.length === 0) return
+
+  for (const zone of zones) {
+    // resolve or create zone div — bare zone.id, no prefix added
+    let zEl = document.getElementById(zone.id)
+    if (!zEl) {
+      zEl = document.createElement('div')
+      zEl.id = zone.id
+      let cls = 'fd-zone'
+      if (zone.class) cls += ` ${zone.class}`
+      zEl.className = cls
+
+      // inject zone label if provided
+      if (zone.label) {
+        const lbl = document.createElement('span')
+        lbl.className = 'fd-zone-label'
+        lbl.textContent = zone.label
+        zEl.appendChild(lbl)
+      }
+
+      canvas.insertBefore(zEl, canvas.firstChild)
+    }
+
+    // measure member nodes — guard against unknown ids (node not yet rendered or missing)
+    const memberIds = zone.nodes || []
+    if (memberIds.length === 0) continue
+
+    const rects = memberIds.map((id) => (nodeEl[id] ? rect(id) : null)).filter(Boolean)
+    if (rects.length === 0) continue
+
+    // union bounding box
+    const xMin = Math.min(...rects.map((r) => r.cx - r.w / 2))
+    const xMax = Math.max(...rects.map((r) => r.cx + r.w / 2))
+    const yMin = Math.min(...rects.map((r) => r.cy - r.h / 2))
+    const yMax = Math.max(...rects.map((r) => r.cy + r.h / 2))
+
+    // Per-zone padding — mirrors lyra-stack-v2.html placeZone() (hub 26/18/14, stores 18/14/10)
+    const pad = zonePadding(zone)
+    const padX = pad.x
+    const padYT = pad.yt
+    const padYB = pad.yb
+
+    const left = xMin - padX
+    const top = yMin - padYT
+    const width = xMax + padX - left
+    const height = yMax + padYB - top
+
+    zEl.style.left = `${left}px`
+    zEl.style.top = `${top}px`
+    zEl.style.width = `${width}px`
+    zEl.style.height = `${height}px`
+  }
+}
+
+// ── init ──────────────────────────────────────────────────────────────
+// Called by the fd-engine bootstrap after parsing fd-data.
+// Returns { typeDefault, placeZones } consumed by the engine orchestrator.
+function init(descriptor) {
+  const t = descriptor.type
+  if (t !== 'architecture' && t !== 'hub-spoke') {
+    console.warn('[fd] architecture.js init() called with unexpected type:', t)
+  }
+  // layout is declarative — no elk step; x/y already in descriptor
+  return {
+    typeDefault: CARD_DEFAULT,
+    placeZones,
+  }
+}
+
+// ── glob-discovery registration ───────────────────────────────────────
+// bundler.js discovers fd/types/*.js and concatenates them into the
+// inline <script>. At runtime each type module self-registers here.
+window.__fdTypes = window.__fdTypes || {}
+window.__fdTypes[TYPE] = { CARD_DEFAULT, placeZones, init }
+// 'hub-spoke' is an alias for 'architecture'
+window.__fdTypes['hub-spoke'] = window.__fdTypes[TYPE]
+
+
+/* ── __fd window entry (generated by bundler.js) ── */
+window.__fd = {
+  initEngine: initEngine,
+  renderNodes: renderNodes,
+  draw: draw,
+  wireResize: wireResize,
+  uniquePlanes: typeof uniquePlanes !== 'undefined' ? uniquePlanes : null,
+  initMarkers: typeof initMarkers !== 'undefined' ? initMarkers : null,
+}
+})()
+
+</script>
+
+<script>
+// fd-bootstrap.js — universal runtime bootstrap for gen-fd.py output
+// Inlined after the fd-engine IIFE bundle. Expects window.__fd + window.__fdTypes.
+
+;(() => {
+  function run() {
+    var dataEl = document.getElementById('fd-data')
+    if (!dataEl || !window.__fd) return
+
+    var descriptor = JSON.parse(dataEl.textContent)
+    var canvasEl = document.getElementById('fd-canvas')
+    var svgEl = document.getElementById('fd-edges')
+    if (!canvasEl || !svgEl) return
+
+    var type = descriptor.type || 'architecture'
+    var typeReg = window.__fdTypes && window.__fdTypes[type]
+    var typeInit = typeReg && typeof typeReg.init === 'function' ? typeReg.init(descriptor) : null
+    var typeDefault = (typeInit && typeInit.typeDefault) || (typeReg && typeReg.CARD_DEFAULT) || 'premium'
+
+    if (descriptor.canvas && descriptor.canvas.height) {
+      canvasEl.style.setProperty('--fd-canvas-h', descriptor.canvas.height + 'px')
+      canvasEl.style.height = descriptor.canvas.height + 'px'
+    }
+
+    window.__fd.initEngine(descriptor, canvasEl, svgEl)
+
+    // Chart-only types (gantt, pie, xychart) bypass node/edge engine
+    if (typeReg && typeof typeReg.renderChart === 'function') {
+      typeReg.renderChart(descriptor)
+      return
+    }
+
+    window.__fd.renderNodes(descriptor, typeDefault)
+
+    if (typeInit && typeof typeInit.positionNodes === 'function') {
+      typeInit.positionNodes(descriptor)
+    } else if (typeReg && typeof typeReg.positionNodes === 'function') {
+      typeReg.positionNodes(descriptor)
+    }
+
+    if (typeInit && typeof typeInit.applyShapes === 'function') {
+      typeInit.applyShapes(descriptor)
+    } else if (typeReg && typeof typeReg.applyShapes === 'function') {
+      typeReg.applyShapes(descriptor)
+    }
+
+    if (window.__fd.initMarkers && window.__fd.uniquePlanes) {
+      window.__fd.initMarkers(window.__fd.uniquePlanes())
+    }
+
+    window.__fd.draw()
+
+    var placeZonesFn = (typeInit && typeInit.placeZones) || (typeReg && typeReg.placeZones) || null
+    if (typeof placeZonesFn === 'function') {
+      placeZonesFn(descriptor)
+    }
+
+    window.__fd.wireResize()
+
+    if (typeof wireHoverSpotlight === 'function' && descriptor.options && descriptor.options.spotlight !== false) {
+      wireHoverSpotlight()
+    }
+
+    if (typeof wireUseCaseUI === 'function' && descriptor.useCases && descriptor.useCases.length) {
+      wireUseCaseUI()
+    }
+
+    document.querySelectorAll('.ctl[data-plane]').forEach((ctl) => {
+      ctl.addEventListener('click', () => {
+        ctl.classList.toggle('off')
+        canvasEl.classList.toggle('hide-' + ctl.dataset.plane, ctl.classList.contains('off'))
+      })
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      setTimeout(run, 80)
+    })
+  } else {
+    setTimeout(run, 80)
+  }
+})()
+
+</script>
+</body>
+</html>

--- a/artifacts/visuals/310-notation-glossary-guardrails-file-map.html
+++ b/artifacts/visuals/310-notation-glossary-guardrails-file-map.html
@@ -1,0 +1,2834 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="diagram:title" content="#310 notation glossary guardrails — file map">
+<meta name="diagram:category" content="architecture">
+<meta name="diagram:color" content="#22d3ee">
+<meta name="diagram:engine" content="fd-engine">
+<meta name="diagram:type" content="architecture">
+<title>#310 notation glossary guardrails — file map</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+/* reset */
+*,*::before,*::after{box-sizing:border-box}
+html,body{margin:0;padding:0}
+ul,ol{list-style:none;margin:0;padding:0}
+button{cursor:pointer;font-family:inherit}
+
+/* ══════════════════════════════════════════════════════════════════
+   lyra-v2.css — Lyra brand aesthetic · v2 (GitHub-dark variant)
+   Used by: lyra, voicecli (v2-styled artifacts only)
+
+   Difference vs lyra.css (v1 "Forge Floor"):
+   - Surfaces rebased on GitHub-dark (#0d1117 family) with an explicit
+     elevation ladder: bg < bg-cell < bg-panel < bg-card
+   - Adds --border-hi for stronger dividers in dense data grids
+   - Accent alphas pushed (dim 0.08→0.12, glow 0.22→0.40) for more
+     "live ember" feel on cards and nodes
+   - Drops the forge-floor body chrome (spark particles + 42px grid)
+     — v2 docs are flat, data-dense, GitHub-network-graph style
+   - Adds lane palette (lane-a1..i, status-ready/blocked/done) so
+     dep-graph / kernel-arch / swimlane docs share one token set
+
+   Reference implementations:
+   - lyra-v2-dependency-graph-v5.1.html
+   - lyra-kernel-architecture-v5.html
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Brand Tokens — Dark (default, v2 only exists in dark) ── */
+:root, [data-theme="dark"] {
+  color-scheme: dark;
+
+  /* Surface elevation ladder (darkest → lightest) */
+  --bg:           #0d1117;  /* page */
+  --bg-cell:      #0f141a;  /* grid cell / recessed surface inside panel */
+  --bg-panel:     #13191f;  /* section / wrapper */
+  --bg-card:      #161b22;  /* card / raised surface inside panel */
+
+  /* Legacy aliases — keep v1 variable names working in v2 docs */
+  --surface:      #13191f;  /* alias → bg-panel */
+  --surface2:     #161b22;  /* alias → bg-card */
+
+  /* Dividers */
+  --border:       #21262d;
+  --border-hi:    #30363d;
+  --border-bright:#30363d;  /* alias → border-hi */
+
+  /* Text ramp */
+  --text:         #fafafa;
+  --text-muted:   #8b93a1;
+  --text-dim:     #6b7280;
+
+  /* Forge orange — same hue as v1, stronger alphas */
+  --accent:       #e85d04;
+  --accent-2:     #f97316;
+  --accent-dim:   rgba(232,93,4,0.12);
+  --accent-glow:  rgba(232,93,4,0.40);
+  --error:        #ef4444;
+
+  /* Extended lane palette — shared by dep-graph, kernel-arch, swimlanes */
+  --teal:    #06b6d4;  --teal-dim:   rgba(6,182,212,0.10);
+  --amber:   #f59e0b;  --amber-dim:  rgba(245,158,11,0.10);
+  --green:   #10b981;  --green-dim:  rgba(16,185,129,0.10);
+  --cyan:    #22d3ee;
+  --purple:  #c084fc;
+  --pink:    #ec4899;  --pink-dim:   rgba(236,72,153,0.10);
+  --plum:    #a855f7;  --plum-dim:   rgba(168,85,247,0.10);
+  --red:     #ef4444;  --red-dim:    rgba(239,68,68,0.10);
+
+  /* Issue / task status — for plan artifacts */
+  --status-ready:   #22c55e;
+  --status-blocked: #f97316;
+  --status-done:    #475569;
+
+  /* Lane tones — for multi-lane swim/DAG views */
+  --lane-a1: #22c55e;
+  --lane-a2: #6366f1;
+  --lane-a3: #8b5cf6;
+  --lane-b:  #3b82f6;
+  --lane-c1: #a855f7;
+  --lane-c2: #d946ef;
+  --lane-c3: #ec4899;
+  --lane-d:  #06b6d4;
+  --lane-e:  #eab308;
+  --lane-f:  #10b981;
+  --lane-g:  #f97316;
+  --lane-h:  #f59e0b;
+  --lane-i:  #14b8a6;
+}
+
+/* v2 is dark-only by design. If a doc needs a light mode, use lyra.css v1. */
+
+/* ══════════════════════════════════════════════════════════════════
+   Base page chrome — flat body, 24px gutter, 12px base type
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 body,
+body.lyra-v2 {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', system-ui, sans-serif;
+  padding: 24px;
+  min-height: 100vh;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Page header primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 header.page-header,
+body.lyra-v2 header.page-header {
+  max-width: 100%;
+  margin: 0 auto 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.lyra-v2 header.page-header h1,
+body.lyra-v2 header.page-header h1 {
+  font-family: 'Outfit', sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.lyra-v2 header.page-header h1 .accent,
+body.lyra-v2 header.page-header h1 .accent { color: var(--accent); }
+.lyra-v2 .subtitle,
+body.lyra-v2 .subtitle {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin-top: 6px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Section / panel primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 .section,
+body.lyra-v2 .section {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 18px 20px 20px;
+  position: relative;
+  overflow: hidden;
+}
+.lyra-v2 .section-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.lyra-v2 .section-title {
+  font-family: 'Outfit', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--text);
+  margin-bottom: 4px;
+  letter-spacing: -0.02em;
+}
+.lyra-v2 .section-title .accent { color: var(--accent); }
+.lyra-v2 .section-subtitle {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+  line-height: 1.45;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Card primitive — raised surface with border-left tone stripe
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 .card {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 9px 11px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-hi);
+  border-left: 3px solid currentColor;
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--text);
+  transition: background 0.15s, border-color 0.15s, transform 0.12s;
+}
+.lyra-v2 .card:hover {
+  background: var(--bg-panel);
+  border-color: currentColor;
+  transform: translateX(1px);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   Footer primitive
+   ══════════════════════════════════════════════════════════════════ */
+.lyra-v2 footer.page-footer {
+  margin-top: 18px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+}
+.lyra-v2 footer.page-footer a { color: var(--accent); text-decoration: none; }
+.lyra-v2 footer.page-footer a:hover { text-decoration: underline; }
+
+/* ══════════════════════════════════════════════════════════════════
+   Slide mode — lyra-v2 aesthetic (forge-slides)
+   Same flame-gradient as v1, but on the GitHub-dark ladder.
+   ══════════════════════════════════════════════════════════════════ */
+.deck.lyra-v2 .slide--title,
+.lyra-v2 .deck .slide--title {
+  background-image:
+    radial-gradient(ellipse at 50% 30%, var(--accent-glow) 0%, transparent 55%),
+    linear-gradient(135deg, var(--bg) 0%, var(--bg-panel) 100%);
+}
+.lyra-v2 .deck .slide--title .slide__display {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--title .slide__subtitle { color: var(--text-muted); }
+.lyra-v2 .deck .slide--content .slide__label { color: var(--accent); }
+.lyra-v2 .deck .slide--content .slide__heading {
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+.lyra-v2 .deck .slide--content li::before { color: var(--accent); }
+.lyra-v2 .deck .slide--section .slide__number {
+  color: var(--accent);
+  opacity: 0.1;
+}
+.lyra-v2 .deck .slide--closing {
+  background-image:
+    radial-gradient(ellipse at 50% 70%, var(--accent-glow) 0%, transparent 60%),
+    linear-gradient(to top, var(--bg), var(--bg-panel));
+}
+.lyra-v2 .deck .slide--closing .slide__heading {
+  color: var(--accent);
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--closing .cta {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+  border: none;
+  font-weight: 700;
+}
+.lyra-v2 .deck .slide--quote .slide__quote-mark { color: var(--accent); }
+.lyra-v2 .deck .slide--comparison .slide__col.accent {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+}
+
+
+/* fd-engine.css — static rules for the fd-engine canvas, nodes, edges, card variants
+ * Inlined into generated HTML output at generation time (not linked at runtime).
+ * No viewBox / no preserveAspectRatio on the SVG overlay (AC-10).
+ * Self-bootstrapping: the :root block below maps each internal short-name token to a
+ *   universal forge aesthetic token with a hard fallback. Works on lyra-v2, cool-dark,
+ *   editorial, and all other aesthetics — no per-aesthetic shim needed.
+ * Plane CSS vars (--fd-plane-{name}) default below; aesthetic layer may override.
+ */
+
+/* ---- Token contract: self-bootstrapping short-name aliases ---- */
+/* fd-engine.css is inlined AFTER the aesthetic, so these :root declarations run last.
+ *
+ * Two mapping strategies:
+ *   A) fd short-name ≠ aesthetic token name → var(--universal-name, #hex)
+ *      The aesthetic's universal token wins; hard hex = lyra-v2 dark fallback.
+ *   B) fd short-name = aesthetic token name (--cyan, --amber, --slate, …) →
+ *      hard hex fallback only (no self-referential var()); aesthetics that already
+ *      declare the token will have their value replaced by the same hex here — safe
+ *      because we target the same colour. Aesthetics that omit the token get the
+ *      fallback, which is what we want.
+ *
+ * Regression note for roxabi.css (defines --panel:#13191f, no --bg-panel):
+ *   --panel → var(--bg-panel, #13191f) → bg-panel absent → #13191f = unchanged. ✓ */
+:root {
+  /* Strategy A: fd name ≠ aesthetic universal name */
+  --panel:  var(--bg-panel,   #13191f);
+  --panel2: var(--bg-card,    #161b22);
+  --bd2:    var(--border-hi,  #30363d);
+  --mut:    var(--text-muted, #8b93a1);
+  --mut2:   var(--text-dim,   #6b7280);
+  --mono:   var(--font-mono,  "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+  --sans:   var(--font-sans,  "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif);
+  --vio:    var(--plum,       #a855f7);
+  --emer:   var(--green,      #10b981);
+  /* Strategy B: fd name = aesthetic token name — hard fallback, no self-ref var() */
+  --slate:  #64748b;
+  --amber:  #f59e0b;
+  --cyan:   #22d3ee;
+  --sky:    #58a6ff;
+  --orng:   #fb923c;
+  --rose:   #fb7185;
+}
+
+/* ---- Plane color defaults (overridden by aesthetic inlines) ---- */
+:root {
+  --fd-plane-control:  #38bdf8;
+  --fd-plane-write:    #34d399;
+  --fd-plane-read:     #64748b;
+  --fd-plane-data:     #a78bfa;
+  --fd-plane-async:    #fb923c;
+  --fd-plane-feedback: #fb7185;
+  --fd-plane-message:  #38bdf8;
+  --fd-plane-media:    #fbbf24;
+  --fd-plane-llm:      #a78bfa;
+  --fd-canvas-h:       720px;
+}
+
+/* ---- Canvas container ---- */
+.fd-canvas {
+  position: relative;
+  width: 100%;
+  height: var(--fd-canvas-h, 720px);
+}
+
+/* ---- SVG overlay (AC-10: no viewBox, no preserveAspectRatio) ---- */
+.fd-edges {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+  z-index: 1;
+}
+
+/* ---- Edge path base rules ---- */
+.fd-edges path {
+  fill: none;
+  stroke-width: 1.8;
+  opacity: .62;
+  transition: opacity .15s, stroke-width .15s;
+}
+
+/* ---- Per-plane stroke colors ---- */
+.fd-edges path.control  { stroke: var(--fd-plane-control);  }
+.fd-edges path.write    { stroke: var(--fd-plane-write);    }
+.fd-edges path.read     { stroke: var(--fd-plane-read);     }
+.fd-edges path.data     { stroke: var(--fd-plane-data);     }
+.fd-edges path.async    { stroke: var(--fd-plane-async);    }
+.fd-edges path.feedback { stroke: var(--fd-plane-feedback); }
+.fd-edges path.message  { stroke: var(--fd-plane-message);  }
+.fd-edges path.media    { stroke: var(--fd-plane-media);    }
+.fd-edges path.llm      { stroke: var(--fd-plane-llm);      }
+
+/* ---- Edge state classes (dimmed / hot) ---- */
+.fd-edges path.hot {
+  opacity: 1;
+  stroke-width: 3;
+}
+.fd-canvas.dimmed .fd-edges path:not(.hot) {
+  opacity: .06;
+}
+
+/* ---- Use-case edge states ---- */
+.fd-edges path.uc-active {
+  opacity: 1 !important;
+  stroke-width: 2.8 !important;
+}
+.fd-edges path.uc-done {
+  opacity: .48 !important;
+  stroke-width: 2 !important;
+}
+
+/* ---- Edge label ---- */
+.fd-elabel {
+  font-family: var(--mono);
+  font-size: 9px;
+  fill: var(--mut);
+  opacity: 0;
+}
+.fd-elabel.hot {
+  opacity: 1;
+}
+
+/* ---- Particle dot wrapper ---- */
+.fd-edges g.fd-particle-wrap {
+  filter: drop-shadow(0 0 6px var(--pcol, #38bdf8));
+}
+
+/* ---- Node base (.fd-node extends fgraph-base .fgraph-node conventions) ---- */
+/* % coordinate system: --x and --y in 0..100 range, matching fgraph-base.css */
+.fd-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  left: calc(var(--x) * 1%);
+  top: calc(var(--y) * 1%);
+  z-index: 2;
+}
+
+/* ---- Premium card (.fd-card-premium) ---- */
+/* Extracted and generalized from lyra-stack-v2.html lines 135-195.
+ * Applied to nodes with cardStyle:"premium" (architecture / hub-spoke types by default). */
+.fd-card-premium {
+  width: 154px;
+  background: linear-gradient(180deg, var(--panel), var(--panel2));
+  border: 1px solid var(--bd2);
+  border-radius: 11px;
+  padding: 9px 11px 9px 13px;
+  cursor: default;
+  transition: transform .12s, box-shadow .15s, border-color .15s;
+  box-shadow: 0 3px 14px #00000055;
+}
+
+/* Keep canvas placement — .fd-card-premium must not override .fd-node absolute coords */
+.fd-node.fd-card-premium {
+  position: absolute;
+}
+
+.fd-card-premium:hover {
+  transform: translate(-50%, -50%) translateY(-2px);
+  border-color: #3d567a;
+  box-shadow: 0 8px 26px #000a;
+}
+
+/* Accent bar (.fd-accent) — left side color stripe */
+.fd-card-premium .fd-accent {
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--slate);
+}
+
+/* Node header row */
+.fd-card-premium .fd-nh {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+/* Node name — cards.js emits .fd-title; .fd-nn kept for legacy reference output.
+   Sans title + Mono subtitle = the dual-font craft primitive (matches the
+   lyra-diagram gold standard: IBM Plex Sans title / Mono descriptor). */
+.fd-card-premium .fd-title,
+.fd-card-premium .fd-nn {
+  font-weight: 700;
+  font-size: 12px;
+  font-family: var(--sans);
+  letter-spacing: -.2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Subtitle / image line (.fd-sub) */
+.fd-card-premium .fd-sub {
+  color: var(--mut);
+  font-size: 10px;
+  font-family: var(--mono);
+  margin-top: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Description line */
+.fd-card-premium .fd-desc {
+  color: var(--mut2);
+  font-size: 10px;
+  margin-top: 3px;
+  line-height: 1.3;
+}
+
+/* Tag badge (.fd-tag) */
+.fd-tag {
+  font-size: 8.5px;
+  font-family: var(--mono);
+  font-weight: 700;
+  padding: 1.5px 5px;
+  border-radius: 5px;
+  white-space: nowrap;
+}
+
+/* Tag color variants (plane-aware) */
+.fd-tag-control  { background: #38bdf822; color: var(--fd-plane-control,  #38bdf8); }
+.fd-tag-write    { background: #34d39922; color: var(--fd-plane-write,    #34d399); }
+.fd-tag-read     { background: #64748b22; color: #9fb3cc; }
+.fd-tag-data     { background: #a78bfa22; color: var(--fd-plane-data,     #a78bfa); }
+.fd-tag-async    { background: #fb923c22; color: var(--fd-plane-async,    #fb923c); }
+.fd-tag-feedback { background: #fb718522; color: var(--fd-plane-feedback, #fb7185); }
+.fd-tag-message  { background: #38bdf822; color: var(--fd-plane-message,  #38bdf8); }
+.fd-tag-media    { background: #fbbf2422; color: var(--fd-plane-media,    #fbbf24); }
+.fd-tag-llm      { background: #a78bfa22; color: var(--fd-plane-llm,      #a78bfa); }
+.fd-tag-base     { background: #34d39922; color: var(--emer); }
+.fd-tag-base-svc { background: #38bdf822; color: var(--sky);  }
+.fd-tag-ml-base  { background: #a78bfa22; color: var(--vio);  }
+.fd-tag-cuda     { background: #fb923c22; color: var(--orng); }
+.fd-tag-upstream { background: #64748b22; color: #9fb3cc;     }
+.fd-tag-internal { background: #38bdf814; color: #7dd3fc; border: 1px solid #38bdf822; }
+
+/* Host badge (.fd-host) — bottom-right corner */
+.fd-host {
+  position: absolute;
+  right: 7px;
+  bottom: 6px;
+  font-size: 8px;
+  font-family: var(--mono);
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 20px;
+}
+.fd-host.M1 { background: #34d39915; color: var(--emer); }
+.fd-host.M2 { background: #fbbf2415; color: var(--amber); border: 1px dashed #fbbf2255; }
+
+/* ---- Node state classes ---- */
+.fd-card-premium.hot {
+  border-color: #fff3;
+  box-shadow: 0 0 0 1px #ffffff22, 0 10px 30px #000c;
+}
+
+.fd-canvas.dimmed .fd-card-premium:not(.hot) {
+  opacity: .28;
+}
+
+/* Use-case node states */
+.fd-card-premium.uc-active {
+  border-color: var(--amber) !important;
+  box-shadow: 0 0 0 2px #fbbf2444, 0 0 22px #fbbf2433, 0 6px 24px #000c !important;
+  z-index: 5;
+}
+.fd-card-premium.uc-done {
+  border-color: #fbbf2466 !important;
+  opacity: 1 !important;
+}
+
+/* Dormant node */
+.fd-card-premium.dormant {
+  opacity: .62;
+}
+.fd-card-premium.dormant .fd-title::after,
+.fd-card-premium.dormant .fd-nn::after {
+  content: " ⊘";
+  color: var(--rose);
+}
+
+/* ---- Node kind variants ---- */
+
+/* Bus node (wide horizontal bar) */
+.fd-card-premium.fd-kind-bus {
+  width: 62%;
+  max-width: 820px;
+  background: linear-gradient(90deg, #0e2233, #10283c, #0e2233);
+  border: 1.5px solid #2a6b8f;
+  box-shadow: 0 0 26px #38bdf820, inset 0 0 30px #38bdf80f;
+  padding: 11px 18px;
+}
+.fd-card-premium.fd-kind-bus .fd-accent { display: none; }
+.fd-card-premium.fd-kind-bus .fd-title,
+.fd-card-premium.fd-kind-bus .fd-nn { font-size: 13px; color: var(--cyan); }
+.fd-card-premium.fd-kind-bus .fd-nh { justify-content: flex-start; gap: 9px; }
+.fd-card-premium.fd-kind-bus .fd-subj {
+  color: var(--mut);
+  font-size: 9.5px;
+  font-family: var(--mono);
+  margin-top: 5px;
+  letter-spacing: .2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fd-card-premium.fd-kind-bus .fd-subj b { color: #bfe6ff; font-weight: 600; }
+
+/* Store node */
+.fd-card-premium.fd-kind-store {
+  width: 142px;
+  background: linear-gradient(180deg, #140e24, #110c20);
+  border-color: #2d1e4a;
+}
+.fd-card-premium.fd-kind-store .fd-accent { background: var(--vio); }
+
+/* Hub-interior sub-node */
+.fd-card-premium.fd-kind-hub-int {
+  width: 136px;
+  padding: 7px 9px 7px 11px;
+  background: linear-gradient(180deg, #0d1a2e, #0b1526);
+  border-color: #1e3555;
+}
+.fd-card-premium.fd-kind-hub-int .fd-accent { background: var(--hub-c, var(--cyan)); }
+.fd-card-premium.fd-kind-hub-int .fd-title,
+.fd-card-premium.fd-kind-hub-int .fd-nn { font-size: 11px; }
+.fd-card-premium.fd-kind-hub-int .fd-desc { font-size: 9.5px; }
+
+/* External / cloud node */
+.fd-card-premium.fd-kind-ext {
+  width: 154px;
+  background: repeating-linear-gradient(
+    135deg,
+    #0e1420, #0e1420 7px,
+    #101826 7px, #101826 14px
+  );
+  border: 1.5px dashed var(--bd2);
+}
+.fd-card-premium.fd-kind-ext .fd-accent { display: none; }
+.fd-card-premium.fd-kind-ext .fd-title,
+.fd-card-premium.fd-kind-ext .fd-nn { color: #cbd6e6; }
+
+/* ---- Zone regions ---- */
+.fd-zone {
+  position: absolute;
+  z-index: 0;
+  border-radius: 14px;
+  border: 1px dashed;
+  pointer-events: none;
+}
+.fd-zone .fd-zone-label {
+  position: absolute;
+  top: 7px;
+  left: 11px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   CRAFT QUALITY BAR — additive primitives (Phase 1)
+   Mirror of fgraph-base craft block, scoped to the fd-engine card grammar.
+   ════════════════════════════════════════════════════════════════════ */
+
+/* Ambient edge-flow — slow marching dashes (passive data/async). Self-contained
+   keyframe so fd-engine.css stays bootstrappable on its own. */
+@keyframes fg-flow { to { stroke-dashoffset: -200px; } }
+.fd-edges path.flow { stroke-dasharray: 6 4; animation: fg-flow 20s linear infinite; }
+
+/* Accent glow — add the .fd-glow modifier to a hub / hero node.
+   --glow-radius declared here too (mirror of fgraph-base) so fd-engine.css
+   bootstraps standalone; harmless duplicate when both are inlined together. */
+:root { --glow-radius: 40px; }
+.fd-card-premium.fd-glow {
+  box-shadow: 0 0 var(--glow-radius, 40px) var(--accent-glow, #38bdf833), 0 3px 14px #00000055;
+}
+
+/* Node icon slot — inline SVG glyph in the premium card header (.fd-nh). */
+.fd-card-premium .fd-ico { width: 18px; height: 18px; flex: none; color: currentColor; }
+.fd-card-premium .fd-ico svg { width: 100%; height: 100%; display: block; }
+
+
+/* fd-page-shell.css — layout chrome for gen-fd.py output (header, bar, diagram-row, sidebar) */
+
+html,
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans, "Inter", ui-sans-serif, system-ui, sans-serif);
+  -webkit-font-smoothing: antialiased;
+  line-height: 1.4;
+}
+
+.page {
+  padding: 22px 22px 60px;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 18px;
+  justify-content: space-between;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 18px;
+}
+
+.htitle h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}
+
+.htitle h1 b {
+  color: var(--cyan);
+}
+
+.htitle p {
+  margin: 5px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
+.badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 3px 9px;
+  border-radius: 20px;
+  border: 1px solid var(--border-hi);
+  color: var(--text-muted);
+}
+
+.badge.cyan {
+  border-color: rgba(34, 211, 238, 0.3);
+  background: rgba(34, 211, 238, 0.06);
+  color: var(--cyan);
+}
+
+.badge.amber {
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.06);
+  color: var(--amber);
+}
+
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.lg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 3px 9px;
+  font-family: var(--mono);
+}
+
+.lln {
+  width: 16px;
+  height: 0;
+  border-top: 2.5px solid;
+  border-radius: 2px;
+}
+
+.ctl-group {
+  display: flex;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+.ctl {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 5px 10px;
+  transition: 0.15s;
+}
+
+.ctl:hover {
+  border-color: var(--cyan);
+}
+
+.ctl.off {
+  opacity: 0.35;
+  text-decoration: line-through;
+}
+
+.uc-bar {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.uc-label {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.uc-btn {
+  cursor: pointer;
+  user-select: none;
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+}
+
+.uc-btn:hover {
+  border-color: var(--amber);
+  color: var(--text);
+}
+
+.uc-btn.active {
+  background: rgba(245, 158, 11, 0.06);
+  border-color: rgba(245, 158, 11, 0.4);
+  color: var(--amber);
+}
+
+.uc-play {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--green);
+  background: rgba(16, 185, 129, 0.06);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+}
+
+.uc-play:hover {
+  border-color: var(--green);
+}
+
+.uc-play:disabled {
+  opacity: 0.38;
+  cursor: default;
+}
+
+.uc-reset {
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hi);
+  border-radius: 7px;
+  padding: 4px 9px;
+  transition: 0.15s;
+  display: none;
+}
+
+.uc-reset.visible {
+  display: inline-block;
+}
+
+.uc-reset:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.diagram-row {
+  display: flex;
+  gap: 0;
+  align-items: stretch;
+  margin-bottom: 22px;
+}
+
+.stage-wrap {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+  border: 1px solid var(--border);
+  border-radius: 12px 0 0 12px;
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-cell));
+  overflow: auto;
+}
+
+.sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  border: 1px solid var(--border-hi);
+  border-left: none;
+  border-radius: 0 12px 12px 0;
+  background: var(--bg-cell);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar.hidden {
+  display: none;
+}
+
+.stage-wrap.full-width {
+  border-radius: 12px;
+}
+
+.sb-header {
+  padding: 12px 13px 9px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sb-header h4 {
+  margin: 0 0 2px;
+  font-size: 12.5px;
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+.sb-header .fd-img {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 9.5px;
+  margin-bottom: 6px;
+  word-break: break-all;
+}
+
+.sb-header dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 8px;
+}
+
+.sb-header dt {
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 9.5px;
+}
+
+.sb-header dd {
+  margin: 0;
+  font-size: 10.5px;
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+.sb-header .hint {
+  color: var(--text-dim);
+  font-size: 10px;
+  font-style: italic;
+  line-height: 1.5;
+}
+
+.sb-uc {
+  padding: 11px 13px;
+  border-top: 1px solid var(--border);
+  flex: 1;
+  overflow: auto;
+  display: none;
+}
+
+.sb-uc.visible {
+  display: block;
+}
+
+.sb-uc .uc-title {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin-bottom: 7px;
+}
+
+.uc-steps-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.uc-steps-list li {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 4px 7px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  color: var(--text-dim);
+  transition: 0.15s;
+  line-height: 1.4;
+}
+
+.uc-steps-list li.step-done {
+  color: var(--green);
+  border-color: rgba(16, 185, 129, 0.15);
+  background: rgba(16, 185, 129, 0.05);
+}
+
+.uc-steps-list li.step-active {
+  color: var(--amber);
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.06);
+  box-shadow: 0 0 8px rgba(245, 158, 11, 0.12);
+}
+
+.uc-steps-list li .sn {
+  font-size: 8.5px;
+  opacity: 0.5;
+  margin-right: 4px;
+}
+
+.sb-uc .uc-desc {
+  margin-top: 9px;
+  font-size: 10px;
+  color: var(--text-muted);
+  line-height: 1.55;
+  padding-top: 9px;
+  border-top: 1px dashed var(--border);
+}
+
+.sb-uc .uc-desc b {
+  color: var(--text);
+}
+
+.fd-net-label {
+  position: absolute;
+  left: 14px;
+  top: 10px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.zone-m1 {
+  border-color: rgba(16, 185, 129, 0.25);
+  background: rgba(16, 185, 129, 0.03);
+}
+
+.zone-m1 .fd-zone-label {
+  color: rgba(16, 185, 129, 0.6);
+}
+
+.zone-m2 {
+  border-color: rgba(245, 158, 11, 0.25);
+  background: rgba(245, 158, 11, 0.04);
+}
+
+.zone-m2 .fd-zone-label {
+  color: rgba(245, 158, 11, 0.6);
+}
+
+.zone-hub {
+  border-color: rgba(56, 189, 248, 0.2);
+  background: rgba(56, 189, 248, 0.04);
+  border-style: solid;
+  border-radius: 16px;
+}
+
+.zone-hub .fd-zone-label {
+  color: rgba(56, 189, 248, 0.55);
+}
+
+.zone-stores {
+  border-color: rgba(167, 139, 250, 0.2);
+  background: rgba(167, 139, 250, 0.04);
+}
+
+.zone-stores .fd-zone-label {
+  color: rgba(167, 139, 250, 0.55);
+}
+
+.fd-canvas.hide-control .fd-edges path.control,
+.fd-canvas.hide-write .fd-edges path.write,
+.fd-canvas.hide-read .fd-edges path.read,
+.fd-canvas.hide-data .fd-edges path.data,
+.fd-canvas.hide-async .fd-edges path.async,
+.fd-canvas.hide-feedback .fd-edges path.feedback,
+.fd-canvas.hide-message .fd-edges path.message,
+.fd-canvas.hide-media .fd-edges path.media,
+.fd-canvas.hide-llm .fd-edges path.llm {
+  opacity: 0.06;
+}
+</style>
+</head>
+<body>
+<div class="page">
+
+  <header>
+    <div class="htitle">
+      <h1><b>#310 notation glossary guardrails</b> — file map</h1>
+      <p>fd-engine · architecture · lyra-v2 · declarative · 22 nodes · 22 edges · DOM-measured bezier edges</p>
+    </div>
+    <div class="badges">
+      <span class="badge cyan">fd-engine</span>
+      <span class="badge amber">architecture</span>
+      <span class="badge">lyra-v2</span>
+      <span class="badge">file:// safe</span>
+    </div>
+  </header>
+
+  <div class="bar">
+    <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center">
+      <div class="legend"><span class="lg"><span class="lln" style="border-color:var(--plum)"></span>data</span><span class="lg"><span class="lln" style="border-color:var(--cyan)"></span>control</span><span class="lg"><span class="lln" style="border-color:var(--purple)"></span>read</span><span class="lg"><span class="lln" style="border-color:var(--amber)"></span>async</span><span class="lg"><span class="lln" style="border-color:var(--green)"></span>write</span><span class="lg"><span class="lln" style="border-color:var(--accent)"></span>feedback</span></div>
+      <div class="ctl-group"><span class="ctl" id="ctl-data" data-plane="data">data</span><span class="ctl" id="ctl-control" data-plane="control">control</span><span class="ctl" id="ctl-read" data-plane="read">read</span><span class="ctl" id="ctl-async" data-plane="async">async</span><span class="ctl" id="ctl-write" data-plane="write">write</span><span class="ctl" id="ctl-feedback" data-plane="feedback">feedback</span></div>
+    </div>
+    
+  </div>
+
+  <div class="diagram-row">
+    <div class="stage-wrap full-width">
+      <div class="fd-canvas" id="fd-canvas">
+        
+        <div class="fd-zone zone-hub" id="zoneSkill"><span class="fd-zone-label">plugins/compress/skills/compress/SKILL.md</span></div>
+        <div class="fd-zone zone-stores" id="zoneNotation"><span class="fd-zone-label">plugins/shared/references/notation.md · NEW</span></div>
+        <div class="fd-zone zone-m2" id="zoneDevcore"><span class="fd-zone-label">plugins/dev-core</span></div>
+        <div class="fd-zone zone-stores" id="zoneRefs"><span class="fd-zone-label">compress references/</span></div>
+        <div class="fd-zone zone-hub" id="zoneValidate"><span class="fd-zone-label">tools/validate_plugins.py</span></div>
+        <div class="fd-zone zone-m2" id="zoneTests"><span class="fd-zone-label">tests/test_check_notation_legends.py · NEW</span></div>
+        <svg class="fd-edges" id="fd-edges" aria-hidden="true"><defs></defs></svg>
+      </div>
+    </div>
+
+    <div class="sidebar hidden" id="fd-sidebar">
+      <div class="sb-header" id="sbHeader">
+        <h4>Hover = detail</h4>
+        <div class="hint">Hover a node to isolate its edges and see image / host / role.<br>Select a use case to animate the flow.</div>
+      </div>
+      <div class="sb-uc" id="sbUc">
+        <div class="uc-title" id="ucTitle"></div>
+        <ul class="uc-steps-list" id="ucStepsList"></ul>
+        <div class="uc-desc" id="ucDesc"></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<script type="application/json" id="fd-data">
+{
+  "type": "architecture",
+  "title": "#310 notation glossary guardrails — file map",
+  "theme": "lyra-v2",
+  "layout": "declarative",
+  "canvas": {
+    "height": 1000
+  },
+  "options": {
+    "particles": false,
+    "spotlight": true,
+    "sidebar": false
+  },
+  "nodes": [
+    {
+      "id": "wl",
+      "x": 12,
+      "y": 12,
+      "n": "Whitelist:",
+      "img": "anchor line",
+      "h": "EX",
+      "kind": "store",
+      "d": "canonical glyph set anchor — CI-matched to notation.md Core Table",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M8 6h13M8 12h13M8 18h13M3.5 6h.01M3.5 12h.01M3.5 18h.01'/>\u003c/svg>"
+    },
+    {
+      "id": "p035",
+      "x": 30,
+      "y": 12,
+      "n": "P0/P3/P5",
+      "img": "phase wiring",
+      "h": "EX",
+      "d": "Phase 0 existence-gated load · Phase 3 collision check · Phase 5 symbol assert",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 3v5M12 8l-6 6v5M12 8l6 6v5'/>\u003c/svg>"
+    },
+    {
+      "id": "g2",
+      "x": 12,
+      "y": 30,
+      "n": "G2 Coinage",
+      "img": "guardrail",
+      "h": "EX",
+      "d": "no-free-coinage + token-neutrality principle",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003ccircle cx='12' cy='12' r='9'/>\u003cpath d='M9 9.5c0-1.4 1.3-2.5 3-2.5s3 1.1 3 2.5-1.3 2.5-3 2.5-3 1.1-3 2.5 1.3 2.5 3 2.5 3-1.1 3-2.5M12 5v2m0 10v2'/>\u003c/svg>"
+    },
+    {
+      "id": "g1",
+      "x": 30,
+      "y": 30,
+      "n": "G1 Polarity",
+      "img": "guardrail · Phase 4",
+      "h": "EX",
+      "d": "polarity transform + 4-field flag schema",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M5 21V4h11l-2 4 2 4H5'/>\u003c/svg>"
+    },
+    {
+      "id": "g3",
+      "x": 12,
+      "y": 48,
+      "n": "G3 Gloss",
+      "img": "guardrail",
+      "h": "EX",
+      "d": "gloss trigger predicate — when a glyph needs an inline gloss",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003ccircle cx='12' cy='12' r='9'/>\u003cpath d='M9.5 9a2.5 2.5 0 0 1 5 .5c0 1.5-2.5 2-2.5 3.5M12 17h.01'/>\u003c/svg>"
+    },
+    {
+      "id": "g4",
+      "x": 30,
+      "y": 48,
+      "n": "G4 Verbatim",
+      "img": "guardrail",
+      "h": "EX",
+      "d": "verbatim floor — citing evidence.md excerpts",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M7 7h4v4c0 3-1.5 5-4 6M15 7h4v4c0 3-1.5 5-4 6'/>\u003c/svg>"
+    },
+    {
+      "id": "coretab",
+      "x": 66,
+      "y": 30,
+      "n": "Core Table",
+      "img": "## Core Table anchor",
+      "h": "EX",
+      "kind": "store",
+      "d": "glyph | senses | gloss? | fidelity warn | notes — adjudication records",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003crect x='3' y='4' width='18' height='16' rx='1'/>\u003cpath d='M3 10h18M9 4v16M15 4v16'/>\u003c/svg>"
+    },
+    {
+      "id": "grammar",
+      "x": 66,
+      "y": 12,
+      "n": "Grammar §",
+      "img": "lazy section",
+      "h": "EX",
+      "d": "composition grammar — loaded on demand",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M4 7V5h16v2M12 5v14M9 19h6'/>\u003c/svg>"
+    },
+    {
+      "id": "maint",
+      "x": 84,
+      "y": 12,
+      "n": "Maintenance",
+      "img": "lazy section",
+      "h": "EX",
+      "d": "adjudication procedure with grep counts",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M14.7 6.3a4 4 0 0 0-5.4 5.4L4 17v3h3l5.3-5.3a4 4 0 0 0 5.4-5.4L14 12l-1.7-1.7z'/>\u003c/svg>"
+    },
+    {
+      "id": "registry",
+      "x": 84,
+      "y": 30,
+      "n": "Registry",
+      "img": "reserved-var table",
+      "h": "EX",
+      "kind": "store",
+      "d": "reserved-var registry — Let-var namespace guard",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M6 3h12v18l-6-4-6 4z'/>\u003c/svg>"
+    },
+    {
+      "id": "base",
+      "x": 60,
+      "y": 48,
+      "n": "base.md:16",
+      "img": "dev-core agent",
+      "h": "EX",
+      "d": "legend block → one-line pointer",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M6 3h9l4 4v14H6z'/>\u003cpath d='M15 3v4h4'/>\u003c/svg>"
+    },
+    {
+      "id": "docw",
+      "x": 75,
+      "y": 48,
+      "n": "doc-writer",
+      "img": "doc-writer.md:51",
+      "h": "EX",
+      "d": "legend block → one-line pointer",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M6 3h9l4 4v14H6z'/>\u003cpath d='M15 3v4h4'/>\u003c/svg>"
+    },
+    {
+      "id": "pj",
+      "x": 90,
+      "y": 48,
+      "n": "plugin.json",
+      "img": "0.8.13 → 0.8.14",
+      "h": "EX",
+      "d": "dev-core version bump",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M4 4h6l10 10-6 6L4 10z'/>\u003ccircle cx='8.5' cy='8.5' r='1.5'/>\u003c/svg>"
+    },
+    {
+      "id": "compress",
+      "x": 12,
+      "y": 70,
+      "n": "compress.md",
+      "img": "references/",
+      "h": "EX",
+      "d": "displaced content — ledger append template + mode-specific edge rows",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M6 3h9l4 4v14H6z'/>\u003cpath d='M15 3v4h4M9 13h6M9 17h6'/>\u003c/svg>"
+    },
+    {
+      "id": "evid",
+      "x": 30,
+      "y": 70,
+      "n": "evidence.md",
+      "img": "references/ · NEW",
+      "h": "EX",
+      "d": "Tencent 2604.07192 · MetaGlyph 2601.07354 · LILO · GEPA excerpts",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003ccircle cx='10.5' cy='10.5' r='6.5'/>\u003cpath d='M15.5 15.5L21 21'/>\u003c/svg>"
+    },
+    {
+      "id": "gloss",
+      "x": 48,
+      "y": 70,
+      "n": "glossary.md",
+      "img": "references/ · NEW",
+      "h": "EX",
+      "d": "glossary-mode body",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M4 19V5a2 2 0 0 1 2-2h13v16H6a2 2 0 0 0-2 2zm0 0a2 2 0 0 0 2 2h13'/>\u003c/svg>"
+    },
+    {
+      "id": "checkfn",
+      "x": 66,
+      "y": 68,
+      "n": "Legends Chk",
+      "img": "check_notation_legends()",
+      "h": "EX",
+      "glow": true,
+      "d": "gate a: pointer lines · gate b: whitelist ≡ core-table set-equality, column-1 backtick extraction, non-empty guard",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z'/>\u003cpath d='M9 12l2 2 4-4'/>\u003c/svg>"
+    },
+    {
+      "id": "const",
+      "x": 84,
+      "y": 68,
+      "n": "FILES const",
+      "img": "NOTATION_LEGEND_FILES",
+      "h": "EX",
+      "kind": "store",
+      "d": "pointer-file list consumed by gate a",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003crect x='3' y='5' width='18' height='14' rx='2'/>\u003cpath d='M7 9h10M7 13h6'/>\u003c/svg>"
+    },
+    {
+      "id": "mainchk",
+      "x": 66,
+      "y": 86,
+      "n": "main() gate",
+      "img": "checks dispatch",
+      "h": "EX",
+      "d": "runs the check · exit tiers 2 (error) / 1 (warn)",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M4 17l6-5-6-5M12 19h8'/>\u003c/svg>"
+    },
+    {
+      "id": "clichoice",
+      "x": 84,
+      "y": 86,
+      "n": "--check CLI",
+      "img": "argparse choice",
+      "h": "EX",
+      "d": "notation-legends added to --check choices",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M4 8h10M18 8h2M4 16h4M12 16h8'/>\u003ccircle cx='16' cy='8' r='2'/>\u003ccircle cx='10' cy='16' r='2'/>\u003c/svg>"
+    },
+    {
+      "id": "tmpfix",
+      "x": 12,
+      "y": 88,
+      "n": "Tmp Fixtures",
+      "img": "tmp_path files",
+      "h": "EX",
+      "d": "synthetic SKILL.md / notation.md fixtures",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M9 3h6M10 3v6l-5 9a2 2 0 0 0 2 3h10a2 2 0 0 0 2-3l-5-9V3'/>\u003c/svg>"
+    },
+    {
+      "id": "inject",
+      "x": 30,
+      "y": 88,
+      "n": "Inject Args",
+      "img": "injectable params",
+      "h": "EX",
+      "d": "paths passed as parameters — no repo coupling",
+      "icon": "\u003csvg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>\u003cpath d='M12 3v10m0 0l-4-4m4 4l4-4M4 17v4h16v-4'/>\u003c/svg>"
+    }
+  ],
+  "edges": [
+    {
+      "f": "wl",
+      "t": "coretab",
+      "plane": "data",
+      "label": "set-equality contract (CI gate b)",
+      "srcFace": "right",
+      "dstFace": "left"
+    },
+    {
+      "f": "p035",
+      "t": "coretab",
+      "plane": "control",
+      "label": "Phase 0: existence-gated load",
+      "dstFace": "left"
+    },
+    {
+      "f": "p035",
+      "t": "registry",
+      "plane": "read",
+      "label": "Phase 3: reserved-var collision check"
+    },
+    {
+      "f": "g3",
+      "t": "coretab",
+      "plane": "read",
+      "label": "gloss? column drives trigger predicate",
+      "srcFace": "top",
+      "dstFace": "left"
+    },
+    {
+      "f": "g3",
+      "t": "gloss",
+      "plane": "async",
+      "flow": true,
+      "label": "glossary-mode body"
+    },
+    {
+      "f": "g2",
+      "t": "evid",
+      "plane": "read",
+      "label": "token-neutrality citations",
+      "srcFace": "right",
+      "dstFace": "top"
+    },
+    {
+      "f": "g4",
+      "t": "evid",
+      "plane": "read",
+      "label": "verbatim floor cites evidence"
+    },
+    {
+      "f": "g1",
+      "t": "compress",
+      "plane": "data",
+      "label": "displaced: ledger template + mode edge rows",
+      "srcFace": "bottom",
+      "dstFace": "top"
+    },
+    {
+      "f": "maint",
+      "t": "coretab",
+      "plane": "write",
+      "label": "adjudication records + grep counts",
+      "srcFace": "bottom",
+      "dstFace": "right"
+    },
+    {
+      "f": "grammar",
+      "t": "coretab",
+      "plane": "async",
+      "flow": true,
+      "label": "lazy section"
+    },
+    {
+      "f": "base",
+      "t": "coretab",
+      "plane": "read",
+      "flow": true,
+      "label": "one-line pointer · base.md:16"
+    },
+    {
+      "f": "docw",
+      "t": "coretab",
+      "plane": "read",
+      "flow": true,
+      "label": "one-line pointer · doc-writer.md:51",
+      "dstFace": "bottom"
+    },
+    {
+      "f": "pj",
+      "t": "docw",
+      "plane": "async",
+      "label": "v0.8.14 ships pointer swap"
+    },
+    {
+      "f": "checkfn",
+      "t": "base",
+      "plane": "feedback",
+      "label": "gate a: pointer present"
+    },
+    {
+      "f": "checkfn",
+      "t": "docw",
+      "plane": "feedback",
+      "label": "gate a: pointer present",
+      "dstFace": "bottom"
+    },
+    {
+      "f": "checkfn",
+      "t": "wl",
+      "plane": "feedback",
+      "label": "gate b: whitelist backtick set",
+      "srcFace": "left",
+      "dstFace": "bottom"
+    },
+    {
+      "f": "checkfn",
+      "t": "coretab",
+      "plane": "feedback",
+      "label": "gate b: col-1 set-equality",
+      "srcFace": "top",
+      "dstFace": "bottom"
+    },
+    {
+      "f": "const",
+      "t": "checkfn",
+      "plane": "data",
+      "label": "NOTATION_LEGEND_FILES"
+    },
+    {
+      "f": "mainchk",
+      "t": "checkfn",
+      "plane": "control",
+      "label": "main() dispatch · exit tiers 2/1"
+    },
+    {
+      "f": "clichoice",
+      "t": "mainchk",
+      "plane": "control",
+      "label": "--check notation-legends"
+    },
+    {
+      "f": "tmpfix",
+      "t": "checkfn",
+      "plane": "feedback",
+      "label": "pytest tmp_path fixtures",
+      "srcFace": "right",
+      "dstFace": "left"
+    },
+    {
+      "f": "inject",
+      "t": "checkfn",
+      "plane": "feedback",
+      "label": "injectable params",
+      "srcFace": "right",
+      "dstFace": "left"
+    }
+  ],
+  "zones": [
+    {
+      "id": "zoneSkill",
+      "class": "zone-hub",
+      "label": "plugins/compress/skills/compress/SKILL.md",
+      "padding": {
+        "top": 48
+      },
+      "nodes": [
+        "wl",
+        "p035",
+        "g1",
+        "g2",
+        "g3",
+        "g4"
+      ]
+    },
+    {
+      "id": "zoneNotation",
+      "class": "zone-stores",
+      "label": "plugins/shared/references/notation.md · NEW",
+      "padding": {
+        "top": 48
+      },
+      "nodes": [
+        "coretab",
+        "grammar",
+        "registry",
+        "maint"
+      ]
+    },
+    {
+      "id": "zoneDevcore",
+      "class": "zone-m2",
+      "label": "plugins/dev-core",
+      "padding": {
+        "top": 48
+      },
+      "nodes": [
+        "base",
+        "docw",
+        "pj"
+      ]
+    },
+    {
+      "id": "zoneRefs",
+      "class": "zone-stores",
+      "label": "compress references/",
+      "padding": {
+        "top": 48
+      },
+      "nodes": [
+        "compress",
+        "evid",
+        "gloss"
+      ]
+    },
+    {
+      "id": "zoneValidate",
+      "class": "zone-hub",
+      "label": "tools/validate_plugins.py",
+      "padding": {
+        "top": 48
+      },
+      "nodes": [
+        "checkfn",
+        "const",
+        "mainchk",
+        "clichoice"
+      ]
+    },
+    {
+      "id": "zoneTests",
+      "class": "zone-m2",
+      "label": "tests/test_check_notation_legends.py · NEW",
+      "padding": {
+        "top": 48
+      },
+      "nodes": [
+        "tmpfix",
+        "inject"
+      ]
+    }
+  ]
+}
+</script>
+
+<script>
+(function(){
+'use strict'
+
+/* ── fd/core.js ── */
+// fd/core.js — geometry core: rect, pairKey, faceFor, portAnchor, stubLen
+// Lifted verbatim from lyra-stack-v2.html lines 492-534 and generalized for
+// descriptor-driven fd-engine contract.
+// Concat order: core.js FIRST (edges.js depends on names defined here).
+// NOTE: all vars/functions here are intentionally "unused" in isolation —
+// they are consumed by edges.js and other fd/ modules via bundler concat.
+
+var nodeEl = {} // id → DOM element map, populated by initEngine
+var canvas = null // .fd-canvas element ref
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var svg = null // .fd-edges SVG overlay element ref
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var paths = [] // one SVG <path> per deduped pair
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var pathByPair = new Map() // pairKey → SVG <path>
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var DESCRIPTOR = null // full descriptor object set by initEngine
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+var NS = 'http://www.w3.org/2000/svg'
+
+// ---- Geometry helpers (verbatim lift from lyra-stack-v2.html l.492-534) ----
+
+// l.492-495: canvas-relative rect for a node by id
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function rect(id) {
+  var el = nodeEl[id]
+  var cr = canvas.getBoundingClientRect()
+  var b = el.getBoundingClientRect()
+  return { cx: b.left - cr.left + b.width / 2, cy: b.top - cr.top + b.height / 2, w: b.width, h: b.height }
+}
+
+// l.498: canonical (unordered) key for a node pair
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function pairKey(a, b) {
+  return [a, b].sort().join('|')
+}
+
+// l.501-514: face selection — source exits toward target, target enters from opposite
+// Keeps srcFace / dstFace per-edge overrides from descriptor
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function faceFor(dx, dy, isSource, edge) {
+  if (edge) {
+    if (isSource && edge.srcFace) return edge.srcFace
+    if (!isSource && edge.dstFace) return edge.dstFace
+  }
+  if (Math.abs(dy) >= Math.abs(dx)) {
+    if (isSource) return dy > 0 ? 'bottom' : 'top'
+    else return dy > 0 ? 'top' : 'bottom'
+  } else {
+    if (isSource) return dx > 0 ? 'right' : 'left'
+    else return dx > 0 ? 'left' : 'right'
+  }
+}
+
+// l.516-528: port anchor — spreads slots evenly across the chosen face
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function portAnchor(r, face, slotIdx, slotCount) {
+  var cx = r.cx,
+    cy = r.cy,
+    w = r.w,
+    h = r.h
+  var hw = w / 2,
+    hh = h / 2
+  var faceLen = face === 'top' || face === 'bottom' ? w : h
+  var spread = Math.min(faceLen * 0.55, slotCount * 16)
+  var step = slotCount > 1 ? spread / (slotCount - 1) : 0
+  var offset = slotCount > 1 ? -spread / 2 + slotIdx * step : 0
+  switch (face) {
+    case 'top':
+      return { x: cx + offset, y: cy - hh, nx: 0, ny: -1 }
+    case 'bottom':
+      return { x: cx + offset, y: cy + hh, nx: 0, ny: 1 }
+    case 'left':
+      return { x: cx - hw, y: cy + offset, nx: -1, ny: 0 }
+    case 'right':
+      return { x: cx + hw, y: cy + offset, nx: 1, ny: 0 }
+  }
+}
+
+// l.531-534: proportional bezier offset — clamp(dist * 0.35, 30, 220)
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — consumed by edges.js */
+function stubLen(dx, dy) {
+  var dist = Math.sqrt(dx * dx + dy * dy)
+  return Math.max(30, Math.min(220, dist * 0.35))
+}
+
+// ---- Engine initializer ----
+// Called once at DOMContentLoaded by the generated output script.
+// descriptor: parsed fd-data JSON
+// canvasEl:   .fd-canvas DOM element
+// svgEl:      .fd-edges SVG overlay element
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — entry point called by generated HTML */
+function initEngine(descriptor, canvasEl, svgEl) {
+  DESCRIPTOR = descriptor
+  canvas = canvasEl
+  svg = svgEl
+  nodeEl = {}
+  paths = []
+  pathByPair = new Map()
+
+  // Apply canvas height from descriptor (default 720px via CSS --fd-canvas-h)
+  if (descriptor.canvas?.height) {
+    canvasEl.style.setProperty('--fd-canvas-h', `${descriptor.canvas.height}px`)
+  }
+}
+
+
+/* ── fd/edges.js ── */
+// fd/edges.js — edge drawing layer: draw(), redraw(), initMarkers(), ResizeObserver
+// Lifted verbatim and generalized from lyra-stack-v2.html lines 537-626 + l.960.
+// Depends on names from core.js (concat order: core.js MUST precede this file).
+// Plane colors: derived from descriptor.edges[i].plane via CSS vars --fd-plane-{name},
+// never hardcoded hex.
+
+// ---- Marker injection ----
+// Creates one <marker id="fd-arr-{plane}"> per unique semantic plane.
+// fill uses an injected SVG <style> rule binding CSS var per plane.
+// planes: array of unique plane name strings (e.g. ['message','llm','media'])
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function initMarkers(planes) {
+  var defs = svg.querySelector('defs')
+  if (!defs) {
+    defs = document.createElementNS(NS, 'defs')
+    svg.insertBefore(defs, svg.firstChild)
+  }
+  // Inject a <style> block into the SVG for plane fill vars (one per plane)
+  var styleEl = document.createElementNS(NS, 'style')
+  var cssRules = planes.map((pl) => `#fd-arr-${pl} path { fill: var(--fd-plane-${pl}, #8aa0bd); }`).join('\n')
+  styleEl.textContent = cssRules
+  defs.appendChild(styleEl)
+
+  planes.forEach((pl) => {
+    // Skip if marker already exists (idempotent re-init guard)
+    if (svg.querySelector(`#fd-arr-${pl}`)) return
+    var marker = document.createElementNS(NS, 'marker')
+    marker.setAttribute('id', `fd-arr-${pl}`)
+    marker.setAttribute('markerWidth', '9')
+    marker.setAttribute('markerHeight', '9')
+    marker.setAttribute('refX', '7')
+    marker.setAttribute('refY', '3')
+    marker.setAttribute('orient', 'auto')
+    // NO preserveAspectRatio — AC-10 compliance (no viewBox either)
+    var arrow = document.createElementNS(NS, 'path')
+    arrow.setAttribute('d', 'M0,0 L7,3 L0,6 Z')
+    // fill resolved via the injected CSS var rule above
+    marker.appendChild(arrow)
+    defs.appendChild(marker)
+  })
+}
+
+// ---- Full edge pass ----
+// Verbatim-adapted from lyra-stack-v2.html l.537-626.
+// Reads DESCRIPTOR.edges (set by initEngine). Uses nodeEl, canvas, svg, paths,
+// pathByPair from core.js module scope.
+function draw() {
+  // Clear all existing paths, labels, circles from the SVG overlay
+  svg.querySelectorAll(':scope > path, :scope > text, :scope > circle, :scope > g').forEach((n) => {
+    n.remove()
+  })
+  paths = []
+  pathByPair.clear()
+
+  var EDGES = DESCRIPTOR.edges || []
+
+  // --- Step 1: deduplicate EDGES into unique pairs -------------------------
+  // For each unordered pair keep: plane of first occurrence, label if any,
+  // canonical source (f), for slot allocation.
+  var seenPairs = new Map() // pairKey → {f, t, plane, lab, edge, edgeIndices:[]}
+  var i, e, k
+  for (i = 0; i < EDGES.length; i++) {
+    e = EDGES[i]
+    k = pairKey(e.f, e.t)
+    if (!seenPairs.has(k)) {
+      seenPairs.set(k, {
+        f: e.f,
+        t: e.t,
+        plane: e.plane,
+        lab: e.label || null,
+        edge: e,
+        flow: !!e.flow,
+        edgeIndices: [i],
+      })
+    } else {
+      seenPairs.get(k).edgeIndices.push(i)
+      // upgrade label if this occurrence has one and first didn't
+      if (e.label && !seenPairs.get(k).lab) seenPairs.get(k).lab = e.label
+      // upgrade flow if ANY occurrence of the pair requests it (dedup keeps the first edge only)
+      if (e.flow) seenPairs.get(k).flow = true
+    }
+  }
+  var dedupedEdges = Array.from(seenPairs.values()) // array of unique pairs
+
+  // --- Step 2: build port maps over deduped edges -------------------------
+  // Key: "nodeId:face" → [pairIdx in dedupedEdges]
+  var portMap = new Map()
+  var ref, f, t, edge, rf, rt, dx, dy, fFace, tFace, fk, tk
+  for (i = 0; i < dedupedEdges.length; i++) {
+    ref = dedupedEdges[i]
+    f = ref.f
+    t = ref.t
+    edge = ref.edge
+    rf = rect(f)
+    rt = rect(t)
+    dx = rt.cx - rf.cx
+    dy = rt.cy - rf.cy
+    fFace = faceFor(dx, dy, true, edge)
+    tFace = faceFor(dx, dy, false, edge)
+    fk = `${f}:${fFace}`
+    tk = `${t}:${tFace}`
+    if (!portMap.has(fk)) portMap.set(fk, [])
+    if (!portMap.has(tk)) portMap.set(tk, [])
+    portMap.get(fk).push(i)
+    portMap.get(tk).push(i)
+  }
+
+  // --- Step 3: draw one path per deduplicated pair ------------------------
+  var plane, lab, fSlots, tSlots, fi, ti, pu1, pu2, stb, c1x, c1y, c2x, c2y, dStr, p, tx2, mx, my
+  for (i = 0; i < dedupedEdges.length; i++) {
+    ref = dedupedEdges[i]
+    f = ref.f
+    t = ref.t
+    plane = ref.plane
+    lab = ref.lab
+    edge = ref.edge
+    rf = rect(f)
+    rt = rect(t)
+    dx = rt.cx - rf.cx
+    dy = rt.cy - rf.cy
+
+    fFace = faceFor(dx, dy, true, edge)
+    tFace = faceFor(dx, dy, false, edge)
+    fk = `${f}:${fFace}`
+    tk = `${t}:${tFace}`
+
+    fSlots = portMap.get(fk)
+    tSlots = portMap.get(tk)
+    fi = fSlots.indexOf(i)
+    ti = tSlots.indexOf(i)
+
+    pu1 = portAnchor(rf, fFace, fi, fSlots.length)
+    pu2 = portAnchor(rt, tFace, ti, tSlots.length)
+
+    // Proportional stub: longer links curve more (verbatim l.592-598)
+    stb = stubLen(dx, dy)
+    c1x = pu1.x + pu1.nx * stb
+    c1y = pu1.y + pu1.ny * stb
+    c2x = pu2.x + pu2.nx * stb
+    c2y = pu2.y + pu2.ny * stb
+
+    dStr =
+      `M${pu1.x.toFixed(1)},${pu1.y.toFixed(1)}` +
+      ` C${c1x.toFixed(1)},${c1y.toFixed(1)}` +
+      ` ${c2x.toFixed(1)},${c2y.toFixed(1)}` +
+      ` ${pu2.x.toFixed(1)},${pu2.y.toFixed(1)}`
+
+    p = document.createElementNS(NS, 'path')
+    p.setAttribute('d', dStr)
+    // CSS class = plane name → stroke resolved via .fd-edges path.{plane} in fd-engine.css
+    // edge.flow → append .flow for the ambient marching-dash animation (craft bar).
+    // ref.flow is set if ANY occurrence of the deduped pair requested flow.
+    p.setAttribute('class', ref.flow ? `${plane} flow` : plane)
+    // Arrowhead marker per plane — no hardcoded hex, color via CSS var in marker's injected style
+    p.setAttribute('marker-end', `url(#fd-arr-${plane})`)
+    // Data attributes for spotlight + particle matching
+    p.dataset.f = f
+    p.dataset.t = t
+    p.dataset.pk = pairKey(f, t)
+    svg.appendChild(p)
+    paths.push(p)
+    pathByPair.set(pairKey(f, t), p)
+
+    // Edge label (de Casteljau midpoint — verbatim l.613-624)
+    if (lab) {
+      tx2 = document.createElementNS(NS, 'text')
+      mx = 0.125 * pu1.x + 0.375 * c1x + 0.375 * c2x + 0.125 * pu2.x
+      my = 0.125 * pu1.y + 0.375 * c1y + 0.375 * c2y + 0.125 * pu2.y
+      tx2.setAttribute('x', mx.toFixed(1))
+      tx2.setAttribute('y', (my - 4).toFixed(1))
+      tx2.setAttribute('text-anchor', 'middle')
+      tx2.setAttribute('class', 'fd-elabel')
+      tx2.dataset.pk = pairKey(f, t)
+      tx2.textContent = lab
+      svg.appendChild(tx2)
+    }
+  }
+}
+
+// ---- Redraw: re-runs full edge pass + optional zone placement ----
+// Called by ResizeObserver and any layout-changing event.
+function redraw() {
+  draw()
+  // If a placeZones function is defined (by architecture.js type module), call it
+  if (typeof placeZones === 'function') placeZones(DESCRIPTOR)
+}
+
+// ---- ResizeObserver wiring ----
+// Called from initEngine after DOM is ready.
+// Verbatim from lyra-stack-v2.html l.960 — adapted to fd-engine naming.
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function wireResize() {
+  new ResizeObserver(redraw).observe(canvas)
+}
+
+// ---- Unique plane list helper ----
+// Derives the set of plane names from descriptor.edges for initMarkers call.
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML */
+function uniquePlanes() {
+  var planes = []
+  var seen = {}
+  var EDGES = DESCRIPTOR?.edges || []
+  var i, pl
+  for (i = 0; i < EDGES.length; i++) {
+    pl = EDGES[i].plane
+    if (pl && !seen[pl]) {
+      seen[pl] = true
+      planes.push(pl)
+    }
+  }
+  return planes
+}
+
+
+/* ── fd/cards.js ── */
+// fd/cards.js — Layer 1: node renderer
+// Concat order: core.js → cards.js → architecture.js
+// Depends on: nodeEl (map), canvas (element) — declared in core.js scope
+
+// ── kind → fgraph-base.css shape class mapping ────────────────────────
+const KIND_SHAPE = {
+  bus: 'pill',
+  broker: 'pill',
+  router: 'pill',
+  agent: 'hexagon',
+  worker: 'hexagon',
+  trigger: 'circle',
+  event: 'circle',
+  database: 'cylinder',
+  storage: 'cylinder',
+  store: 'cylinder',
+  queue: 'cylinder',
+  decision: 'diamond',
+  gate: 'diamond',
+  file: 'folded',
+  config: 'folded',
+  document: 'folded',
+}
+
+// ── kind → tone class mapping (fgraph-base.css tone modifiers) ────────
+const KIND_TONE = {
+  bus: 'cyan',
+  broker: 'cyan',
+  router: 'cyan',
+  agent: 'amber',
+  worker: 'amber',
+  trigger: 'green',
+  event: 'green',
+  database: 'purple',
+  storage: 'purple',
+  store: 'purple',
+  queue: 'purple',
+  decision: 'red',
+  gate: 'red',
+  // hub-int accent defaults to --hub-c (cyan fallback) per fd-engine.css line 290
+  'hub-int': 'cyan',
+}
+
+// ── host badge label normalisation ────────────────────────────────────
+function hostLabel(raw) {
+  if (!raw) return null
+  if (raw === 'M1') return 'M₁'
+  if (raw === 'M2') return 'M₂'
+  if (raw === 'EX') return 'External'
+  return raw
+}
+
+// ── premium card HTML ──────────────────────────────────────────────────
+// .fd-card-premium structure:
+//   .fd-accent  — left accent bar (color via --fd-plane-{plane} or --fd-tone-{kind})
+//   .fd-nh      — flex header row: .fd-title + .fd-tag (plane-coloured badge)
+//   .fd-sub     — node.d  (subtitle / description, optional)
+//   .fd-host    — node.h  (host badge, optional; 'EX' = external, no badge per SKILL.md)
+function buildPremiumCard(node) {
+  const accentVar = node.plane
+    ? `var(--fd-plane-${node.plane}, var(--fd-tone-${node.kind || 'default'}, var(--text-dim)))`
+    : `var(--fd-tone-${node.kind || 'default'}, var(--text-dim))`
+
+  const tagPlane = node.plane || 'control'
+  // node.img holds the tag badge text; emits fd-tag-{plane} for colour variant
+  const tag = node.img ? `<div class="fd-tag fd-tag-${tagPlane}">${node.img}</div>` : ''
+  const sub = node.d ? `<div class="fd-sub">${node.d}</div>` : ''
+  // node.icon holds an inline <svg> string — rendered in the header icon slot (craft bar)
+  const ico = node.icon ? `<span class="fd-ico">${node.icon}</span>` : ''
+  // h='EX' = external, no badge (SKILL.md spec)
+  const hb = node.h && node.h !== 'EX' ? `<div class="fd-host ${node.h}">${hostLabel(node.h)}</div>` : ''
+
+  return (
+    `<span class="fd-accent" style="background:${accentVar}"></span>` +
+    `<div class="fd-nh">${ico}<div class="fd-title">${node.n}</div>${tag}</div>` +
+    sub +
+    hb
+  )
+}
+
+// ── simple card HTML ───────────────────────────────────────────────────
+function buildSimpleCard(node) {
+  const sub = node.d ? `<div class="fd-sub">${node.d}</div>` : ''
+  return `<div class="fd-title">${node.n}</div>${sub}`
+}
+
+// ── renderNode ────────────────────────────────────────────────────────
+// node        — descriptor node object
+// typeDefault — 'premium' | 'simple' | undefined (from types/{type}.js CARD_DEFAULT)
+// Returns the created element (also populates nodeEl[node.id]).
+function renderNode(node, typeDefault) {
+  const el = document.createElement('div')
+
+  // base classes
+  let cls = 'fgraph-node fd-node'
+
+  // fd-kind-{kind} class — used by fd-engine.css kind-variant rules
+  if (node.kind) cls += ` fd-kind-${node.kind}`
+
+  // shape class from kind
+  const shape = KIND_SHAPE[node.kind]
+  if (shape) cls += ` ${shape}`
+
+  // tone class from kind
+  const tone = KIND_TONE[node.kind]
+  if (tone) cls += ` ${tone}`
+
+  el.className = cls
+  el.dataset.id = node.id
+
+  // position: CSS var convention matching fgraph-base.css (--x, --y in 0..100 % space)
+  el.style.setProperty('--x', node.x)
+  el.style.setProperty('--y', node.y)
+
+  // card style resolution: per-node override (highest) → typeDefault → 'simple' fallback (RD-3)
+  const style = node.cardStyle || typeDefault || 'simple'
+
+  if (style === 'premium') {
+    el.classList.add('fd-card-premium')
+    // node.glow → accent halo on hub / hero cards (craft bar)
+    if (node.glow) el.classList.add('fd-glow')
+    el.innerHTML = buildPremiumCard(node)
+  } else {
+    el.innerHTML = buildSimpleCard(node)
+  }
+
+  // register in shared nodeEl map (declared in core.js scope)
+  nodeEl[node.id] = el
+
+  return el
+}
+
+// ── renderNodes ───────────────────────────────────────────────────────
+// descriptor — full fd-data descriptor object
+// typeDefault comes from types/{type}.js via the init() call
+// biome-ignore lint/correctness/noUnusedVariables: called by core.js in concat bundle
+function renderNodes(descriptor, typeDefault) {
+  const nodes = descriptor.nodes || []
+  for (const node of nodes) {
+    const el = renderNode(node, typeDefault)
+    canvas.appendChild(el)
+  }
+}
+
+
+/* ── fd/particles.js ── */
+// fd/particles.js — Layer 4: rAF particle engine
+// Lifted verbatim from lyra-stack-v2.html lines 628-691 and adapted for
+// the fd-engine descriptor-driven contract (RD-2).
+//
+// Opt-in contract (RD-2):
+//   descriptor.options.particles === false (default) → particles OFF (AC-9)
+//   descriptor.options.particles === true  → one-shot per edge on hover/UC trigger
+//   descriptor.options.particles === "loop" → continuous: spawnParticle() loops on active edges
+//
+// Concat order: core.js → edges.js → cards.js → particles.js → [interactions.js] → types/{type}.js
+// Depends on: NS, svg, pathByPair, pairKey — declared in core.js / edges.js scope.
+//
+// Guard: zero occurrences of the banned lowercase token in this file.
+// Self-check: grep -rn '\bmermaid\b' plugins/forge/ must be empty.
+
+function easeInOutCubic(t) {
+  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2
+}
+
+// Active particle state — one particle at a time (one-shot mode)
+// Loop mode tracks multiple particles via loopParticles[]
+let _particleEl = null
+let _particleRAF = null
+let _loopParticles = [] // [{wrapper, rafId}] — loop mode only
+
+function clearParticle() {
+  if (_particleRAF) {
+    cancelAnimationFrame(_particleRAF)
+    _particleRAF = null
+  }
+  if (_particleEl) {
+    _particleEl.remove()
+    _particleEl = null
+  }
+}
+
+// clearLoopParticles: stop all loop-mode particles
+function clearLoopParticles() {
+  for (let i = 0; i < _loopParticles.length; i++) {
+    const lp = _loopParticles[i]
+    if (lp.rafId) cancelAnimationFrame(lp.rafId)
+    if (lp.wrapper) lp.wrapper.remove()
+  }
+  _loopParticles = []
+}
+
+// ── spawnParticle ─────────────────────────────────────────────────────────
+// Lifted verbatim from lyra-stack-v2.html l.640-691, adapted for fd-engine:
+//   - plane color resolved via CSS var --fd-plane-{plane} (AC-6, never hardcoded hex)
+//   - particle wrapper class: fd-particle-wrap (matches fd-architecture.html CSS)
+//   - forward direction: pathEl.dataset.f === edgeF (verbatim from source)
+//
+// edgeF, edgeT: node ids of the edge endpoints (directional for forward/reverse)
+// plane:        semantic plane string ('control', 'write', etc.)
+// duration:     animation duration in ms (default 750, per spec)
+// onDone:       optional callback invoked when animation completes (for loop scheduling)
+//
+function spawnParticle(edgeF, edgeT, plane, duration, onDone) {
+  const dur = duration || 750
+  const pk = pairKey(edgeF, edgeT)
+  const pathEl = pathByPair.get(pk)
+  if (!pathEl) return null
+
+  // Resolve color from CSS var (theme-aware, AC-6)
+  // Fallback chain: --fd-plane-{plane} → #8aa0bd (muted default)
+  let col = '#8aa0bd'
+  const tmp = document.documentElement
+  const resolved = getComputedStyle(tmp).getPropertyValue(`--fd-plane-${plane}`).trim()
+  if (resolved) col = resolved
+
+  const forward = pathEl.dataset.f === edgeF
+  const len = pathEl.getTotalLength()
+
+  // Build halo + core inside a <g class="fd-particle-wrap"> (verbatim structure l.664-673)
+  const wrapper = document.createElementNS(NS, 'g')
+  wrapper.setAttribute('class', 'fd-particle-wrap')
+  wrapper.style.setProperty('--pcol', col)
+
+  const halo = document.createElementNS(NS, 'circle')
+  halo.setAttribute('r', '9')
+  halo.setAttribute('fill', col)
+  halo.setAttribute('opacity', '0.22')
+
+  const core = document.createElementNS(NS, 'circle')
+  core.setAttribute('r', '5')
+  core.setAttribute('fill', col)
+
+  wrapper.appendChild(halo)
+  wrapper.appendChild(core)
+  svg.appendChild(wrapper)
+
+  const start = performance.now()
+
+  function frame(now) {
+    const u = Math.min((now - start) / dur, 1)
+    const e = easeInOutCubic(u)
+    const d = forward ? e * len : (1 - e) * len
+    const pt = pathEl.getPointAtLength(d)
+    halo.setAttribute('cx', pt.x)
+    halo.setAttribute('cy', pt.y)
+    core.setAttribute('cx', pt.x)
+    core.setAttribute('cy', pt.y)
+    if (u < 1) {
+      return requestAnimationFrame(frame)
+    }
+    if (typeof onDone === 'function') onDone()
+    return null
+  }
+
+  const rafId = requestAnimationFrame(frame)
+  return { wrapper, rafId }
+}
+
+// ── startParticles / stopParticles (loop mode) ────────────────────────────
+// Called by the engine bootstrap when descriptor.options.particles === "loop".
+// Runs spawnParticle() continuously on all active edges, recycling on completion.
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function startParticles(descriptor) {
+  clearLoopParticles()
+  const edges = descriptor?.edges || []
+  if (!edges.length) return
+
+  // Loop: spawn one particle per edge in sequence, recycling each on completion
+  function spawnLoop(edgeIdx) {
+    const e = edges[edgeIdx % edges.length]
+    const plane = e.plane || 'control'
+    const lp = { wrapper: null, rafId: null }
+    _loopParticles.push(lp)
+
+    function onDone() {
+      if (lp.wrapper) lp.wrapper.remove()
+      // Re-spawn after a brief gap (50ms), cycling through edges
+      setTimeout(() => {
+        const nextIdx = (edgeIdx + 1) % edges.length
+        spawnLoop(nextIdx)
+      }, 50)
+    }
+
+    const result = spawnParticle(e.f, e.t, plane, 750, onDone)
+    if (result) {
+      lp.wrapper = result.wrapper
+      lp.rafId = result.rafId
+    }
+  }
+
+  // Stagger initial spawns across edges
+  edges.forEach((_e, i) => {
+    setTimeout(() => {
+      spawnLoop(i)
+    }, i * 180)
+  })
+}
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function stopParticles() {
+  clearParticle()
+  clearLoopParticles()
+}
+
+
+/* ── fd/interactions.js ── */
+// fd/interactions.js — Layer 5: spotlight, use-case step sequencer, sidebar
+// Lifted from lyra-stack-v2.html lines 720-974 and adapted for the
+// fd-engine descriptor-driven contract.
+//
+// Spotlight (hover): dimmed class on canvas, hot class on touched edges + neighbor nodes.
+// Use-case animation: descriptor.useCases[] → step sequencer (play/pause/reset/replay).
+// Sidebar: optional (descriptor.options.sidebar); falls back gracefully when absent.
+//
+// Concat order: core.js → edges.js → cards.js → particles.js → interactions.js → types/{type}.js
+// Depends on: canvas, nodeEl, paths, pathByPair, pairKey, svg — core.js/edges.js scope.
+//             spawnParticle, clearParticle — particles.js scope.
+//             DESCRIPTOR — core.js scope.
+//
+// Guard: zero occurrences of the banned lowercase token in this file.
+
+// ── spotlight (hover) ─────────────────────────────────────────────────────
+// Adapted from lyra-stack-v2.html l.720-751.
+// sidebar: optional; nodeData: the node descriptor object for the hovered node.
+
+function spotlight(nodeData) {
+  canvas.classList.add('dimmed')
+  const id = nodeData.id
+  const neigh = {}
+  neigh[id] = true
+
+  paths.forEach((p) => {
+    const on = p.dataset.f === id || p.dataset.t === id
+    p.classList.toggle('hot', on)
+    if (on) {
+      neigh[p.dataset.f] = true
+      neigh[p.dataset.t] = true
+    }
+  })
+
+  // edge labels follow their path
+  svg.querySelectorAll('text[data-pk]').forEach((t) => {
+    const pk = t.dataset.pk
+    const p = pathByPair.get(pk)
+    t.classList.toggle('hot', p?.classList.contains('hot') ?? false)
+  })
+
+  Object.keys(nodeEl).forEach((k) => {
+    nodeEl[k].classList.toggle('hot', !!neigh[k])
+  })
+
+  // sidebar header: update if sidebar exists
+  const sbHeader = document.getElementById('sbHeader')
+  if (sbHeader) {
+    const hostStr = !nodeData.h || nodeData.h === 'EX' ? 'external' : nodeData.h === 'M1' ? 'M&#x2081;' : 'M&#x2082;'
+    sbHeader.innerHTML =
+      `<h4>${nodeData.n}</h4>` +
+      (nodeData.img ? `<div class="fd-img">${nodeData.img}</div>` : '') +
+      `<dl><dt>plane</dt><dd>${nodeData.plane || '&#x2014;'}</dd>` +
+      `<dt>host</dt><dd>${hostStr}</dd>` +
+      `<dt>role</dt><dd>${nodeData.d || '&#x2014;'}</dd></dl>`
+  }
+}
+
+function clearSpot() {
+  canvas.classList.remove('dimmed')
+  paths.forEach((p) => {
+    p.classList.remove('hot')
+  })
+  svg.querySelectorAll('text').forEach((t) => {
+    t.classList.remove('hot')
+  })
+  Object.values(nodeEl).forEach((el) => {
+    el.classList.remove('hot')
+  })
+
+  // reset sidebar header to default hint
+  const sbHeader = document.getElementById('sbHeader')
+  if (sbHeader) {
+    sbHeader.innerHTML =
+      '<h4>Hover = detail</h4>' +
+      '<div class="hint">Hover a node to isolate its edges and see image / host / role.<br>Select a use case to animate the flow.</div>'
+  }
+}
+
+// ── use-case step sequencer ───────────────────────────────────────────────
+// Adapted from lyra-stack-v2.html l.770-974.
+// State machine: 'none' | 'ready' | 'playing' | 'paused' | 'done'
+// Only wired when descriptor.useCases is present.
+
+let _ucActiveIdx = null
+let _ucState = 'none'
+let _ucTimer = null
+let _ucStepIdx = 0
+
+function _syncUcButtons() {
+  const ucPlay = document.getElementById('ucPlay')
+  const ucReset = document.getElementById('ucReset')
+  if (!ucPlay) return
+  switch (_ucState) {
+    case 'none':
+      ucPlay.textContent = '▶ play'
+      ucPlay.disabled = true
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'ready':
+      ucPlay.textContent = '▶ play'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'playing':
+      ucPlay.textContent = '⏸ pause'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+    case 'paused':
+      ucPlay.textContent = '▶ resume'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.add('visible')
+      break
+    case 'done':
+      ucPlay.textContent = '↺ replay'
+      ucPlay.disabled = false
+      if (ucReset) ucReset.classList.remove('visible')
+      break
+  }
+}
+
+function _resetUcVisuals() {
+  Object.values(nodeEl).forEach((el) => {
+    el.classList.remove('uc-active', 'uc-done')
+  })
+  paths.forEach((p) => {
+    p.classList.remove('uc-active', 'uc-done')
+  })
+  canvas.classList.remove('dimmed')
+  // clear particle (particles.js)
+  if (typeof clearParticle === 'function') clearParticle()
+
+  const ucStepsList = document.getElementById('ucStepsList')
+  if (ucStepsList) {
+    ucStepsList.querySelectorAll('li').forEach((li) => {
+      li.classList.remove('step-active', 'step-done')
+    })
+  }
+}
+
+function _stopUcTimer() {
+  if (_ucTimer) {
+    clearTimeout(_ucTimer)
+    _ucTimer = null
+  }
+}
+
+function _selectUc(idx) {
+  _stopUcTimer()
+  _resetUcVisuals()
+  _ucActiveIdx = idx
+  _ucStepIdx = 0
+  _ucState = 'ready'
+
+  const uc = DESCRIPTOR.useCases[idx]
+  const ucTitle = document.getElementById('ucTitle')
+  const ucDesc = document.getElementById('ucDesc')
+  const ucStepsList = document.getElementById('ucStepsList')
+  const sbUc = document.getElementById('sbUc')
+
+  if (ucTitle) ucTitle.textContent = uc.title
+  if (ucDesc) ucDesc.innerHTML = uc.desc
+  if (ucStepsList) {
+    ucStepsList.innerHTML = ''
+    uc.steps.forEach((s, i) => {
+      const li = document.createElement('li')
+      li.innerHTML = `<span class="sn">${String(i + 1).padStart(2, '0')}</span>${s.label}`
+      ucStepsList.appendChild(li)
+    })
+  }
+  if (sbUc) sbUc.classList.add('visible')
+
+  document.querySelectorAll('.uc-btn').forEach((b) => {
+    b.classList.toggle('active', Number(b.dataset.uc) === idx)
+  })
+  _syncUcButtons()
+}
+
+function _applyUcStep(stepIdx) {
+  const uc = DESCRIPTOR.useCases[_ucActiveIdx]
+  if (stepIdx >= uc.steps.length) {
+    _ucState = 'done'
+    _syncUcButtons()
+    return
+  }
+  _ucStepIdx = stepIdx
+  const step = uc.steps[stepIdx]
+  canvas.classList.add('dimmed')
+
+  // mark previous steps done (verbatim from lyra-stack-v2)
+  for (let i = 0; i < stepIdx; i++) {
+    uc.steps[i].nodes.forEach((id) => {
+      if (nodeEl[id]) {
+        nodeEl[id].classList.remove('uc-active')
+        nodeEl[id].classList.add('uc-done')
+      }
+    })
+    if (uc.steps[i].edge) {
+      const prevEf = uc.steps[i].edge[0]
+      const prevEt = uc.steps[i].edge[1]
+      const prevPp = pathByPair.get(pairKey(prevEf, prevEt))
+      if (prevPp) {
+        prevPp.classList.remove('uc-active')
+        prevPp.classList.add('uc-done')
+      }
+    }
+  }
+
+  // activate current step nodes
+  step.nodes.forEach((id) => {
+    if (nodeEl[id]) nodeEl[id].classList.add('uc-active', 'hot')
+  })
+
+  // activate edge + spawn particle if particles opt-in
+  if (typeof clearParticle === 'function') clearParticle()
+  if (step.edge) {
+    const ef = step.edge[0]
+    const et = step.edge[1]
+    const pp = pathByPair.get(pairKey(ef, et))
+    if (pp) {
+      pp.classList.add('uc-active', 'hot')
+      // spawn particle if particles enabled and spawnParticle available
+      if (typeof spawnParticle === 'function' && DESCRIPTOR.options && DESCRIPTOR.options.particles !== false) {
+        // Find plane from edges
+        const edges = DESCRIPTOR.edges || []
+        let edgeDef = null
+        for (let j = 0; j < edges.length; j++) {
+          const ed = edges[j]
+          if ((ed.f === ef && ed.t === et) || (ed.f === et && ed.t === ef)) {
+            edgeDef = ed
+            break
+          }
+        }
+        const plane = edgeDef ? edgeDef.plane : 'control'
+        spawnParticle(ef, et, plane, 750, null)
+      }
+    }
+  }
+
+  // update step list
+  const ucStepsList = document.getElementById('ucStepsList')
+  if (ucStepsList) {
+    const items = ucStepsList.querySelectorAll('li')
+    items.forEach((li, i) => {
+      li.classList.remove('step-active', 'step-done')
+      if (i < stepIdx) li.classList.add('step-done')
+      if (i === stepIdx) li.classList.add('step-active')
+    })
+  }
+
+  // sidebar header: show step label
+  const sbHeader = document.getElementById('sbHeader')
+  const firstId = step.nodes[0]
+  if (firstId && nodeEl[firstId] && sbHeader) {
+    const nodes = DESCRIPTOR.nodes || []
+    let nd = null
+    for (let k = 0; k < nodes.length; k++) {
+      if (nodes[k].id === firstId) {
+        nd = nodes[k]
+        break
+      }
+    }
+    if (nd && _ucState !== 'playing') {
+      spotlight(nd)
+    } else {
+      sbHeader.innerHTML = `<h4>${step.label}</h4>`
+    }
+  } else if (sbHeader) {
+    sbHeader.innerHTML = `<h4>${step.label}</h4>`
+  }
+
+  _ucTimer = setTimeout(() => {
+    _applyUcStep(stepIdx + 1)
+  }, 900)
+}
+
+// ── wireUseCaseUI ─────────────────────────────────────────────────────────
+// Called from the engine bootstrap when descriptor.useCases is present.
+// Wires up .uc-btn, #ucPlay, #ucReset DOM controls.
+// Safe to call even when some controls are absent (sidebar-less mode).
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function wireUseCaseUI() {
+  document.querySelectorAll('.uc-btn').forEach((b) => {
+    b.addEventListener('click', () => {
+      _selectUc(Number(b.dataset.uc))
+    })
+  })
+
+  const ucPlay = document.getElementById('ucPlay')
+  const ucReset = document.getElementById('ucReset')
+
+  if (ucPlay) {
+    ucPlay.addEventListener('click', () => {
+      if (_ucActiveIdx === null) return
+      if (_ucState === 'playing') {
+        _stopUcTimer()
+        _ucState = 'paused'
+        _syncUcButtons()
+      } else if (_ucState === 'done' || _ucState === 'ready') {
+        _resetUcVisuals()
+        _ucStepIdx = 0
+        _ucState = 'playing'
+        _syncUcButtons()
+        _applyUcStep(0)
+      } else if (_ucState === 'paused') {
+        _ucState = 'playing'
+        _syncUcButtons()
+        _applyUcStep(_ucStepIdx)
+      }
+    })
+  }
+
+  if (ucReset) {
+    ucReset.addEventListener('click', () => {
+      _stopUcTimer()
+      _resetUcVisuals()
+      _ucStepIdx = 0
+      _ucState = 'ready'
+      _syncUcButtons()
+    })
+  }
+}
+
+// ── wireHoverSpotlight ────────────────────────────────────────────────────
+// Adds mouseenter/mouseleave listeners to all rendered .fd-node elements.
+// Called once after renderNodes(), before draw().
+// Skips spotlight during playing state (verbatim from lyra-stack-v2 l.480-482).
+
+/* biome-ignore lint/correctness/noUnusedVariables: cross-file concat — called by generated HTML bootstrap */
+function wireHoverSpotlight() {
+  const nodes = DESCRIPTOR.nodes || []
+  nodes.forEach((nd) => {
+    const el = nodeEl[nd.id]
+    if (!el) return
+    el.addEventListener('mouseenter', () => {
+      if (_ucState !== 'playing') spotlight(nd)
+    })
+    el.addEventListener('mouseleave', () => {
+      if (_ucState !== 'playing') clearSpot()
+    })
+  })
+}
+
+
+/* ── fd/architecture.js ── */
+// fd/types/architecture.js — declarative layout handler + zone placement
+// Glob-discovery: bundler.js discovers this file via glob('fd/types/*.js').
+// Exports TYPE so bundler can key it: window.__fdTypes[TYPE] = { CARD_DEFAULT, placeZones, init }
+
+const TYPE = 'architecture'
+const CARD_DEFAULT = 'premium' // RD-3: architecture/hub-spoke default is premium
+
+// ── placeZones ────────────────────────────────────────────────────────
+// Generalised from lyra-stack-v2.html placeZone() lines 693–718.
+// Parametric over descriptor.zones[] instead of hardcoded ids.
+//
+// For each zone:
+//   1. Collect rect() measurements for all member nodes.
+//   2. Compute union bounding box (min/max of cx±w/2, cy±h/2) + padding.
+//   3. Apply left/top/width/height to zone div#{zone.id} (bare id — no prefix added).
+//   4. Create the zone div if absent (class: fd-zone + zone.class).
+//
+// Zone descriptor id == HTML element id: zone.id = "zone-forge" → getElementById("zone-forge").
+// rect() is declared in core.js scope (concat order: core.js, cards.js, architecture.js).
+function zonePadding(zone) {
+  const p = zone.padding || {}
+  if (zone.class === 'zone-hub') {
+    return { x: p.x ?? 14, yt: p.top ?? 36, yb: p.bottom ?? 12 }
+  }
+  if (zone.class === 'zone-stores') {
+    return { x: p.x ?? 14, yt: p.top ?? 20, yb: p.bottom ?? 10 }
+  }
+  if (zone.class === 'zone-m2') {
+    return { x: p.x ?? 16, yt: p.top ?? 20, yb: p.bottom ?? 12 }
+  }
+  return { x: p.x ?? 16, yt: p.top ?? 20, yb: p.bottom ?? 12 }
+}
+
+function placeZones(descriptor) {
+  const zones = descriptor.zones
+  if (!zones || zones.length === 0) return
+
+  for (const zone of zones) {
+    // resolve or create zone div — bare zone.id, no prefix added
+    let zEl = document.getElementById(zone.id)
+    if (!zEl) {
+      zEl = document.createElement('div')
+      zEl.id = zone.id
+      let cls = 'fd-zone'
+      if (zone.class) cls += ` ${zone.class}`
+      zEl.className = cls
+
+      // inject zone label if provided
+      if (zone.label) {
+        const lbl = document.createElement('span')
+        lbl.className = 'fd-zone-label'
+        lbl.textContent = zone.label
+        zEl.appendChild(lbl)
+      }
+
+      canvas.insertBefore(zEl, canvas.firstChild)
+    }
+
+    // measure member nodes — guard against unknown ids (node not yet rendered or missing)
+    const memberIds = zone.nodes || []
+    if (memberIds.length === 0) continue
+
+    const rects = memberIds.map((id) => (nodeEl[id] ? rect(id) : null)).filter(Boolean)
+    if (rects.length === 0) continue
+
+    // union bounding box
+    const xMin = Math.min(...rects.map((r) => r.cx - r.w / 2))
+    const xMax = Math.max(...rects.map((r) => r.cx + r.w / 2))
+    const yMin = Math.min(...rects.map((r) => r.cy - r.h / 2))
+    const yMax = Math.max(...rects.map((r) => r.cy + r.h / 2))
+
+    // Per-zone padding — mirrors lyra-stack-v2.html placeZone() (hub 26/18/14, stores 18/14/10)
+    const pad = zonePadding(zone)
+    const padX = pad.x
+    const padYT = pad.yt
+    const padYB = pad.yb
+
+    const left = xMin - padX
+    const top = yMin - padYT
+    const width = xMax + padX - left
+    const height = yMax + padYB - top
+
+    zEl.style.left = `${left}px`
+    zEl.style.top = `${top}px`
+    zEl.style.width = `${width}px`
+    zEl.style.height = `${height}px`
+  }
+}
+
+// ── init ──────────────────────────────────────────────────────────────
+// Called by the fd-engine bootstrap after parsing fd-data.
+// Returns { typeDefault, placeZones } consumed by the engine orchestrator.
+function init(descriptor) {
+  const t = descriptor.type
+  if (t !== 'architecture' && t !== 'hub-spoke') {
+    console.warn('[fd] architecture.js init() called with unexpected type:', t)
+  }
+  // layout is declarative — no elk step; x/y already in descriptor
+  return {
+    typeDefault: CARD_DEFAULT,
+    placeZones,
+  }
+}
+
+// ── glob-discovery registration ───────────────────────────────────────
+// bundler.js discovers fd/types/*.js and concatenates them into the
+// inline <script>. At runtime each type module self-registers here.
+window.__fdTypes = window.__fdTypes || {}
+window.__fdTypes[TYPE] = { CARD_DEFAULT, placeZones, init }
+// 'hub-spoke' is an alias for 'architecture'
+window.__fdTypes['hub-spoke'] = window.__fdTypes[TYPE]
+
+
+/* ── __fd window entry (generated by bundler.js) ── */
+window.__fd = {
+  initEngine: initEngine,
+  renderNodes: renderNodes,
+  draw: draw,
+  wireResize: wireResize,
+  uniquePlanes: typeof uniquePlanes !== 'undefined' ? uniquePlanes : null,
+  initMarkers: typeof initMarkers !== 'undefined' ? initMarkers : null,
+}
+})()
+
+</script>
+
+<script>
+// fd-bootstrap.js — universal runtime bootstrap for gen-fd.py output
+// Inlined after the fd-engine IIFE bundle. Expects window.__fd + window.__fdTypes.
+
+;(() => {
+  function run() {
+    var dataEl = document.getElementById('fd-data')
+    if (!dataEl || !window.__fd) return
+
+    var descriptor = JSON.parse(dataEl.textContent)
+    var canvasEl = document.getElementById('fd-canvas')
+    var svgEl = document.getElementById('fd-edges')
+    if (!canvasEl || !svgEl) return
+
+    var type = descriptor.type || 'architecture'
+    var typeReg = window.__fdTypes && window.__fdTypes[type]
+    var typeInit = typeReg && typeof typeReg.init === 'function' ? typeReg.init(descriptor) : null
+    var typeDefault = (typeInit && typeInit.typeDefault) || (typeReg && typeReg.CARD_DEFAULT) || 'premium'
+
+    if (descriptor.canvas && descriptor.canvas.height) {
+      canvasEl.style.setProperty('--fd-canvas-h', descriptor.canvas.height + 'px')
+      canvasEl.style.height = descriptor.canvas.height + 'px'
+    }
+
+    window.__fd.initEngine(descriptor, canvasEl, svgEl)
+
+    // Chart-only types (gantt, pie, xychart) bypass node/edge engine
+    if (typeReg && typeof typeReg.renderChart === 'function') {
+      typeReg.renderChart(descriptor)
+      return
+    }
+
+    window.__fd.renderNodes(descriptor, typeDefault)
+
+    if (typeInit && typeof typeInit.positionNodes === 'function') {
+      typeInit.positionNodes(descriptor)
+    } else if (typeReg && typeof typeReg.positionNodes === 'function') {
+      typeReg.positionNodes(descriptor)
+    }
+
+    if (typeInit && typeof typeInit.applyShapes === 'function') {
+      typeInit.applyShapes(descriptor)
+    } else if (typeReg && typeof typeReg.applyShapes === 'function') {
+      typeReg.applyShapes(descriptor)
+    }
+
+    if (window.__fd.initMarkers && window.__fd.uniquePlanes) {
+      window.__fd.initMarkers(window.__fd.uniquePlanes())
+    }
+
+    window.__fd.draw()
+
+    var placeZonesFn = (typeInit && typeInit.placeZones) || (typeReg && typeReg.placeZones) || null
+    if (typeof placeZonesFn === 'function') {
+      placeZonesFn(descriptor)
+    }
+
+    window.__fd.wireResize()
+
+    if (typeof wireHoverSpotlight === 'function' && descriptor.options && descriptor.options.spotlight !== false) {
+      wireHoverSpotlight()
+    }
+
+    if (typeof wireUseCaseUI === 'function' && descriptor.useCases && descriptor.useCases.length) {
+      wireUseCaseUI()
+    }
+
+    document.querySelectorAll('.ctl[data-plane]').forEach((ctl) => {
+      ctl.addEventListener('click', () => {
+        ctl.classList.toggle('off')
+        canvasEl.classList.toggle('hide-' + ctl.dataset.plane, ctl.classList.contains('off'))
+      })
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      setTimeout(run, 80)
+    })
+  } else {
+    setTimeout(run, 80)
+  }
+})()
+
+</script>
+</body>
+</html>

--- a/plugins/compress/README.md
+++ b/plugins/compress/README.md
@@ -21,6 +21,17 @@ It applies 10 transformation rules:
 
 Things it never touches: frontmatter, code blocks, file paths, tool names, safety rules, `$ARGUMENTS`.
 
+## Fidelity guardrails
+
+Every output is governed by four guardrails (G1–G4 in `skills/compress/SKILL.md`, evidence pinned in `skills/compress/references/evidence.md`):
+
+- **G1 Polarity** — a negative constraint (`do not use Y`) is rewritten to a concrete alternative (`use Z`) only when Z actually exists; the skill never invents one. No alternative → the constraint is kept and flagged `needs external verification`.
+- **G2 No free coinage** — emitted symbols come from the canonical inline whitelist (or a local `Let:` binding). Glyphs are chosen for register and precision, never for token economy — measured savings come from prose pruning.
+- **G3 Gloss trigger** — predicates, process blocks, `Let:` bindings, non-whitelist symbols, and chains of more than 3 operators all get a mandatory one-line gloss.
+- **G4 Verbatim floor** — commands, tool names, spawn templates, and safety rules stay in words.
+
+The whitelist in SKILL.md is canonical. When the optional shared glossary (`plugins/shared/references/notation.md`) is installed it extends the symbol domain; without it the skill runs fully standalone.
+
 ## Install
 
 ```bash
@@ -34,7 +45,7 @@ claude plugin install compress
 - `compress fixer` — compresses the agent at `.claude/agents/fixer.md`
 - `compress path/to/file.md` — compresses a file directly
 
-The plugin shows a before/after line count and asks for approval before writing any changes.
+The plugin shows per-section before/after token counts and asks for approval before writing any changes.
 
 ## License
 

--- a/plugins/compress/skills/compress/SKILL.md
+++ b/plugins/compress/skills/compress/SKILL.md
@@ -87,7 +87,7 @@ One ledger row per completed target, appended ONLY via S — append command temp
 ## Guardrails
 
 ∀ mode, ∀ output — the fidelity floor; evidence pinned in `references/evidence.md`.
-Whitelist: `∀` `∃` `∄` `∈` `∉` `∧` `∨` `¬` `→` `⟺` `∅` `∩` `∪` `⊂` `∥` `|X|` `:=` `←` `{ }` `;` `()` `↦`
+Whitelist: `∀` `∃` `∄` `∈` `∉` `∧` `∨` `¬` `→` `⇒` `⟺` `∅` `∩` `∪` `⊂` `∥` `|X|` `:=` `←` `{ }` `;` `()` `↦` `≥` `≤` `✓` `✗`
 - **G1** polarity: `¬use Y` → `use Z (¬Y)` iff a concrete Z ∃ — never invent Z. No alternative → keep the constraint + flag `needs external verification` (block format: Phase 4).
 - **G2** no free coinage: emitted symbols ∈ whitelist (∪ core table when loaded) ∨ Let-defined; ¬coin indexed vars. Glyph substitution is token-neutral at best; choose glyphs for register/precision, never for economy; measured savings come from prose pruning. ¬hardcode token tiers ∨ tokenizer-relative glyph rules — cost claims require measurement via S (API count; record tokenizer + date).
 - **G3** gloss trigger: `(predicate ∨ O-block ∨ Let-bind) ∨ (symbol ∉ whitelist) ∨ (chain > 3 operators)` → mandatory `— …` gloss ≤1 line. Bare non-whitelist symbols forbidden in output.

--- a/plugins/compress/skills/compress/SKILL.md
+++ b/plugins/compress/skills/compress/SKILL.md
@@ -43,7 +43,7 @@ Let:
 ## Phase 0 — Dispatch
 
 Parse the first token of `$ARGUMENTS`: ∈ μ set → mode; omitted → `compress`. Ambiguous (neither a mode nor a resolvable path/name) → ask "Mode or target?" (1–2 sentences), then dispatch. First token matching a mode always dispatches as mode — force scope interpretation with a path (e.g. `./lint`).
-Mode valid ⟺ ref(μ) ∃. ∄ → halt: `mode "<μ>" not yet implemented` — ¬improvise a mode body. Today only `references/compress.md` ships → `derive|expand|lint|glossary` all halt.
+Mode valid ⟺ ref(μ) ∃. ∄ → halt: `mode "<μ>" not yet implemented` — ¬improvise a mode body. Today `references/compress.md` + `references/glossary.md` ship → `derive|expand|lint` halt.
 Glossary gate: `${CLAUDE_PLUGIN_ROOT}/../shared/references/notation.md` ∃ → load its `## Core Table` section only; ∄ → the `Whitelist:` line (Guardrails) is the sole symbol domain — standalone install, G1–G4 still bind.
 
 ## Phase 1 — Scope

--- a/plugins/compress/skills/compress/SKILL.md
+++ b/plugins/compress/skills/compress/SKILL.md
@@ -33,17 +33,18 @@ Let:
 
 | Phase | ID | Notes |
 |-------|----|-------|
-| 0 | dispatch | mode parse + mode-exists gate |
+| 0 | dispatch | mode parse + mode-exists gate + glossary gate |
 | 1 | scope | resolve T + read budget |
 | 2 | analyze | pre-image `source_ref` + tokens_before via S |
-| 3 | transform | apply ref(μ) rules |
+| 3 | transform | apply ref(μ) rules under G1–G4 |
 | 4 | present | per-section Δtokens + user choice |
-| 5 | write | verify + ledger append via S |
+| 5 | write | verify + symbol assert + ledger append via S |
 
 ## Phase 0 — Dispatch
 
 Parse the first token of `$ARGUMENTS`: ∈ μ set → mode; omitted → `compress`. Ambiguous (neither a mode nor a resolvable path/name) → ask "Mode or target?" (1–2 sentences), then dispatch. First token matching a mode always dispatches as mode — force scope interpretation with a path (e.g. `./lint`).
 Mode valid ⟺ ref(μ) ∃. ∄ → halt: `mode "<μ>" not yet implemented` — ¬improvise a mode body. Today only `references/compress.md` ships → `derive|expand|lint|glossary` all halt.
+Glossary gate: `${CLAUDE_PLUGIN_ROOT}/../shared/references/notation.md` ∃ → load its `## Core Table` section only; ∄ → the `Whitelist:` line (Guardrails) is the sole symbol domain — standalone install, G1–G4 still bind.
 
 ## Phase 1 — Scope
 
@@ -60,29 +61,21 @@ N = 0 → halt, list every attempted resolution. Name matches in both layouts �
 ∀ f ∈ T, before any write:
 - `source_ref(f)` := `git hash-object "<f>"` (fallback: `sha256sum`) — pre-image hash, captured now, carried to Phase 5
 - tokens_before per section: `python3 S count "<f>"` — note the report's `method:` ∈ {anthropic-api, tiktoken-proxy, estimate}; also capture `agreement`/`calibration` when present
-- total < ~200 tokens → warn (cheap pre-check heuristic), proceed only if confirmed
-- mark compression candidates per ref(μ)
+- total < ~200 tokens → warn (cheap pre-check heuristic), proceed only if confirmed; mark compression candidates per ref(μ)
 
 ## Phase 3 — Transform
 
-Read ref(μ), apply its rules. Compress mode body: symbols legend, transform rules R1–R10, ¬compress list, measured rationale — all in `references/compress.md`.
+Read ref(μ), apply its rules under the Guardrails. Compress mode body — symbols legend, transform rules R1–R10, mode edge cases, measured rationale — all in `references/compress.md`. Collision-check every new `Let:` var: glossary ∃ → its reserved-var registry; ∄ → the whitelist glyph domain only (reserved-var binding collisions ¬checked standalone — accepted degradation).
 
 ## Phase 4 — Present
 
-Per-section table: `section | tokens_before | tokens_after | Δtokens` (candidate text re-counted via S). Flag every `Δtokens ≈ 0` section — prefer the readable form there. Never present char% or line% as savings — tokens are the only metric.
+Per-section table: `section | tokens_before | tokens_after | Δtokens` (candidate text re-counted via S). Flag every `Δtokens ≈ 0` section — prefer the readable form there. Never present char% or line% as savings — tokens are the only metric. Every G1 flag → one fixed-format block `{constraint | polarity | alternative-exists | verification-method}` (vault persistence optional — completes with no vault).
 → present choice **Yes** | **Preview** | **Adjust**. Preview → show full text, re-ask. Adjust → apply feedback, re-present.
 
 ## Phase 5 — Write
 
-Write file. Verify: frontmatter intact ∧ `$ARGUMENTS` intact ∧ safety rules intact ∧ ¬semantic loss. Re-count via `python3 S count "<f>"` → tokens_after.
-One ledger row per completed target, appended ONLY via S — generate one run ULID (`python3 S new-ulid`) and share it as `--correlation` across every row of a multi-file run:
-
-```
-python3 S append --target "<f>" --mode <μ> --source-ref <hash> \
-  --tokens-before <n> --tokens-after <n> --correlation <run-ulid> \
-  --sections-json '[{"name": "…", "tokens_before": …, "tokens_after": …}]' --method <m> \
-  --proxy-agreement <bool> --calibration "<line>"  # when captured in Phase 2
-```
+Write file. Verify: frontmatter intact ∧ `$ARGUMENTS` intact ∧ safety rules intact ∧ ¬semantic loss ∧ every emitted symbol ∈ whitelist ∪ core table ∨ locally Let-defined. Re-count via `python3 S count "<f>"` → tokens_after.
+One ledger row per completed target, appended ONLY via S — append command template + shared run-ULID `--correlation`: `references/compress.md` § Ledger Append.
 
 ## Edge Cases
 
@@ -90,7 +83,17 @@ python3 S append --target "<f>" --mode <μ> --source-ref <hash> \
 |----------|----------|
 | Agent (¬skill) | Preserve agent frontmatter |
 | User rejects at Phase 4 | Halt |
-| Mode-specific (already formal, no repeated concepts, mixed prose + code) | Per ref(μ) |
+
+## Guardrails
+
+∀ mode, ∀ output — the fidelity floor; evidence pinned in `references/evidence.md`.
+Whitelist: `∀` `∃` `∄` `∈` `∉` `∧` `∨` `¬` `→` `⟺` `∅` `∩` `∪` `⊂` `∥` `|X|` `:=` `←` `{ }` `;` `()` `↦`
+- **G1** polarity: `¬use Y` → `use Z (¬Y)` iff a concrete Z ∃ — never invent Z. No alternative → keep the constraint + flag `needs external verification` (block format: Phase 4).
+- **G2** no free coinage: emitted symbols ∈ whitelist (∪ core table when loaded) ∨ Let-defined; ¬coin indexed vars. Glyph substitution is token-neutral at best; choose glyphs for register/precision, never for economy; measured savings come from prose pruning. ¬hardcode token tiers ∨ tokenizer-relative glyph rules — cost claims require measurement via S (API count; record tokenizer + date).
+- **G3** gloss trigger: `(predicate ∨ O-block ∨ Let-bind) ∨ (symbol ∉ whitelist) ∨ (chain > 3 operators)` → mandatory `— …` gloss ≤1 line. Bare non-whitelist symbols forbidden in output.
+- **G4** verbatim floor: commands, tool names, spawn templates, safety rules stay in words (evidence: references/evidence.md — Tencent 2604.07192).
+
+Economics: R5/R6/R7 = the primary economic transform; R1 = disambiguation, ¬economy — a rename pays iff `(T_phrase − T_var) × occ > T_letline (≈8–10)` (practical: phrase ≥3 tokens ∧ occ ≥4, ∨ phrase ≥4 ∧ occ ≥3); G1/G3 spend tokens to buy compliance.
 
 ## Safety
 

--- a/plugins/compress/skills/compress/references/compress.md
+++ b/plugins/compress/skills/compress/references/compress.md
@@ -1,6 +1,6 @@
 # Compress Mode
 
-Mode body for `/compress` default mode — loaded by SKILL.md Phase 3. Contains the symbols legend, the transform rules, the do-not-compress list, mode-specific edge cases, and the measured rationale that governs when a substitution is worth making.
+Mode body for `/compress` default mode — loaded by SKILL.md Phase 3. Contains the symbols legend, the transform rules, mode-specific edge cases, the Phase 5 ledger-append template, and the measured rationale that governs when a substitution is worth making. Output fidelity is governed by SKILL.md `## Guardrails` (G1–G4).
 
 ## Symbols
 
@@ -12,12 +12,12 @@ Identify: repeated nouns (≥3×) | verbose conditionals | iteration prose | mag
 
 ## Transform Rules (R1–R10)
 
-- **R1** Definitions: concept ≥ 3× → Greek var in `Let:` block (after title). Lowercase, mnemonic. Template:
+- **R1** Definitions (disambiguation, ¬economy — pays only past the SKILL.md break-even inequality): concept ≥ 3× → Greek var in `Let:` block (after title). Lowercase, mnemonic, collision-checked per SKILL.md Phase 3. Template:
   ```
   Let:
-    φ := set of all findings
-    γ(f) ∈ [0,100] ∩ ℤ  — confidence
-    τ := 80               — threshold
+    η := set of all findings
+    κ(f) ∈ [0,100] ∩ ℤ  — confidence
+    θ := 80               — threshold
   ```
 - **R2** Predicates: multi-bullet conditions → `pred(x) ⟺ A ∧ B ∧ C`
 - **R3** Quantifiers: "for each" → `∀ x ∈ Y:` | "if any" → `∃ x:` | "exists" → `X ∃ →`
@@ -29,7 +29,7 @@ Identify: repeated nouns (≥3×) | verbose conditionals | iteration prose | mag
 - **R9** Process encapsulation: procedure/workflow → `O_name { step₁; step₂; … } → output`
 - **R10** Parameterized patterns: repeated pattern(varying inputs) → `F(x, y)`
 
-**¬compress:** frontmatter | code blocks | `$ARGUMENTS` | file paths | tool names | safety rules | table structure
+**¬compress:** superseded by SKILL.md `## Guardrails` G1–G4 — commands, file paths, tool names, spawn templates, safety rules sit under the G4 verbatim floor; frontmatter, code blocks, `$ARGUMENTS`, table structure stay protected by SKILL.md Safety + R6.
 
 ## Mode Edge Cases
 
@@ -49,3 +49,14 @@ Per-glyph cost is tokenizer-dependent — glyph substitution alone is not compre
 - The bulk of real token gains comes from R5/R6/R7 — prose pruning — not from glyphs. Some substitutions are net-negative.
 
 Consequences: judge every candidate substitution by `Δtokens`, never by character or line counts (both can shrink while tokens increase). R1–R4/R8–R10 buy consistency and unambiguous structure; R5/R6/R7 buy tokens. When Phase 4 flags `Δtokens ≈ 0` for a section, prefer the more readable form.
+
+## Ledger Append (Phase 5)
+
+One ledger row per completed target, appended ONLY via S (SKILL.md's sole ledger writer) — generate one run ULID (`python3 S new-ulid`) and share it as `--correlation` across every row of a multi-file run:
+
+```
+python3 S append --target "<f>" --mode <μ> --source-ref <hash> \
+  --tokens-before <n> --tokens-after <n> --correlation <run-ulid> \
+  --sections-json '[{"name": "…", "tokens_before": …, "tokens_after": …}]' --method <m> \
+  --proxy-agreement <bool> --calibration "<line>"  # when captured in Phase 2
+```

--- a/plugins/compress/skills/compress/references/evidence.md
+++ b/plugins/compress/skills/compress/references/evidence.md
@@ -1,0 +1,36 @@
+# Evidence — Pinned Excerpts
+
+Load-bearing evidence behind the SKILL.md guardrails (G1–G4). Each pin: source ID, the finding as measured, and the guardrail it licenses. Extend a guardrail only after re-verifying against the source.
+
+## Tencent — arXiv 2604.07192 (controlled null result + polarity taxonomy)
+
+- Encoding form has no detectable effect on constraint compliance — controlled null result, Cliff's δ < 0.01.
+- Compliance is governed by polarity: negative constraints opposing model defaults fail 10–100% regardless of notation; 36/47 observed failures = default bias.
+- Classical-Chinese counterexample: 4.6% savings vs 25–30% for tokenizer-aligned English tags — perceived density ≠ tokenizer efficiency.
+
+Licenses: G1 (polarity transform; never invent an alternative the source does not supply) · G2 (glyph substitution is token-neutral at best).
+
+## MetaGlyph — arXiv 2601.07354 (per-operator fidelity)
+
+- Operator fidelity is model-dependent: `→` read as a transformation operator 0% of the time, `∈` at 26%, `∩` read as a list.
+- U-curve: mid-size instruction-tuned models perform worst — glyph familiarity cannot be assumed from model capability.
+
+Licenses: G3 (mandatory gloss on non-whitelist and fidelity-warned symbols) · G2 (whitelist over free coinage).
+
+## LILO — ICLR 2024 (NL gloss is load-bearing)
+
+- Named abstractions without natural-language documentation (AutoDoc) become unusable downstream — the gloss carries semantic load; it is not decoration.
+
+Licenses: G3 (`— …` gloss ≤1 line on every Let-bind, predicate, and O-block).
+
+## Pseudo-code ablation note
+
+- Pseudo-code ablations corroborate LILO: symbolic or structural form without an NL gloss degrades downstream execution; exact wording is the reliable floor for anything an agent must execute or obey.
+
+Licenses: G4 (verbatim floor — commands, tool names, spawn templates, safety rules stay in words).
+
+## GEPA — ICLR 2026 (non-load-bearing credit)
+
+- Rule derivation by reflection over execution traces beats RL with 35× fewer rollouts. Prior art for the future derive mode only.
+
+Licenses: none — credited to keep the citation honest; no guardrail depends on it.

--- a/plugins/compress/skills/compress/references/glossary.md
+++ b/plugins/compress/skills/compress/references/glossary.md
@@ -1,0 +1,41 @@
+# Glossary Mode
+
+Mode body for `/compress glossary` — loaded by SKILL.md Phase 3 when μ = glossary. Maintains the canonical glossary (`${CLAUDE_PLUGIN_ROOT}/../shared/references/notation.md`): add, deprecate, or version notation entries under closed-vocabulary rules. Cortex link: this mode is closed-vocabulary governance mechanics only — a human-gated add/deprecate/version loop over a fixed symbol set, nothing more.
+
+## Preconditions
+
+- Glossary gate: `${CLAUDE_PLUGIN_ROOT}/../shared/references/notation.md` ∄ → halt: `glossary mode requires the shared glossary — standalone installs carry only the inline whitelist, which this mode does not edit`.
+- Load the lazy halves of notation.md: `## Disambiguation Grammar` + `## Maintenance Policy` + `## Reserved-Variable Registry`. (Compress mode loads `## Core Table` only — this mode is the reason the other sections exist.)
+
+## Pipeline
+
+| Step | Action |
+|------|--------|
+| 1 | Parse request → op ∈ {add, deprecate, version} + target glyph/var |
+| 2 | Measure: fresh `git grep` counts + file spread over `plugins/` for the target (and any competing glyph) |
+| 3 | Collision protocol (below) for new vars; adjudication draft (counts, outcome, rationale, date) for glyphs |
+| 4 | → present choice **Apply** \| **Preview** \| **Abort** — extension is human-gated, never improvised mid-run |
+| 5 | Apply per Maintenance Policy; core-active operator changes edit SKILL.md `Whitelist:` in the same change |
+| 6 | Verify: `python3 tools/validate_plugins.py --check notation-legends` exits 0 (whitelist ≡ core table, pointers intact) |
+
+## Op semantics
+
+- **add** — new core-active operator glyph → new `## Core Table` row + whitelist span (lockstep, step 5); new reserved variable → registry row with measured bindings + status. Both need the step-4 gate; a rejected candidate is still recorded (Maintenance Policy table) so the adjudication isn't re-litigated from zero.
+- **deprecate** — move the core row into Maintenance Policy's deprecated table + drop the whitelist span in the same change. Never delete the record.
+- **version** — re-measure dated counts (registry rows, adjudication cells) and update them as a new dated entry; never silently edit an old measurement.
+
+## Collision protocol (vs registry)
+
+New or re-bound variable proposed → look it up in `## Reserved-Variable Registry`:
+
+- var ∄ registry → free; bind it, offer a registry row if the binding recurs (≥3 files).
+- var ∃ with the same sense → reuse the canonical binding, no new entry.
+- var ∃ with a different sense → either pick an unbound var, or mark the binding `(local)` in the target file's `Let:` block. An un-marked collision is exactly what compress Phase 3 flags — don't ship one from the mode that owns the registry.
+
+## Edge cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Request names a glyph already deprecated | Show its Maintenance Policy record; re-adding requires a fresh adjudication through the full pipeline |
+| Whitelist edit would push SKILL.md over its line budget | Halt and report — the budget gate (`validate_plugins.py`) wins; rework before extending |
+| Counts contradict the requested outcome | Present the numbers and recommend against; the human gate decides |

--- a/plugins/compress/skills/compress/references/glossary.md
+++ b/plugins/compress/skills/compress/references/glossary.md
@@ -32,7 +32,7 @@ New or re-bound variable proposed → look it up in `## Reserved-Variable Regist
 - var ∃ with the same sense → reuse the canonical binding, no new entry.
 - var ∃ with a different sense → either pick an unbound var, or mark the binding `(local)` in the target file's `Let:` block. An un-marked collision is exactly what compress Phase 3 flags — don't ship one from the mode that owns the registry.
 
-## Edge cases
+## Edge Cases
 
 | Scenario | Behavior |
 |----------|----------|

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/agents/doc-writer.md
+++ b/plugins/dev-core/agents/doc-writer.md
@@ -48,7 +48,7 @@ DP undefined → output: "`.claude/stack.yml` not found in context. Add `@.claud
 8. `## Edge Cases`
 9. `$ARGUMENTS` (last line, always)
 
-**Compressed notation:** `∃` exists | `¬` not | `⇒` implies | `∀` for all | `∧` and | `∨` or | `∅` null | `→` maps to | `S*` next-step variable | `¬do-x` = do NOT do x | Σ = state dict
+**Compressed notation:** legend → canonical glossary: `${CLAUDE_PLUGIN_ROOT}/../shared/references/notation.md` (repo: `plugins/shared/references/notation.md`)
 
 **Decision options** in **bold**. Conditions: `∃ X ⇒ do Y` / `¬∃ X ⇒ do Z`.
 

--- a/plugins/dev-core/skills/shared/references/base.md
+++ b/plugins/dev-core/skills/shared/references/base.md
@@ -13,4 +13,4 @@ codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project que
 
 ## Notation
 
-`¬` not | `→` then/maps-to | `∨` or | `∧` and | `∃` exists | `∀` for all | `≥/≤` threshold | `✓/✗` pass/fail | `S*` next-step variable | `Σ` state dict
+Legend → canonical glossary: `${CLAUDE_PLUGIN_ROOT}/../shared/references/notation.md` (repo: `plugins/shared/references/notation.md`)

--- a/plugins/shared/references/notation.md
+++ b/plugins/shared/references/notation.md
@@ -1,0 +1,114 @@
+# Notation — Canonical Glossary
+
+Single source of truth for the formal notation used across this marketplace's skills and agents. It merges the three prior legends (compress `## Symbols`, dev-core `base.md` Notation, dev-core `doc-writer.md` compressed-notation line) — dispositions recorded in the merge audit below. This glossary is writer-side tooling: consumers of compressed files never need it — every emitted symbol must be self-sufficient via the whitelist or a local Let-binding with gloss.
+
+Consumers: compress Phase 0 loads `## Core Table` only; compress Phase 3 checks Let-bindings against the Reserved-Variable Registry; the glossary mode loads Grammar + Maintenance; `tools/validate_plugins.py --check notation-legends` holds the core table set-equal to compress's `Whitelist:` line and gates the dev-core pointer lines.
+
+All counts below: `git grep` over `plugins/`, measured 2026-07-04. Re-measure before citing — counts drift.
+
+## Core Table
+
+Active glyphs only — this table ≡ the compress SKILL.md `Whitelist:` line (validator-enforced). Deprecated or rejected glyphs live in Maintenance Policy, never here. Column 1 carries nothing but the glyph spans (`\|` escapes the table delimiter).
+
+| glyph | senses | gloss? | fidelity ⚠ | notes/adjudication |
+|-------|--------|--------|------------|---------------------|
+| `∀` | for all / every | — | — | — |
+| `∃`/`∄` | exists / does not exist | — | — | — |
+| `∈`/`∉` | member of / not member of | mandatory on `∈` | MetaGlyph: membership read ~26% | — |
+| `∧`/`∨` | and / or | — | — | — |
+| `¬` | not / never / forbidden | — | — | compound idiom `¬do-x` = "do NOT do x" — see Grammar, ¬ registers |
+| `→` | 4 positional senses — see Grammar | mandatory | MetaGlyph: transformation-operator read 0% | sense fixed by position, not by the glyph — always gloss or disambiguate |
+| `⇒` | implies / contrastive consequence | — | — | Retained (2026-07-04): ×40 across 8 files; sanctioned implies/contrastive register (doc-writer legend origin); never classified as drift |
+| `⟺` | if and only if | — | — | Retained over `⇔` (2026-07-04): `⟺` ×12 across 8 files vs `⇔` ×0 in plugins/ |
+| `∅` | empty / null / none | — | — | — |
+| `∩`/`∪` | intersection / union | mandatory on `∩` | MetaGlyph: `∩` read as a list | — |
+| `⊂` | subset of / contained in | — | — | — |
+| `∥` | parallel / concurrently | — | — | — |
+| `\|X\|` | count / cardinality of X | — | — | escaped as `\|X\|` here only because `\|` delimits table cells |
+| `:=`/`←` | define / assign | — | — | — |
+| `{ }` | scoped block | — | — | — |
+| `;` | step sequence inside a block | — | — | — |
+| `()` | parameters / grouping | — | — | — |
+| `↦` | maps to (function graph) | — | — | — |
+| `≥`/`≤` | threshold comparison | — | — | Promoted from base.md legend (2026-07-04): `≥` ×107/47 files, `≤` ×47/31 — too live to demote |
+| `✓`/`✗` | pass / fail | — | — | Promoted from base.md legend (2026-07-04): `✓` ×110/22 files, `✗` ×33/16 |
+
+## Source-Legend Merge Audit
+
+Every entry of the three source legends, with its disposition. Nothing was dropped.
+
+| Source | Entries | Disposition |
+|--------|---------|-------------|
+| compress `references/compress.md` `## Symbols` | the 22 whitelist glyphs (∀ … ↦) | core-active rows, senses carried over verbatim |
+| dev-core `base.md` Notation line | ¬ → ∨ ∧ ∃ ∀ | core-active (already whitelisted) |
+| dev-core `base.md` Notation line | ≥/≤ threshold · ✓/✗ pass/fail | core-active rows, promoted into the whitelist (counts above) |
+| dev-core `base.md` Notation line | S* next-step variable · Σ state dict | registry entries (variables, not operators — outside the equality domain) |
+| dev-core `doc-writer.md` compressed-notation line | ∃ ¬ ∀ ∧ ∨ ∅ | core-active (already whitelisted) |
+| dev-core `doc-writer.md` compressed-notation line | ⇒ implies | adjudicated → core-active row (cell above) |
+| dev-core `doc-writer.md` compressed-notation line | → maps-to | merged into the `→` row; maps-to is one of its 4 senses (Grammar) |
+| dev-core `doc-writer.md` compressed-notation line | ¬do-x idiom | merged into the `¬` core-active row + Grammar ¬ registers |
+| dev-core `doc-writer.md` compressed-notation line | S* · Σ state dict | registry entries (same rows as base.md's) |
+
+## Disambiguation Grammar
+
+Loaded by glossary (and future lint) modes — not by compress runs.
+
+### `→` — four positional senses
+
+Classified from 24 fresh samples (`git grep '→' plugins/`, deterministic shuffle, 2026-07-04):
+
+| Sense | Shape | Samples |
+|-------|-------|---------|
+| guard → action (conditional) | `N = 0 → halt` — left side is a condition | 12/24 |
+| pipeline sequence | `parse → render → present` — chain of steps | 6/24 |
+| maps-to / rewrite | `lockfile hash → node_modules cache` | 5/24 |
+| produces / returns | `trigger → mandatory gloss ≤1 line` | 1/24 |
+
+Position decides the sense: condition on the left reads conditional; a chain of ≥3 reads sequence; a data pair reads maps-to. When position leaves ambiguity, gloss (its `gloss?` flag is mandatory).
+
+### `¬` — modal registers
+
+- predicate negation — `¬valid`, `¬empty`: states a fact.
+- imperative prohibition — `¬` before a command or action: "never do this". Strongest form is the compound `¬do-x` idiom ("do NOT do x"), inherited from the doc-writer legend.
+- absence — `¬found`, `¬∃`: nothing there (prefer `∄` when quantifying).
+
+### Separator hierarchy
+
+Binding strength, tightest first: `/` and `,` < `·` < `|` < `;` < newline < heading. A slash joins in-cell alternatives (`∃`/`∄`); the interpunct groups short phrases; the pipe separates legend or table entries; the semicolon sequences block steps; structure above that belongs to lines and headings.
+
+## Maintenance Policy
+
+Loaded by glossary mode. The glossary is closed-vocabulary: extension is human-gated, never improvised mid-run.
+
+- **Add** — measure first (`git grep` counts + file spread over `plugins/`), record an adjudication (counts, outcome, rationale, date) in the glyph's notes cell, then → present choice before the row lands. Adding a core-active operator glyph requires the same change to compress SKILL.md's `Whitelist:` line — `--check notation-legends` fails the commit otherwise.
+- **Deprecate** — move the row out of `## Core Table` into the table below and drop the glyph from the whitelist in the same change; the equality gate keeps the two in lockstep. Never delete the record.
+- **Version** — this file rides normal PRs; the validator (CI + lefthook) is the drift gate. Counts in adjudications are point-in-time and dated, never silently edited.
+
+| Deprecated / rejected glyph | Record |
+|-----------------------------|--------|
+| `⇔` | Rejected (2026-07-04): ×0 in plugins/ vs `⟺` ×12 across 8 files — `⟺` is the house iff |
+
+## Reserved-Variable Registry
+
+Variables carry file-local bindings — they are NOT operators and sit outside the whitelist equality domain. Counts: `git grep` over `plugins/`, 2026-07-04. Status ∈ canonical / collision / aspirational.
+
+| var | binding(s) | grep counts | status |
+|-----|-----------|-------------|--------|
+| `σ` | `.claude/stack.yml` (dominant) · spec artifact · status-icon map · staging branch | ×162 · 27 files | collision (4-way) |
+| `Ω` | override file (dominant) · `/interview` skill handle | ×14 · 3 files | collision |
+| `α` | agent (dominant) · analysis artifact · agent-memory file | ×153 · 20 files | collision |
+| `β` | base branch (dominant) · brainstorm artifact · frontend path | ×42 · 7 files | collision |
+| `ω` | worktree (dominant) · option/choice | ×36 · 4 files | collision |
+| `μ` | mode (compress) · memory file · micro-task · main branch | ×46 · 10 files | collision |
+| `τ` | tier (dominant) · memory topic files | ×121 · 26 files | collision |
+| `φ` | frame artifact (dominant) · finding · face-reference config | ×79 · 9 files | collision |
+| `Δ` | delta — changed files / Δtokens · changelog entry | ×36 · 7 files | canonical (one concept: difference) |
+| `Σ` | state map/dict (dominant — the base.md + doc-writer legend sense) · severity icon · testing-standards path | ×52 · 12 files | collision |
+| `π` | plan artifact · open PR · test file · proposed config table | ×46 · 7 files | collision (no dominant sense) |
+| `S*` | next-step variable (dev-core base legend) | ×42 · 14 files | canonical |
+
+**`(local)` re-binding rule:** a file may re-bind a registry variable by marking it `(local)` in its `Let:` block — e.g. `π := pattern list (local)`. compress Phase 3 flags any un-marked collision against this table; with the glossary absent (standalone install) only whitelist-glyph collisions are checkable — accepted degradation.
+
+## Register Conventions (aspirational)
+
+Uppercase-Latin for sets/collections and lowercase-Greek for scalars, modes, and artifact handles is a direction, not a rule: this corpus does not follow it consistently (`Σ` binds a state map, `T` binds a file set), and no gate enforces it. Scope is this repo's `plugins/` corpus only — the operator's ssot shards follow their own conventions and are out-of-corpus evidence here. Treat the register rule as aspirational until a measured migration says otherwise.

--- a/tests/test_check_notation_legends.py
+++ b/tests/test_check_notation_legends.py
@@ -1,0 +1,275 @@
+"""Tests for the notation-legends check in tools/validate_plugins.py.
+
+Two gates (issue #310, spec Decision 9):
+- Pointer gate: each gated dev-core legend file carries exactly one line
+  containing `notation.md` (the one-line pointer to the canonical glossary).
+- Set-equality gate: backtick spans of SKILL.md's `Whitelist:` line must be
+  set-equal to the column-1 backtick spans of notation.md's `## Core Table`
+  active rows (separator rows skipped, `\\|` unescaped, both sets non-empty).
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL = REPO_ROOT / 'tools' / 'validate_plugins.py'
+
+
+def run_tool(*extra_args):
+    """Run validate_plugins.py as a subprocess and return (returncode, stdout, stderr)."""
+    result = subprocess.run(
+        [sys.executable, str(TOOL), *extra_args],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def _load_tool():
+    """Import tools/validate_plugins.py as a module."""
+    spec = importlib.util.spec_from_file_location('validate_plugins', TOOL)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_legend(tmp_path: Path, name: str = 'base.md', line: str | None = None) -> Path:
+    """Write a gated legend file; default body carries a compliant one-line pointer."""
+    if line is None:
+        line = (
+            'Notation legend → canonical glossary: '
+            '`${CLAUDE_PLUGIN_ROOT}/../shared/references/notation.md` '
+            '(repo: `plugins/shared/references/notation.md`)'
+        )
+    path = tmp_path / name
+    path.write_text(f'# Stub agent\n\n## Notation\n\n{line}\n', encoding='utf-8')
+    return path
+
+
+def _write_skill(tmp_path: Path, spans: list[str] | None) -> Path:
+    """Write a synthetic SKILL.md; spans=None omits the Whitelist: line entirely."""
+    body = '# Stub skill\n\n## Guardrails\n\n'
+    if spans is not None:
+        body += 'Whitelist: ' + ' '.join(f'`{s}`' for s in spans) + '\n'
+    path = tmp_path / 'SKILL.md'
+    path.write_text(body, encoding='utf-8')
+    return path
+
+
+def _write_glossary(tmp_path: Path, cells: list[str]) -> Path:
+    """Write a synthetic notation.md whose core-table column-1 cells are `cells`.
+
+    Each cell is raw markdown for column 1 (e.g. '`∀`' or '`∃`/`∄`' or '`\\|X\\|`').
+    A trailing section with a stray backtick span guards the next-## boundary.
+    """
+    lines = [
+        '# Notation',
+        '',
+        '## Core Table',
+        '',
+        '| glyph | senses | gloss? | fidelity ⚠ | notes/adjudication |',
+        '|-------|--------|--------|------------|---------------------|',
+    ]
+    for cell in cells:
+        lines.append(f'| {cell} | sense | — | — | prefer `∀` over `⇔` |')
+    lines += ['', '## Maintenance Policy', '', 'deprecated: `zzz` — must not leak into the set', '']
+    path = tmp_path / 'notation.md'
+    path.write_text('\n'.join(lines), encoding='utf-8')
+    return path
+
+
+def _run_check(mod, tmp_path: Path, *, legend=None, skill=None, glossary=None):
+    """Invoke check_notation_legends with defaults valid so one gate is under test."""
+    if legend is None:
+        legend = _write_legend(tmp_path)
+    if skill is None:
+        skill = _write_skill(tmp_path, ['∀', '¬'])
+    if glossary is None:
+        glossary = _write_glossary(tmp_path, ['`∀`', '`¬`'])
+    return mod.check_notation_legends(
+        legend_files=[legend], skill_path=skill, glossary_path=glossary
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pointer gate — compliant pointer passes
+# ---------------------------------------------------------------------------
+
+def test_pointer_line_passes(tmp_path):
+    """A gated file with exactly one line containing notation.md yields no errors."""
+    mod = _load_tool()
+    assert _run_check(mod, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Pointer gate — full legend (no notation.md) fails
+# ---------------------------------------------------------------------------
+
+def test_full_legend_fails_pointer_gate(tmp_path):
+    """A gated file whose legend is spelled out inline (no pointer) is drift."""
+    mod = _load_tool()
+    legend = _write_legend(
+        tmp_path, line='`¬` not | `→` then | `∀` for all | `Σ` state dict'
+    )
+    errors = _run_check(mod, tmp_path, legend=legend)
+    assert len(errors) == 1
+    assert 'notation.md' in errors[0]
+    assert str(legend) in errors[0] or legend.name in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Pointer gate — missing gated file → IO error tier ('not found at')
+# ---------------------------------------------------------------------------
+
+def test_missing_legend_file(tmp_path):
+    """A missing gated file reports 'not found at' (exit-2 tier via _is_io_error)."""
+    mod = _load_tool()
+    errors = _run_check(mod, tmp_path, legend=tmp_path / 'absent.md')
+    assert errors
+    assert any('not found at' in e for e in errors)
+    assert all(mod._is_io_error(e) for e in errors if 'not found at' in e)
+
+
+def test_missing_glossary_file(tmp_path):
+    """A missing notation.md reports 'not found at' (exit-2 tier)."""
+    mod = _load_tool()
+    errors = _run_check(mod, tmp_path, glossary=tmp_path / 'nowhere' / 'notation.md')
+    assert any('not found at' in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Set equality — whitelist ≡ core table passes (multi-glyph cells, escaped pipes,
+# column-1-only extraction)
+# ---------------------------------------------------------------------------
+
+def test_set_equality_passes(tmp_path):
+    """Whitelist spans ≡ core-table column-1 spans → no errors.
+
+    Locks three parse contracts at once: multi-glyph cells (`∃`/`∄`) contribute
+    each span; `\\|X\\|` in a table cell unescapes to whitelist's `|X|`; backtick
+    spans outside column 1 (the notes cell carries `⇔`) never enter the set.
+    """
+    mod = _load_tool()
+    skill = _write_skill(tmp_path, ['∀', '∃', '∄', '|X|', ':='])
+    glossary = _write_glossary(tmp_path, ['`∀`', '`∃`/`∄`', '`\\|X\\|`', '`:=`'])
+    assert _run_check(mod, tmp_path, skill=skill, glossary=glossary) == []
+
+
+# ---------------------------------------------------------------------------
+# Set equality — whitelist ⊃ core table fails, diff named
+# ---------------------------------------------------------------------------
+
+def test_whitelist_superset_fails(tmp_path):
+    """A whitelist glyph absent from the core table is named in the error."""
+    mod = _load_tool()
+    skill = _write_skill(tmp_path, ['∀', '¬', '⇒'])
+    glossary = _write_glossary(tmp_path, ['`∀`', '`¬`'])
+    errors = _run_check(mod, tmp_path, skill=skill, glossary=glossary)
+    assert errors
+    assert any('⇒' in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Set equality — core table ⊃ whitelist fails, diff named
+# ---------------------------------------------------------------------------
+
+def test_core_table_superset_fails(tmp_path):
+    """A core-table glyph absent from the whitelist is named in the error."""
+    mod = _load_tool()
+    skill = _write_skill(tmp_path, ['∀', '¬'])
+    glossary = _write_glossary(tmp_path, ['`∀`', '`¬`', '`↦`'])
+    errors = _run_check(mod, tmp_path, skill=skill, glossary=glossary)
+    assert errors
+    assert any('↦' in e for e in errors)
+
+
+def test_two_way_drift_names_both_directions(tmp_path):
+    """Drift in both directions reports both the missing and the extra glyph."""
+    mod = _load_tool()
+    skill = _write_skill(tmp_path, ['∀', '⇒'])
+    glossary = _write_glossary(tmp_path, ['`∀`', '`↦`'])
+    errors = _run_check(mod, tmp_path, skill=skill, glossary=glossary)
+    joined = '\n'.join(errors)
+    assert '⇒' in joined
+    assert '↦' in joined
+
+
+# ---------------------------------------------------------------------------
+# Non-empty guard — empty parsed sets fail loudly (never vacuously pass)
+# ---------------------------------------------------------------------------
+
+def test_missing_whitelist_line_fails_loud(tmp_path):
+    """A SKILL.md without a Whitelist: line fails — even against an empty table."""
+    mod = _load_tool()
+    skill = _write_skill(tmp_path, None)
+    glossary = _write_glossary(tmp_path, [])
+    errors = _run_check(mod, tmp_path, skill=skill, glossary=glossary)
+    assert errors
+
+
+def test_empty_core_table_fails_loud(tmp_path):
+    """A core table with no active rows fails, even if the anchor heading exists."""
+    mod = _load_tool()
+    glossary = _write_glossary(tmp_path, [])
+    errors = _run_check(mod, tmp_path, glossary=glossary)
+    assert errors
+
+
+def test_missing_core_table_anchor_is_drift(tmp_path):
+    """notation.md without a '## Core Table' heading fails as drift, not IO error."""
+    mod = _load_tool()
+    glossary = tmp_path / 'notation.md'
+    glossary.write_text('# Notation\n\n## Some Other Section\n', encoding='utf-8')
+    errors = _run_check(mod, tmp_path, glossary=glossary)
+    assert errors
+    assert not any(mod._is_io_error(e) for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Separator rows — never contribute to the parsed set
+# ---------------------------------------------------------------------------
+
+def test_separator_row_skipped(tmp_path):
+    """Separator rows (---, :--- variants) parse clean and add nothing to the set."""
+    mod = _load_tool()
+    glossary = tmp_path / 'notation.md'
+    glossary.write_text(
+        '# Notation\n\n## Core Table\n\n'
+        '| glyph | senses |\n'
+        '|:------|:------:|\n'
+        '| `∀` | sense |\n'
+        '| `¬` | sense |\n\n'
+        '## Next\n',
+        encoding='utf-8',
+    )
+    assert _run_check(mod, tmp_path, glossary=glossary) == []
+
+
+# ---------------------------------------------------------------------------
+# Shipped tree — defaults pass, CLI choice wired, full run reports the check
+# ---------------------------------------------------------------------------
+
+def test_shipped_tree_passes():
+    """Default paths against the real repo tree report no errors."""
+    mod = _load_tool()
+    assert mod.check_notation_legends() == []
+
+
+def test_check_cli_shipped_tree():
+    """--check notation-legends against the shipped tree exits 0."""
+    rc, stdout, stderr = run_tool('--check', 'notation-legends')
+    assert rc == 0, (
+        f'--check notation-legends failed on shipped tree.\n'
+        f'stdout:\n{stdout}\nstderr:\n{stderr}'
+    )
+
+
+def test_full_run_reports_notation_legends():
+    """The default all-checks run includes and passes the notation-legends check."""
+    rc, stdout, stderr = run_tool()
+    assert rc == 0, (
+        f'validate_plugins.py failed on shipped tree.\nstdout:\n{stdout}\nstderr:\n{stderr}'
+    )
+    assert 'PASS: Notation legends' in stdout

--- a/tests/test_check_notation_legends.py
+++ b/tests/test_check_notation_legends.py
@@ -5,7 +5,8 @@ Two gates (issue #310, spec Decision 9):
   containing `notation.md` (the one-line pointer to the canonical glossary).
 - Set-equality gate: backtick spans of SKILL.md's `Whitelist:` line must be
   set-equal to the column-1 backtick spans of notation.md's `## Core Table`
-  active rows (separator rows skipped, `\\|` unescaped, both sets non-empty).
+  active rows (separator rows are inert by construction, `\\|` unescaped,
+  both sets non-empty).
 """
 
 import importlib.util
@@ -120,6 +121,25 @@ def test_full_legend_fails_pointer_gate(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Pointer gate — two pointer lines trip the multi-pointer gate
+# ---------------------------------------------------------------------------
+
+def test_multiple_pointer_lines_fails(tmp_path):
+    """Two lines that each reference notation.md trip the multi-pointer gate."""
+    mod = _load_tool()
+    legend = _write_legend(
+        tmp_path,
+        line=(
+            'Notation legend → canonical glossary: `notation.md`\n'
+            'See also `plugins/shared/references/notation.md` for details.'
+        ),
+    )
+    errors = _run_check(mod, tmp_path, legend=legend)
+    assert errors
+    assert any('found 2' in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
 # Pointer gate — missing gated file → IO error tier ('not found at')
 # ---------------------------------------------------------------------------
 
@@ -201,12 +221,13 @@ def test_two_way_drift_names_both_directions(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_missing_whitelist_line_fails_loud(tmp_path):
-    """A SKILL.md without a Whitelist: line fails — even against an empty table."""
+    """A SKILL.md without a Whitelist: line fails against a non-empty valid table."""
     mod = _load_tool()
     skill = _write_skill(tmp_path, None)
-    glossary = _write_glossary(tmp_path, [])
+    glossary = _write_glossary(tmp_path, ['`∀`', '`¬`'])
     errors = _run_check(mod, tmp_path, skill=skill, glossary=glossary)
     assert errors
+    assert any('no line starting "Whitelist:" found' in e for e in errors)
 
 
 def test_empty_core_table_fails_loud(tmp_path):
@@ -228,14 +249,23 @@ def test_missing_core_table_anchor_is_drift(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Separator rows — never contribute to the parsed set
+# Separator rows — inert by construction, never contribute to the parsed set
 # ---------------------------------------------------------------------------
 
-def test_separator_row_skipped(tmp_path):
-    """Separator rows (---, :--- variants) parse clean and add nothing to the set."""
+def test_separator_row_immaterial_to_glyph_set(tmp_path):
+    """A core table with a separator row parses to the same outcome as one without.
+
+    Separator cells (e.g. '---', ':---:') carry no backtick spans, so column-1
+    extraction naturally contributes nothing — no explicit skip is needed. Both
+    fixtures share the same glyph rows and the same whitelist; if the separator
+    row mattered, one of the two checks would report drift while the other did
+    not. Both must report zero errors.
+    """
     mod = _load_tool()
-    glossary = tmp_path / 'notation.md'
-    glossary.write_text(
+    skill = _write_skill(tmp_path, ['∀', '¬'])
+
+    with_sep = tmp_path / 'with_sep.md'
+    with_sep.write_text(
         '# Notation\n\n## Core Table\n\n'
         '| glyph | senses |\n'
         '|:------|:------:|\n'
@@ -244,7 +274,59 @@ def test_separator_row_skipped(tmp_path):
         '## Next\n',
         encoding='utf-8',
     )
-    assert _run_check(mod, tmp_path, glossary=glossary) == []
+    without_sep = tmp_path / 'without_sep.md'
+    without_sep.write_text(
+        '# Notation\n\n## Core Table\n\n'
+        '| glyph | senses |\n'
+        '| `∀` | sense |\n'
+        '| `¬` | sense |\n\n'
+        '## Next\n',
+        encoding='utf-8',
+    )
+
+    errors_with = _run_check(mod, tmp_path, skill=skill, glossary=with_sep)
+    errors_without = _run_check(mod, tmp_path, skill=skill, glossary=without_sep)
+    assert errors_with == [] == errors_without
+
+
+# ---------------------------------------------------------------------------
+# UnicodeDecodeError parity — invalid UTF-8 reports a clean error, no traceback
+# ---------------------------------------------------------------------------
+
+def test_invalid_utf8_legend_reports_clean_error(tmp_path):
+    """A legend file with invalid UTF-8 bytes reports a clean decode error."""
+    mod = _load_tool()
+    legend = tmp_path / 'base.md'
+    legend.write_bytes(b'\xff\xfe not utf-8 at all')
+    errors = _run_check(mod, tmp_path, legend=legend)
+    assert errors
+    assert any('not valid utf-8' in e.lower() for e in errors)
+    assert any(mod._is_io_error(e) for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Exit tiers — in-process main() with monkeypatched module constants
+# ---------------------------------------------------------------------------
+
+def test_exit_tier_missing_legend_file_is_2(tmp_path, monkeypatch):
+    """A missing gated legend file ('not found at') exits 2 via main()."""
+    mod = _load_tool()
+    monkeypatch.setattr(mod, 'NOTATION_LEGEND_FILES', [tmp_path / 'absent.md'])
+    rc = mod.main(['--check', 'notation-legends'])
+    assert rc == 2
+
+
+def test_exit_tier_drift_is_1(tmp_path, monkeypatch):
+    """Whitelist/core-table set drift (no IO error) exits 1 via main()."""
+    mod = _load_tool()
+    legend = _write_legend(tmp_path)
+    skill = _write_skill(tmp_path, ['∀', '⇒'])
+    glossary = _write_glossary(tmp_path, ['`∀`', '`¬`'])
+    monkeypatch.setattr(mod, 'NOTATION_LEGEND_FILES', [legend])
+    monkeypatch.setattr(mod, 'COMPRESS_SKILL', skill)
+    monkeypatch.setattr(mod, 'NOTATION_GLOSSARY', glossary)
+    rc = mod.main(['--check', 'notation-legends'])
+    assert rc == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tools/validate_plugins.py
+++ b/tools/validate_plugins.py
@@ -49,8 +49,6 @@ NOTATION_GLOSSARY = PLUGINS_DIR / 'shared' / 'references' / 'notation.md'
 COMPRESS_SKILL = PLUGINS_DIR / 'compress' / 'skills' / 'compress' / 'SKILL.md'
 
 _BACKTICK_SPAN_RE = re.compile(r'`([^`]+)`')
-# Markdown table separator row, e.g. |---|:---:|
-_TABLE_SEPARATOR_RE = re.compile(r'^\s*\|[\s:-]+\|')
 
 _DEFAULT_YAML_PATH = PLUGINS_DIR / 'dev-core' / 'skills' / 'code-review' / 'review-classes.yml'
 _DEFAULT_SKILL_PATH = PLUGINS_DIR / 'dev-core' / 'skills' / 'code-review' / 'SKILL.md'
@@ -507,12 +505,16 @@ def check_notation_legends(legend_files=None, skill_path=None, glossary_path=Non
       'notation.md' — the one-line pointer replacing its former inline legend.
     - Set-equality gate: backtick spans of compress SKILL.md's 'Whitelist:' line
       must be set-equal to the column-1 backtick spans of notation.md's active
-      core-table rows ('## Core Table' up to the next '##' heading, separator
-      rows skipped, cell-1 '\\|' escapes unescaped). Both sets must be non-empty
-      so an empty ≡ empty comparison never vacuously passes.
+      core-table rows ('## Core Table' up to the next '##' heading, cell-1
+      '\\|' escapes unescaped). Separator rows (e.g. '|---|:---:|') are inert
+      by construction — column 1 of a separator row carries no backtick spans,
+      so the column-1 extraction naturally contributes nothing; no explicit
+      skip is needed. Both sets must be non-empty so an empty ≡ empty
+      comparison never vacuously passes.
 
     Exit semantics when called from main():
       - errors containing 'not found at' (missing file) → caller returns 2
+      - errors containing 'not valid utf-8' (decode failure) → caller returns 2
       - pointer/set drift (incl. missing anchors) → caller returns 1
     """
     errors = []
@@ -531,8 +533,13 @@ def check_notation_legends(legend_files=None, skill_path=None, glossary_path=Non
         if not legend.exists():
             errors.append(f'gated legend file not found at {legend}')
             continue
+        try:
+            legend_text = legend.read_text(encoding='utf-8')
+        except UnicodeDecodeError as e:
+            errors.append(f'{legend} is not valid UTF-8: {e}')
+            continue
         pointer_lines = [
-            line for line in legend.read_text(encoding='utf-8').splitlines()
+            line for line in legend_text.splitlines()
             if 'notation.md' in line
         ]
         if not pointer_lines:
@@ -551,49 +558,57 @@ def check_notation_legends(legend_files=None, skill_path=None, glossary_path=Non
     if not skill_path.exists():
         errors.append(f'compress SKILL.md not found at {skill_path}')
     else:
-        wl_lines = [
-            line for line in skill_path.read_text(encoding='utf-8').splitlines()
-            if line.startswith('Whitelist:')
-        ]
-        if not wl_lines:
-            errors.append(f'{skill_path}: no line starting "Whitelist:" found')
+        try:
+            skill_text = skill_path.read_text(encoding='utf-8')
+        except UnicodeDecodeError as e:
+            errors.append(f'{skill_path} is not valid UTF-8: {e}')
         else:
-            whitelist = set(_BACKTICK_SPAN_RE.findall(wl_lines[0]))
-            if not whitelist:
-                errors.append(
-                    f'{skill_path}: Whitelist: line carries no backtick spans'
-                )
+            wl_lines = [
+                line for line in skill_text.splitlines()
+                if line.startswith('Whitelist:')
+            ]
+            if not wl_lines:
+                errors.append(f'{skill_path}: no line starting "Whitelist:" found')
+            else:
+                whitelist = set(_BACKTICK_SPAN_RE.findall(wl_lines[0]))
+                if not whitelist:
+                    errors.append(
+                        f'{skill_path}: Whitelist: line carries no backtick spans'
+                    )
 
     core: set[str] = set()
     if not glossary_path.exists():
         errors.append(f'notation glossary not found at {glossary_path}')
     else:
-        lines = glossary_path.read_text(encoding='utf-8').splitlines()
-        in_section = False
-        anchor_seen = False
-        for line in lines:
-            if line.startswith('## '):
-                in_section = line.strip() == '## Core Table'
-                anchor_seen = anchor_seen or in_section
-                continue
-            if not in_section or not line.lstrip().startswith('|'):
-                continue
-            if _TABLE_SEPARATOR_RE.match(line):
-                continue
-            cells = re.split(r'(?<!\\)\|', line)
-            if len(cells) < 2:
-                continue
-            for span in _BACKTICK_SPAN_RE.findall(cells[1]):
-                core.add(span.replace('\\|', '|'))
-        if not anchor_seen:
-            errors.append(
-                f'{glossary_path}: core table anchor "## Core Table" not found in file'
-            )
-        elif not core:
-            errors.append(
-                f'{glossary_path}: core table has no active glyph rows — '
-                f'empty set would vacuously pass'
-            )
+        try:
+            glossary_text = glossary_path.read_text(encoding='utf-8')
+        except UnicodeDecodeError as e:
+            errors.append(f'{glossary_path} is not valid UTF-8: {e}')
+        else:
+            lines = glossary_text.splitlines()
+            in_section = False
+            anchor_seen = False
+            for line in lines:
+                if line.startswith('## '):
+                    in_section = line.strip() == '## Core Table'
+                    anchor_seen = anchor_seen or in_section
+                    continue
+                if not in_section or not line.lstrip().startswith('|'):
+                    continue
+                cells = re.split(r'(?<!\\)\|', line)
+                if len(cells) < 2:
+                    continue
+                for span in _BACKTICK_SPAN_RE.findall(cells[1]):
+                    core.add(span.replace('\\|', '|'))
+            if not anchor_seen:
+                errors.append(
+                    f'{glossary_path}: core table anchor "## Core Table" not found in file'
+                )
+            elif not core:
+                errors.append(
+                    f'{glossary_path}: core table has no active glyph rows — '
+                    f'empty set would vacuously pass'
+                )
     # Header row ('| glyph | ...') carries no backtick spans, so it never
     # contributes; only glyph rows populate the set.
 

--- a/tools/validate_plugins.py
+++ b/tools/validate_plugins.py
@@ -13,6 +13,8 @@ Checks:
 - Subsumption pairs declared in review-classes.yml notes are mentioned together in
   code-review/SKILL.md (prevents drift in pair definitions across files)
 - Budgeted SKILL.md files stay within their physical line budgets
+- Gated dev-core legend lines are one-line pointers to the canonical notation
+  glossary, and compress's inline whitelist stays set-equal to its core table
 
 Usage:
   python3 tools/validate_plugins.py                     # run all checks
@@ -35,6 +37,20 @@ CANONICAL_PATHS = REPO_ROOT / 'roxabi_sdk' / 'paths.py'
 
 # Plugin name → max physical lines of its skills/*/SKILL.md (issue #309 Decision 5)
 SKILL_LINE_BUDGETS = {'compress': 110}
+
+# Notation-legends check (issue #310 Decision 9): gated legend files must carry a
+# one-line pointer to the canonical glossary, whose core table must stay set-equal
+# to the compress whitelist.
+NOTATION_LEGEND_FILES = [
+    PLUGINS_DIR / 'dev-core' / 'skills' / 'shared' / 'references' / 'base.md',
+    PLUGINS_DIR / 'dev-core' / 'agents' / 'doc-writer.md',
+]
+NOTATION_GLOSSARY = PLUGINS_DIR / 'shared' / 'references' / 'notation.md'
+COMPRESS_SKILL = PLUGINS_DIR / 'compress' / 'skills' / 'compress' / 'SKILL.md'
+
+_BACKTICK_SPAN_RE = re.compile(r'`([^`]+)`')
+# Markdown table separator row, e.g. |---|:---:|
+_TABLE_SEPARATOR_RE = re.compile(r'^\s*\|[\s:-]+\|')
 
 _DEFAULT_YAML_PATH = PLUGINS_DIR / 'dev-core' / 'skills' / 'code-review' / 'review-classes.yml'
 _DEFAULT_SKILL_PATH = PLUGINS_DIR / 'dev-core' / 'skills' / 'code-review' / 'SKILL.md'
@@ -483,6 +499,118 @@ def check_skill_line_budget(budgets=None, plugins_dir=None) -> list[str]:
     return errors
 
 
+def check_notation_legends(legend_files=None, skill_path=None, glossary_path=None) -> list[str]:
+    """Gated legend lines must point at notation.md; whitelist ≡ core table.
+
+    Two gates (issue #310 Decision 9):
+    - Pointer gate: each gated dev-core file carries exactly one line containing
+      'notation.md' — the one-line pointer replacing its former inline legend.
+    - Set-equality gate: backtick spans of compress SKILL.md's 'Whitelist:' line
+      must be set-equal to the column-1 backtick spans of notation.md's active
+      core-table rows ('## Core Table' up to the next '##' heading, separator
+      rows skipped, cell-1 '\\|' escapes unescaped). Both sets must be non-empty
+      so an empty ≡ empty comparison never vacuously passes.
+
+    Exit semantics when called from main():
+      - errors containing 'not found at' (missing file) → caller returns 2
+      - pointer/set drift (incl. missing anchors) → caller returns 1
+    """
+    errors = []
+    if legend_files is None:
+        legend_files = NOTATION_LEGEND_FILES
+    if skill_path is None:
+        skill_path = COMPRESS_SKILL
+    if glossary_path is None:
+        glossary_path = NOTATION_GLOSSARY
+    skill_path = Path(skill_path)
+    glossary_path = Path(glossary_path)
+
+    # Gate (a): one-line pointers in the gated legend files
+    for legend in legend_files:
+        legend = Path(legend)
+        if not legend.exists():
+            errors.append(f'gated legend file not found at {legend}')
+            continue
+        pointer_lines = [
+            line for line in legend.read_text(encoding='utf-8').splitlines()
+            if 'notation.md' in line
+        ]
+        if not pointer_lines:
+            errors.append(
+                f'{legend}: legend is not a one-line pointer — '
+                f'no line references notation.md'
+            )
+        elif len(pointer_lines) > 1:
+            errors.append(
+                f'{legend}: expected exactly one pointer line referencing '
+                f'notation.md, found {len(pointer_lines)}'
+            )
+
+    # Gate (b): whitelist ≡ core-table active rows
+    whitelist: set[str] = set()
+    if not skill_path.exists():
+        errors.append(f'compress SKILL.md not found at {skill_path}')
+    else:
+        wl_lines = [
+            line for line in skill_path.read_text(encoding='utf-8').splitlines()
+            if line.startswith('Whitelist:')
+        ]
+        if not wl_lines:
+            errors.append(f'{skill_path}: no line starting "Whitelist:" found')
+        else:
+            whitelist = set(_BACKTICK_SPAN_RE.findall(wl_lines[0]))
+            if not whitelist:
+                errors.append(
+                    f'{skill_path}: Whitelist: line carries no backtick spans'
+                )
+
+    core: set[str] = set()
+    if not glossary_path.exists():
+        errors.append(f'notation glossary not found at {glossary_path}')
+    else:
+        lines = glossary_path.read_text(encoding='utf-8').splitlines()
+        in_section = False
+        anchor_seen = False
+        for line in lines:
+            if line.startswith('## '):
+                in_section = line.strip() == '## Core Table'
+                anchor_seen = anchor_seen or in_section
+                continue
+            if not in_section or not line.lstrip().startswith('|'):
+                continue
+            if _TABLE_SEPARATOR_RE.match(line):
+                continue
+            cells = re.split(r'(?<!\\)\|', line)
+            if len(cells) < 2:
+                continue
+            for span in _BACKTICK_SPAN_RE.findall(cells[1]):
+                core.add(span.replace('\\|', '|'))
+        if not anchor_seen:
+            errors.append(
+                f'{glossary_path}: core table anchor "## Core Table" not found in file'
+            )
+        elif not core:
+            errors.append(
+                f'{glossary_path}: core table has no active glyph rows — '
+                f'empty set would vacuously pass'
+            )
+    # Header row ('| glyph | ...') carries no backtick spans, so it never
+    # contributes; only glyph rows populate the set.
+
+    if whitelist and core:
+        missing = whitelist - core
+        extra = core - whitelist
+        if missing:
+            errors.append(
+                f'whitelist glyphs missing from the notation.md core table: {sorted(missing)}'
+            )
+        if extra:
+            errors.append(
+                f'core-table glyphs missing from the SKILL.md whitelist: {sorted(extra)}'
+            )
+    return errors
+
+
 def _is_io_error(msg: str) -> bool:
     """Return True when the error message signals an IO/parse failure (exit 2).
 
@@ -500,7 +628,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description='Validate plugin structure and data conventions.')
     parser.add_argument(
         '--check',
-        choices=['class-list-sync', 'subsumption-pairs', 'shared-sources-sync'],
+        choices=['class-list-sync', 'subsumption-pairs', 'shared-sources-sync', 'notation-legends'],
         help='Run only the named check (default: run all checks)',
     )
     args = parser.parse_args(argv)
@@ -533,6 +661,15 @@ def main(argv: list[str] | None = None) -> int:
             return 2 if any(_is_io_error(e) for e in errors) else 1
         return 0
 
+    if args.check == 'notation-legends':
+        errors = check_notation_legends()
+        if errors:
+            print('FAIL: Notation legends', file=sys.stderr)
+            for e in errors:
+                print(f'  {e}', file=sys.stderr)
+            return 2 if any(_is_io_error(e) for e in errors) else 1
+        return 0
+
     # Default: run all checks
     all_errors = []
     checks = [
@@ -546,6 +683,7 @@ def main(argv: list[str] | None = None) -> int:
         ('Subsumption pairs', check_subsumption_pairs),
         ('Shared sources sync', check_shared_sources_sync),
         ('SKILL.md line budget', check_skill_line_budget),
+        ('Notation legends', check_notation_legends),
     ]
 
     for name, check_fn in checks:


### PR DESCRIPTION
## Summary
- Creates the repo's canonical notation SSoT `plugins/shared/references/notation.md`: a 27-glyph `## Core Table` (5-col schema, fidelity-warned glyphs flagged mandatory-gloss with MetaGlyph citations), lazy Disambiguation Grammar (4 measured `→` senses, `¬` modal registers, separator hierarchy) + Maintenance Policy sections, a grep-seeded Reserved-Variable Registry (σ ×162/27 files 4-way collision, Ω override-dominant, α/β/ω/μ, τ/φ/Δ/Σ/π with collisions recorded), and a Source-Legend Merge Audit giving every entry of the 3 legacy legends a recorded disposition. Glyph adjudications by measured counts: `⟺` retained (×12/8 files vs `⇔` ×0), `⇒` retained core-active (×40/8 files — never classified as drift).
- Replaces compress's flat `¬compress` list with evidence-based guardrails **G1–G4** (polarity transform with `needs external verification` 4-field flag schema; no-free-coinage + verbatim token-neutrality principle; decidable gloss trigger; verbatim floor citing the new `references/evidence.md` arXiv pins), a canonical inline `Whitelist:` (27 glyphs, set-equal to the core table), R1 demoted with its break-even inequality, R5/R6/R7 promoted to primary economic transform — all within the 110-line budget (109) and fully functional standalone (glossary pointer existence-gated).
- Repoints the two dev-core legends (`base.md:16`, `doc-writer.md:51`) to one-line pointers with the **dev-core semver bump 0.8.13 → 0.8.14**, and self-protects in the same PR: new `--check notation-legends` in `tools/validate_plugins.py` (pointer gate + whitelist↔core-table set-equality with both-direction diffs; 15 RED-first pytest cases; live seeded-violation falsification).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #310: canonical notation glossary + reserved-var registry + fidelity guardrails | Open |
| Analysis | [compress-skill-v2-ecriture-symbolique-analysis.md](../blob/feat/310-notation-glossary-guardrails/artifacts/analyses/compress-skill-v2-ecriture-symbolique-analysis.md) (epic-level, §3-P1+P6) | Present |
| Spec | [310-notation-glossary-guardrails-spec.mdx](../blob/feat/310-notation-glossary-guardrails/artifacts/specs/310-notation-glossary-guardrails-spec.mdx) | Present (approved) |
| Implementation | 7 commits on `feat/310-notation-glossary-guardrails` (2 slices: P6 standalone → P1 SSoT) | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (15 new pytest, validator 11/11) | Passed |

## Test Plan
- [ ] `python3 tools/validate_plugins.py` → 11/11 PASS incl. `Notation legends`
- [ ] `python3 tools/validate_plugins.py --check notation-legends` → exit 0
- [ ] `python3 -m pytest tests/test_check_notation_legends.py -q` → 15 passed
- [ ] `bash scripts/check-skill-version.sh` → green (dev-core 0.8.14 bump present)
- [ ] Seed test: replace base.md's pointer line with a legend → check FAILS naming the file; drop `⇒` from the whitelist → FAILS naming `⇒`; restore → PASSES (proven in-run)
- [ ] Standalone path: at slice V1 (notation.md absent) compress remained fully functional via the inline whitelist — the existence-gate demo

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| SC1 3-legend merge + grammar | — | ⚠ NO TEST — prompt-logic-only (Source-Legend Merge Audit: 9 rows, every entry dispositioned; S*/✓✗/≥≤/¬do-x/∅/⇒ all accounted) |
| SC2 registry grep counts + (local) rule | — | ⚠ NO TEST — prompt-logic-only (fresh counts 2026-07-04 recorded in-file: σ ×162/27f, Ω ×14/3, α ×153/20, τ ×121/26, Σ/π collisions) |
| SC3 aspirational register note | — | ⚠ NO TEST — prompt-logic-only (heading "Register Conventions (aspirational)", ssot out-of-corpus, no path) |
| SC4 glyph adjudications measured | — | ⚠ NO TEST — prompt-logic-only (⟺ ×12/8 vs ⇔ ×0; ⇒ ×40/8 retained, "never classified as drift" in-cell) |
| SC5 mandatory-gloss flags + writer-side disclaimer | — | ⚠ NO TEST — prompt-logic-only (→/∈/∩ rows flagged w/ MetaGlyph cites; disclaimer verbatim) |
| SC6 notation-legends check both gates | `tests/test_check_notation_legends.py` (15 cases: pointer/missing/equality both directions/empty/separator/CLI/full-run) | ✓ proven + live seeded falsification |
| SC7 no token-cost column | — | ⚠ NO TEST — prompt-logic-only (grep clean) |
| SC8 core-only Phase 0 load; lazy grammar/maintenance | — | ⚠ NO TEST — prompt-logic-only (SKILL.md loads `## Core Table` only; lazy halves referenced only from glossary.md) |
| SC9 dev-core 0.8.14 + check-skill-version | — | ⚠ NO TEST — infra-not-wired (pre-push shell gate; run twice green in-branch) |
| SC10 R1 example collision-free | — | ⚠ NO TEST — prompt-logic-only (η/κ(f)/θ; none ∈ registry) |
| SC11 G1 complete (never-invent-Z, 4-field schema, vault-optional) | — | ⚠ NO TEST — prompt-logic-only (grep: literal flag + schema + "completes with no vault") |
| SC12 G2 no tiers, token-neutrality verbatim | — | ⚠ NO TEST — prompt-logic-only (negative grep `= N tokens` clean; sentence verbatim) |
| SC13 G3 predicate verbatim; no bare symbols | — | ⚠ NO TEST — prompt-logic-only (fixed-string grep hit; scripted sample check: none) |
| SC14 G4 floor + evidence cites | — | ⚠ NO TEST — prompt-logic-only |
| SC15 break-even inequality; R5/6/7 primary | — | ⚠ NO TEST — prompt-logic-only (`T_letline` present) |
| SC16 evidence.md 4 pins | — | ⚠ NO TEST — prompt-logic-only (2604.07192, 2601.07354, LILO, GEPA) |
| SC17 whitelist canonical, existence-gated, standalone | — | ⚠ NO TEST — prompt-logic-only (V1 tree = the standalone demo) |
| SC18 no dangling lint refs | — | ⚠ NO TEST — prompt-logic-only (5 hits, all mode-exists-gated) |
| SC19 G1/G3 spend tokens | — | ⚠ NO TEST — prompt-logic-only |
| SC20 cortex_link mechanics-only | — | ⚠ NO TEST — prompt-logic-only (`ADR-009` grep: 0) |
| SC21 ≤110 + train-A checks + self-containment | `test_check_skill_line_budget.py` + budget sentinel | ✓ proven (109/110; FAIL@114 → PASS@109) |
| SC22 process hygiene | — | ⚠ NO TEST — prompt-logic-only (linear history; no cache edits; greps clean) |

## Drift adaptations (epic #308 log)
- **DP protocol removal** (`1dd4ae8`): glyph adjudications executed as measured-count decisions with counts + outcome + rationale recorded in notation.md; in-flow decisions use the inline present-choice idiom.
- **doc-writer legend line drift** :54 → :51 (agent-frontmatter commits) — pointer gate greps a pattern, not a line number.
- **dev-init base.md fork** (4th identical legend, not named by #310): kept out of scope per descope-under-churn; follow-up filed as **#330** (blocked by this PR's merge).
- **Whitelist 22 → 27**: `⇒ ≥ ≤ ✓ ✗` promoted core-active by measurement (×40/8, ×107/47, ×47/31, ×110/22, ×33/16); `S*`/`Σ` deliberately registry-side (variables, outside the D9 operator equality domain).
- Self-containment guard scope: shipped surface CLEAN; artifacts/*.mdx hits are self-referential rule text.

Fixes #310

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`

### Post-review amendment (iteration 2)
- D9 separator-row clause: implemented via structural inertness (column-1 backtick extraction), not an explicit regex skip — equivalence proven by test; see review iteration-2 comment.
