### PR TITLE
fix(dev-core): robust origin/staging base detection

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/cleanup/SKILL.md
+++ b/plugins/dev-core/skills/cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: cleanup
 argument-hint: [--all | --report-only | --yes | --scope <#N>]
 description: Clean git branches/worktrees/remotes after merge-status verification; sweep stuck pipeline labels and orphan CI runs. Triggers: "cleanup" | "clean branches" | "cleanup worktrees" | "remove stale branches".
-version: 0.6.0
+version: 0.6.1
 allowed-tools: Bash, Read, EnterWorktree, ExitWorktree, ToolSearch
 ---
 

--- a/plugins/dev-core/skills/cleanup/__tests__/analyze-branches.test.sh
+++ b/plugins/dev-core/skills/cleanup/__tests__/analyze-branches.test.sh
@@ -15,7 +15,7 @@ ANALYZE="${SCRIPT_DIR}/../analyze-branches.sh"
 
 TMPDIR_FIXTURE="$(mktemp -d)"
 WT_DIR="${TMPDIR_FIXTURE}/wt-i18n"
-trap 'rm -rf "$TMPDIR_FIXTURE"' EXIT
+trap 'rm -rf "$TMPDIR_FIXTURE" "${ORIGIN_ROOT:-}"' EXIT
 
 cd "$TMPDIR_FIXTURE"
 git init -q
@@ -96,5 +96,40 @@ assert_eq "--scope 19 includes only feat/19-auth (excludes #33, #319)" "feat/19-
 result_hash_scoped="$("$ANALYZE" --json --no-fetch --scope "#19")"
 DEBUG_JSON="$result_hash_scoped"
 assert_eq "--scope #19 strips the leading #" "19" "$(echo "$result_hash_scoped" | jq -r '.scope')"
+
+# Regression: base present only as origin/<base>, not checked out locally (the
+# worktree-per-issue norm). branch_merged must resolve origin/<base> and must NOT
+# mis-classify an unmerged branch as safe_delete just because no LOCAL base branch
+# exists. Before the BASE_REF fix, `git log staging..feat/50-thing` errored (no
+# local staging) -> empty stdout -> merged=true -> safe_delete.
+ORIGIN_ROOT="$(mktemp -d)"
+git init -q --bare "${ORIGIN_ROOT}/origin.git"
+git init -q "${ORIGIN_ROOT}/work"
+cd "${ORIGIN_ROOT}/work"
+git config user.email "test@example.com"
+git config user.name "Test User"
+git remote add origin "${ORIGIN_ROOT}/origin.git"
+echo base > f.txt
+git add f.txt
+git commit -q -m "chore: base"
+git branch -M staging
+git push -q -u origin staging
+echo wip > wip.txt
+git checkout -q -b feat/50-thing
+git add wip.txt
+git commit -q -m "feat: wip (#50)"
+git checkout -q -b scratch        # sit off the feature so it is not the current branch
+git branch -q -D staging          # only origin/staging remains as the base ref
+git fetch -q origin               # ensure the origin/staging tracking ref exists
+
+result_origin="$("$ANALYZE" --json --no-fetch)"
+DEBUG_JSON="$result_origin"
+origin_base="$(echo "$result_origin" | jq -r '.base_branch')"
+feat50_action="$(echo "$result_origin" | jq -r '.local_branches[] | select(.name == "feat/50-thing") | .action')"
+feat50_merged="$(echo "$result_origin" | jq -r '.local_branches[] | select(.name == "feat/50-thing") | .merged')"
+
+assert_eq "origin-only base resolves to staging" "staging" "$origin_base"
+assert_eq "unmerged branch NOT safe_delete when base only on origin/*" "unmerged" "$feat50_action"
+assert_eq "unmerged branch merged=false when base only on origin/*" "false" "$feat50_merged"
 
 echo "PASS: analyze-branches.test.sh"

--- a/plugins/dev-core/skills/cleanup/analyze-branches.sh
+++ b/plugins/dev-core/skills/cleanup/analyze-branches.sh
@@ -59,6 +59,18 @@ fi
 # Detect base AFTER fetch --prune so a freshly-created (or remotely-deleted)
 # origin/staging is reflected in the local remote-tracking refs before detection.
 BASE_BRANCH="$(detect_base_branch)"
+# Ref to compare branches against for merge detection: prefer the remote-tracking
+# base (fresh after fetch --prune, and present even when the base branch is not
+# checked out locally — the norm in the worktree-per-issue flow), else a local
+# branch of that name. Empty when neither resolves, so the merge checks below skip
+# rather than treat an unresolvable base as "0 commits ahead" (= false "merged").
+if git rev-parse --verify --quiet "refs/remotes/origin/${BASE_BRANCH}" >/dev/null 2>&1; then
+  BASE_REF="origin/${BASE_BRANCH}"
+elif git rev-parse --verify --quiet "refs/heads/${BASE_BRANCH}" >/dev/null 2>&1; then
+  BASE_REF="${BASE_BRANCH}"
+else
+  BASE_REF=""
+fi
 
 PROTECTED_JSON='["main","master","staging"]'
 
@@ -146,8 +158,8 @@ branch_merged() {
   local merge_reason="none"
   local merged=false
 
-  if git rev-parse --verify "$ref" >/dev/null 2>&1; then
-    if [ -z "$(git log --oneline "${BASE_BRANCH}..${ref}" 2>/dev/null | head -1)" ]; then
+  if [ -n "$BASE_REF" ] && git rev-parse --verify "$ref" >/dev/null 2>&1; then
+    if [ -z "$(git log --oneline "${BASE_REF}..${ref}" 2>/dev/null | head -1)" ]; then
       merged=true
       merge_reason="regular"
     fi
@@ -166,7 +178,7 @@ branch_merged() {
     local issue
     issue="$(extract_issue_number "$branch_name")"
     if [ -n "$issue" ]; then
-      if [ -n "$(git log --oneline --grep="#${issue}" "$BASE_BRANCH" 2>/dev/null | head -1)" ]; then
+      if [ -n "$BASE_REF" ] && [ -n "$(git log --oneline --grep="#${issue}" "$BASE_REF" 2>/dev/null | head -1)" ]; then
         merged=true
         merge_reason="squash_grep"
       fi
@@ -174,7 +186,7 @@ branch_merged() {
   fi
 
   if [ "$merged" = false ]; then
-    if [ -n "$(git log --oneline --grep="${branch_name}" "$BASE_BRANCH" 2>/dev/null | head -1)" ]; then
+    if [ -n "$BASE_REF" ] && [ -n "$(git log --oneline --grep="${branch_name}" "$BASE_REF" 2>/dev/null | head -1)" ]; then
       merged=true
       merge_reason="squash_grep"
     fi

--- a/plugins/dev-core/skills/cleanup/analyze-branches.sh
+++ b/plugins/dev-core/skills/cleanup/analyze-branches.sh
@@ -60,9 +60,7 @@ fi
 # origin/staging is reflected in the local remote-tracking refs before detection.
 BASE_BRANCH="$(detect_base_branch)"
 
-# Always protect the triad + whatever detect_base_branch resolved (may be a repo's
-# own default, e.g. `develop`), so a generalized base is never offered for deletion.
-PROTECTED_JSON="$(jq -cn --arg b "$BASE_BRANCH" '["main","master","staging",$b]|unique')"
+PROTECTED_JSON='["main","master","staging"]'
 
 PR_LIMIT=1000
 PR_JSON='[]'
@@ -301,7 +299,7 @@ while IFS= read -r remote_ref; do
   fi
   entry="$(classify_branch "remote" "$branch_name" "$remote_ref")"
   remote_branches_json="$(echo "$remote_branches_json" | jq --argjson entry "$entry" '. + [$entry]')"
-done < <(git branch -r 2>/dev/null | sed 's/^[[:space:]]*//' | grep -vE "origin/HEAD|origin/main\$|origin/master\$|origin/staging\$|origin/${BASE_BRANCH}\$" || true)
+done < <(git branch -r 2>/dev/null | sed 's/^[[:space:]]*//' | grep -vE 'origin/HEAD|origin/main$|origin/master$|origin/staging$' || true)
 
 safe_local_json="$(echo "$local_branches_json" | jq '[.[] | select(.action == "safe_delete") | .name]')"
 safe_remote_json="$(echo "$remote_branches_json" | jq '[.[] | select(.action == "safe_delete") | .name]')"

--- a/plugins/dev-core/skills/cleanup/analyze-branches.sh
+++ b/plugins/dev-core/skills/cleanup/analyze-branches.sh
@@ -46,7 +46,6 @@ require_cmd() {
 require_cmd git
 require_cmd jq
 
-BASE_BRANCH="$(detect_base_branch)"
 CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || echo "")"
 GH_AVAILABLE=true
 if ! command -v gh >/dev/null 2>&1; then
@@ -56,6 +55,10 @@ fi
 if [ "$NO_FETCH" = false ]; then
   git fetch --prune origin 2>/dev/null || true
 fi
+
+# Detect base AFTER fetch --prune so a freshly-created (or remotely-deleted)
+# origin/staging is reflected in the local remote-tracking refs before detection.
+BASE_BRANCH="$(detect_base_branch)"
 
 PROTECTED_JSON='["main","master","staging"]'
 

--- a/plugins/dev-core/skills/cleanup/analyze-branches.sh
+++ b/plugins/dev-core/skills/cleanup/analyze-branches.sh
@@ -60,7 +60,9 @@ fi
 # origin/staging is reflected in the local remote-tracking refs before detection.
 BASE_BRANCH="$(detect_base_branch)"
 
-PROTECTED_JSON='["main","master","staging"]'
+# Always protect the triad + whatever detect_base_branch resolved (may be a repo's
+# own default, e.g. `develop`), so a generalized base is never offered for deletion.
+PROTECTED_JSON="$(jq -cn --arg b "$BASE_BRANCH" '["main","master","staging",$b]|unique')"
 
 PR_LIMIT=1000
 PR_JSON='[]'
@@ -299,7 +301,7 @@ while IFS= read -r remote_ref; do
   fi
   entry="$(classify_branch "remote" "$branch_name" "$remote_ref")"
   remote_branches_json="$(echo "$remote_branches_json" | jq --argjson entry "$entry" '. + [$entry]')"
-done < <(git branch -r 2>/dev/null | sed 's/^[[:space:]]*//' | grep -vE 'origin/HEAD|origin/main$|origin/master$|origin/staging$' || true)
+done < <(git branch -r 2>/dev/null | sed 's/^[[:space:]]*//' | grep -vE "origin/HEAD|origin/main\$|origin/master\$|origin/staging\$|origin/${BASE_BRANCH}\$" || true)
 
 safe_local_json="$(echo "$local_branches_json" | jq '[.[] | select(.action == "safe_delete") | .name]')"
 safe_remote_json="$(echo "$remote_branches_json" | jq '[.[] | select(.action == "safe_delete") | .name]')"

--- a/plugins/dev-core/skills/code-review/SKILL.md
+++ b/plugins/dev-core/skills/code-review/SKILL.md
@@ -2,7 +2,7 @@
 name: code-review
 argument-hint: [#PR]
 description: Multi-domain code review (agents + Conventional Comments → findings + verdict). Triggers: "code review" | "review changes" | "review PR #42" | "check my code" | "review my changes" | "review this PR" | "do a code review" | "review the diff" | "look at my code".
-version: 0.2.1
+version: 0.2.2
 allowed-tools: Bash, Read, Write, Glob, Grep, Task, Skill, ToolSearch
 ---
 
@@ -50,7 +50,7 @@ Steps: gather-changes → secret-scan → multi-domain-review → merge-and-pres
 
 ## Phase 1 — Gather Changes
 
-0. `BASE=$(git branch -r | grep -q 'origin/staging' && echo staging || echo main)`
+0. `BASE=$(. "${CLAUDE_SKILL_DIR}/../shared/lib.sh" && detect_base_branch)`
 1. PR# → `gh pr diff <#>` | else → `git diff ${BASE}...HEAD`
 2. Δ = `git diff --name-only ${BASE}...HEAD` (or `gh pr diff <#> --name-only`)
 3. ∀ f ∈ Δ: read full (skip binaries, note)

--- a/plugins/dev-core/skills/code-review/SKILL.md
+++ b/plugins/dev-core/skills/code-review/SKILL.md
@@ -51,8 +51,8 @@ Steps: gather-changes → secret-scan → multi-domain-review → merge-and-pres
 ## Phase 1 — Gather Changes
 
 0. `BASE=$(. "${CLAUDE_SKILL_DIR}/../shared/lib.sh" && detect_base_branch)`
-1. PR# → `gh pr diff <#>` | else → `git diff ${BASE}...HEAD`
-2. Δ = `git diff --name-only ${BASE}...HEAD` (or `gh pr diff <#> --name-only`)
+1. PR# → `gh pr diff <#>` | else → `git diff origin/${BASE}...HEAD`
+2. Δ = `git diff --name-only origin/${BASE}...HEAD` (or `gh pr diff <#> --name-only`)
 3. ∀ f ∈ Δ: read full (skip binaries, note)
 4. |Δ| = 0 → halt
 5. |Δ| > 50 → warn, suggest split
@@ -60,7 +60,7 @@ Steps: gather-changes → secret-scan → multi-domain-review → merge-and-pres
 ## Phase 1.5 — Secret Scan
 
 ```bash
-git diff ${BASE}...HEAD | grep -iE '(password|passwd|secret|api[_-]?key|auth[_-]?token|access[_-]?token|private[_-]?key)\s*[:=]\s*["\x27`][^"\x27`]{8,}' | head -20
+git diff origin/${BASE}...HEAD | grep -iE '(password|passwd|secret|api[_-]?key|auth[_-]?token|access[_-]?token|private[_-]?key)\s*[:=]\s*["\x27`][^"\x27`]{8,}' | head -20
 ```
 
 ∃ matches → WARN (redact to first 2 + last 2 chars):

--- a/plugins/dev-core/skills/code-review/SKILL.md
+++ b/plugins/dev-core/skills/code-review/SKILL.md
@@ -18,7 +18,7 @@ Review branch/PR via fresh domain-specific agents → Conventional Comments → 
 **⚠ Flow: single continuous pipeline (Phases 1→4 + 6 + 8). ¬stop between phases. Decision response → immediately execute next phase. Stop only on: |Δ|=0, explicit Cancel, or Phase 8 completion.**
 
 ```
-/code-review          → diff ${BASE}...HEAD  (BASE = staging if exists, else main)
+/code-review          → diff origin/${BASE}...HEAD  (BASE = staging|main|master, first that exists)
 /code-review #42      → gh pr diff 42
 ```
 

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -2,7 +2,7 @@
 name: dev
 argument-hint: '[#N | "idea" | --from <step> | --audit]'
 description: Workflow orchestrator — single entry point for the full dev lifecycle. Triggers: "dev" | "start working on" | "work on issue" | "work on #" | "develop" | "pick up issue" | "tackle issue" | "let's work on".
-version: 0.3.0
+version: 0.3.1
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---
 
@@ -86,7 +86,7 @@ bash ${CLAUDE_SKILL_DIR}/scan-state.sh {N} {slug}
   analyze:   analysis artifact ∃,
   spec:      spec artifact ∃,
   plan:      plan artifact ∃,
-  implement: worktree ∃ (path: `.claude/worktrees/{N}-*` ∨ legacy `../${REPO}-{N}`) ∧ git diff --name-only origin/staging..HEAD | grep -v '^artifacts/' is non-empty,
+  implement: worktree ∃ (path: `.claude/worktrees/{N}-*` ∨ legacy `../${REPO}-{N}`) ∧ git diff --name-only origin/${BASE}..HEAD | grep -v '^artifacts/' is non-empty,
   pr:        PR ∃,
   ci-watch:  null,       # Σ_s only
   validate:  null,       # Σ_s only

--- a/plugins/dev-core/skills/pr/SKILL.md
+++ b/plugins/dev-core/skills/pr/SKILL.md
@@ -2,7 +2,7 @@
 name: pr
 argument-hint: [--draft | --base <branch>]
 description: Create/update PRs with Conventional Commits title, issue linking & guard rails. Triggers: "create PR" | "open PR" | "submit PR" | "update PR" | "/pr --draft" | "open a pull request" | "make a PR" | "open pull request" | "submit a pull request" | "create a draft PR" | "raise a PR".
-version: 0.4.2
+version: 0.4.3
 allowed-tools: Bash, Read, Grep, ToolSearch
 ---
 
@@ -64,8 +64,8 @@ Emits: `branch`, `base`, commit log, diff stat, existing PR, issue number, lifec
 
 **3a. Commits + diff:**
 ```bash
-git log ${BASE}..HEAD --format="%h %s%n%b"
-git diff ${BASE}...HEAD --stat
+git log origin/${BASE}..HEAD --format="%h %s%n%b"
+git diff origin/${BASE}...HEAD --stat
 ```
 
 **3b. Lifecycle artifacts:** already emitted by Step 1 (`issue`, `analysis`, `spec`, `issue_data`, `test_files`).

--- a/plugins/dev-core/skills/pr/SKILL.md
+++ b/plugins/dev-core/skills/pr/SKILL.md
@@ -53,7 +53,7 @@ Emits: `branch`, `base`, commit log, diff stat, existing PR, issue number, lifec
 | Check | Condition | Action |
 |-------|-----------|--------|
 | Protected branch | Β ∈ {staging, main, master} | **REFUSE.** Create feature branch first. Stop. |
-| No commits | `git log ${β}..HEAD` empty | **REFUSE.** Nothing to PR. Stop. |
+| No commits | `git log origin/${β}..HEAD` empty | **REFUSE.** Nothing to PR. Stop. |
 | PR exists | gh pr list → result | → present choice **Update** (`gh pr edit`) \| **Cancel** |
 | Branch not pushed | `git ls-remote --heads origin $BRANCH` empty | `git push -u origin $BRANCH` |
 | Quality gates | `{commands.lint} && {commands.typecheck}` | Warn on failure, ¬block. Note in PR body if proceeding. |

--- a/plugins/dev-core/skills/pr/gather-state.sh
+++ b/plugins/dev-core/skills/pr/gather-state.sh
@@ -8,15 +8,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/../shared/lib.sh"
 
 BRANCH=$(git branch --show-current 2>/dev/null || true)
+# Refresh remote-tracking refs so base detection + the diffs below reflect the
+# current remote (e.g. a staging branch created since the last fetch).
+git fetch --prune origin 2>/dev/null || true
 BASE=$(detect_base_branch)
 echo "branch=$BRANCH"
 echo "base=$BASE"
 
 echo "---commits---"
-git log "${BASE}..HEAD" --oneline 2>/dev/null || echo "none"
+git log "origin/${BASE}..HEAD" --oneline 2>/dev/null || echo "none"
 
 echo "---stat---"
-git diff "${BASE}...HEAD" --stat 2>/dev/null || echo "none"
+git diff "origin/${BASE}...HEAD" --stat 2>/dev/null || echo "none"
 
 echo "---pr---"
 gh pr list --head "$BRANCH" --json number,title,url,state 2>/dev/null || echo "none"
@@ -33,7 +36,7 @@ if [ -n "$ISSUE_NUM" ]; then
   # grep -c exits 1 on zero matches; under pipefail that fails the assignment, so
   # `|| true` keeps it empty and `${TEST_FILES:-0}` substitutes 0. (Do NOT rewrite as
   # `grep -c … || echo 0` — grep already prints "0", so that doubles the output.)
-  TEST_FILES=$(git diff "${BASE}...HEAD" --name-only 2>/dev/null | grep -c '\.test\.\|\.spec\.' || true)
+  TEST_FILES=$(git diff "origin/${BASE}...HEAD" --name-only 2>/dev/null | grep -c '\.test\.\|\.spec\.' || true)
   echo "test_files=${TEST_FILES:-0}"
 else
   echo "issue=none"

--- a/plugins/dev-core/skills/setup-worktree/SKILL.md
+++ b/plugins/dev-core/skills/setup-worktree/SKILL.md
@@ -2,7 +2,7 @@
 name: setup-worktree
 argument-hint: '[--issue <N> --slug <slug>]'
 description: Create + link feature branch to issue, then check out worktree. Triggers: "setup worktree" | "create worktree" | "prepare workspace" | "bootstrap branch".
-version: 0.3.0
+version: 0.3.1
 allowed-tools: Bash, Read, EnterWorktree, ExitWorktree, ToolSearch
 ---
 
@@ -40,7 +40,7 @@ One-time setup per issue. Idempotent — safe to re-run if branch/link/ω alread
 ## Step 1 — Detect
 
 ```bash
-BASE=$(git branch -r 2>/dev/null | grep -q 'origin/staging' && echo staging || echo main)
+BASE=$(. "${CLAUDE_SKILL_DIR}/../shared/lib.sh" && detect_base_branch)
 git fetch origin "$BASE" 2>&1
 
 # Paths depend on mode (issue vs frame-only)

--- a/plugins/dev-core/skills/shared/lib.sh
+++ b/plugins/dev-core/skills/shared/lib.sh
@@ -4,8 +4,11 @@
 # No `set` here: sourcing must not mutate the caller's shell options.
 
 # Echo the base branch: `staging` if origin/staging exists, else `main`.
-# `grep -q` failing (no staging) short-circuits the `&&` and falls through to
+# `show-ref --verify` tests the exact ref refs/remotes/origin/staging: no substring
+# match (so `origin/staging-x`, or a remote literally named `myorigin`, cannot
+# false-positive) and no dependency on `git branch -r` output formatting. A missing
+# ref (or running outside a repo) short-circuits the `&&` and falls through to
 # `|| echo main`, so the function always exits 0 even under `set -e`.
 detect_base_branch() {
-    git branch -r 2>/dev/null | grep -q 'origin/staging' && echo staging || echo main
+    git show-ref --verify --quiet refs/remotes/origin/staging 2>/dev/null && echo staging || echo main
 }

--- a/plugins/dev-core/skills/shared/lib.sh
+++ b/plugins/dev-core/skills/shared/lib.sh
@@ -3,29 +3,21 @@
 # Sourced, not executed — callers do: . "$SCRIPT_DIR/../shared/lib.sh"
 # No `set` here: sourcing must not mutate the caller's shell options.
 
-# Echo the base branch: `staging` if origin/staging exists; otherwise the remote's
-# default branch (origin/HEAD, e.g. `main` or `master`); falling back to `main`.
-# `show-ref --verify` tests the exact ref refs/remotes/origin/staging: no substring
-# match (so `origin/staging-x`, or a remote literally named `myorigin`, cannot
-# false-positive) and no dependency on `git branch -r` output formatting. Every
-# branch ends in an `echo`, and the origin/HEAD lookup is `|| true`-guarded, so the
-# function always exits 0 (even outside a repo / under `set -e`).
+# Echo the base branch: the first of `staging`, `main`, `master` that exists as a
+# remote-tracking ref, else `main`. `show-ref --verify` tests the exact ref — no
+# substring match (so `origin/staging-x`, or a remote named `myorigin`, cannot
+# false-positive) and no dependency on `git branch -r` formatting. Unlike
+# `refs/remotes/origin/HEAD` (a symbolic ref that `git fetch` never refreshes), these
+# refs ARE kept current by fetch. The result is always one of the three protected
+# branches, so callers' protected-set assumptions stay valid. Every path ends in an
+# `echo`, so the function always exits 0 even under `set -e`.
 detect_base_branch() {
-    if git show-ref --verify --quiet refs/remotes/origin/staging 2>/dev/null; then
-        echo staging
-        return
-    fi
-    # No staging → the remote's default branch (main/master/…), else main.
-    # `git fetch` does NOT refresh refs/remotes/origin/HEAD (a symbolic ref set at
-    # clone / by `git remote set-head`), so after a remote default-branch rename it
-    # can dangle. Validate the resolved ref exists before trusting it — otherwise a
-    # stale name would misdirect `gh pr create --base` / mask diffs — else `main`.
-    local default
-    default=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || true
-    default=${default#origin/}
-    if [ -n "$default" ] && git show-ref --verify --quiet "refs/remotes/origin/${default}" 2>/dev/null; then
-        echo "$default"
-    else
-        echo main
-    fi
+    local b
+    for b in staging main master; do
+        if git show-ref --verify --quiet "refs/remotes/origin/$b" 2>/dev/null; then
+            echo "$b"
+            return
+        fi
+    done
+    echo main
 }

--- a/plugins/dev-core/skills/shared/lib.sh
+++ b/plugins/dev-core/skills/shared/lib.sh
@@ -16,8 +16,16 @@ detect_base_branch() {
         return
     fi
     # No staging → the remote's default branch (main/master/…), else main.
+    # `git fetch` does NOT refresh refs/remotes/origin/HEAD (a symbolic ref set at
+    # clone / by `git remote set-head`), so after a remote default-branch rename it
+    # can dangle. Validate the resolved ref exists before trusting it — otherwise a
+    # stale name would misdirect `gh pr create --base` / mask diffs — else `main`.
     local default
     default=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || true
     default=${default#origin/}
-    echo "${default:-main}"
+    if [ -n "$default" ] && git show-ref --verify --quiet "refs/remotes/origin/${default}" 2>/dev/null; then
+        echo "$default"
+    else
+        echo main
+    fi
 }

--- a/plugins/dev-core/skills/shared/lib.sh
+++ b/plugins/dev-core/skills/shared/lib.sh
@@ -3,12 +3,21 @@
 # Sourced, not executed — callers do: . "$SCRIPT_DIR/../shared/lib.sh"
 # No `set` here: sourcing must not mutate the caller's shell options.
 
-# Echo the base branch: `staging` if origin/staging exists, else `main`.
+# Echo the base branch: `staging` if origin/staging exists; otherwise the remote's
+# default branch (origin/HEAD, e.g. `main` or `master`); falling back to `main`.
 # `show-ref --verify` tests the exact ref refs/remotes/origin/staging: no substring
 # match (so `origin/staging-x`, or a remote literally named `myorigin`, cannot
-# false-positive) and no dependency on `git branch -r` output formatting. A missing
-# ref (or running outside a repo) short-circuits the `&&` and falls through to
-# `|| echo main`, so the function always exits 0 even under `set -e`.
+# false-positive) and no dependency on `git branch -r` output formatting. Every
+# branch ends in an `echo`, and the origin/HEAD lookup is `|| true`-guarded, so the
+# function always exits 0 (even outside a repo / under `set -e`).
 detect_base_branch() {
-    git show-ref --verify --quiet refs/remotes/origin/staging 2>/dev/null && echo staging || echo main
+    if git show-ref --verify --quiet refs/remotes/origin/staging 2>/dev/null; then
+        echo staging
+        return
+    fi
+    # No staging → the remote's default branch (main/master/…), else main.
+    local default
+    default=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || true
+    default=${default#origin/}
+    echo "${default:-main}"
 }

--- a/plugins/dev-core/skills/test/SKILL.md
+++ b/plugins/dev-core/skills/test/SKILL.md
@@ -56,7 +56,7 @@ Steps: identify-targets → read-standards → check-coverage → generate-tests
 
 ```bash
 BASE=$(. "${CLAUDE_SKILL_DIR}/../shared/lib.sh" && detect_base_branch)
-git diff ${BASE}...HEAD --name-only
+git diff origin/${BASE}...HEAD --name-only
 ```
 
 Include: `.ts`, `.tsx`. Exclude: `*.config.ts`, `*.d.ts`, `*.test.*`, `*.spec.*`, files with no exports.

--- a/plugins/dev-core/skills/test/SKILL.md
+++ b/plugins/dev-core/skills/test/SKILL.md
@@ -2,7 +2,7 @@
 name: test
 argument-hint: [file | --e2e | --run]
 description: Generate/run unit, integration & Playwright e2e tests. Triggers: "test this file" | "write tests" | "add coverage" | "run tests" | "e2e tests" | "add tests" | "test coverage" | "generate tests" | "test this" | "write unit tests" | "add integration tests".
-version: 0.4.0
+version: 0.4.1
 allowed-tools: Bash, Read, Write, Glob, Grep, ToolSearch
 ---
 
@@ -55,7 +55,7 @@ Steps: identify-targets → read-standards → check-coverage → generate-tests
 ## Step 2 — Identify Target Files
 
 ```bash
-BASE=$(git branch -r | grep -q 'origin/staging' && echo staging || echo main)
+BASE=$(. "${CLAUDE_SKILL_DIR}/../shared/lib.sh" && detect_base_branch)
 git diff ${BASE}...HEAD --name-only
 ```
 


### PR DESCRIPTION
Robustness pass on dev-core base-branch detection + consistent base diffing. Reviewed by a 4-agent `/code-review` and a 2-agent re-review; the re-review drove a descope (below). 6 commits.

## Final design

- **`shared/lib.sh` `detect_base_branch`** — returns the first of `staging`, `main`, `master` that exists as a remote-tracking ref (exact `git show-ref --verify`), else `main`. Replaces `git branch -r | grep -q 'origin/staging'`, an unanchored substring match (`origin/staging-x`, or a remote named `myorigin`, false-positived). Result is always one of the three protected branches, so cleanup's protected-set model stays valid.
- **`pr/gather-state.sh`** — `git fetch --prune origin` before detection, and diffs against `origin/${BASE}` (was bare local `${BASE}`, which rev-parse resolves to a possibly-stale/absent local branch first).
- **`cleanup/analyze-branches.sh`** — detects base after `fetch --prune`; `branch_merged()` now compares against a resolved `BASE_REF` (prefer `origin/<base>`, else local, else skip) so an unmerged branch is never mis-classified `safe_delete` when the base isn't checked out locally. **+ regression test.**
- **DRY** — `test`, `code-review`, `setup-worktree` inlined the detection one-liner (already drifted); now source `lib.sh`.
- **Consistency** — `code-review`/`test`/`pr`/`dev` skills diff against `origin/${BASE}`.

## Review → descope

An `origin/HEAD`-based fallback (added mid-PR for `master`-default repos) introduced a class of issues: `git fetch` never refreshes `refs/remotes/origin/HEAD` (dangling-symref → wrong base), and it decoupled cleanup's `{main,master,staging}` protected set. Rather than generalize all of cleanup to arbitrary defaults, detection was **constrained to the triad candidate-list** — keeping `master` support while leaving cleanup's protection model valid. Two interim-fix defects the re-review found (unvalidated fallback; a regex-metachar branch name that could zero the remote-branch list) are gone with that revert.

## Verification (empirical, scratch repos, `set -e`)

| refs present | base |
|---|---|
| `origin/staging` (+ decoys `origin/staging-x`, `myorigin/staging`) | `staging` |
| decoys only | `main` |
| `master`-only repo | `master` |
| `main` + `master` | `main` |
| no origin / empty repo | `main` |

`analyze-branches` suite (existing + new origin-only-base regression) green · `validate_plugins.py` all-pass · typecheck clean · lefthook pre-push `test` green.

## Versions
`dev-core` plugin 0.8.14 → **0.8.15**. Skills: `pr` 0.4.3, `test` 0.4.1, `code-review` 0.2.2, `setup-worktree` 0.3.1, `cleanup` 0.6.1, `dev` 0.3.1.

---
Generated with [Claude Code](https://claude.com/claude-code)