### PR TITLE
fix(promote): tolerate bare CHANGELOG headings + component tag prefix in finalize 9b

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -256,7 +256,10 @@ git push origin "$VERSION"
 
 **9d.** Release:
 ```bash
-gh release create "$VERSION" --title "$VERSION" --notes "$CHANGELOG_CONTENT"
+# Title drops the tag separator: `<component>/vX.Y.Z` → `<component> vX.Y.Z` (bare `vX.Y.Z` unchanged),
+# matching existing GitHub Release names (e.g. `roxabi-live v0.24.0`).
+TITLE="${VERSION/\/v/ v}"
+gh release create "$VERSION" --title "$TITLE" --notes "$CHANGELOG_CONTENT"
 ```
 
 Inform: "Release $VERSION finalized. Run `/cleanup` to clean branches."

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -237,9 +237,15 @@ gh pr list --base main --head staging --state merged --limit 1 --json number,tit
 
 **9b.** Detect V:
 ```bash
-grep -oP '## \[\Kv[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1
+# Newest CHANGELOG heading — tolerate `## [0.24.1]` and `## [v0.24.1]`, bare or with a
+# trailing `(compare-url)` (release-please writes the former, `release-artifacts.md` the latter).
+V_RAW=$(grep -oP '^##\s*\[\Kv?[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1)
+# Apply the repo's tag convention: `<component>/vX.Y.Z` if it already uses one, else bare `vX.Y.Z`.
+TAG_PREFIX=$(git tag -l '*/v*' --sort=-v:refname | head -1 | sed -E 's|/v[0-9]+\.[0-9]+\.[0-9]+$|/v|')
+VERSION="${TAG_PREFIX:-v}${V_RAW#v}"
+echo "$VERSION"
 ```
-Q: **Use {detected}** | **Custom version**
+Q: **Use {VERSION}** | **Custom version** (override when a multi-package repo's newest tag is the wrong component)
 
 **9c.** Tag:
 ```bash


### PR DESCRIPTION
## Problem

`/promote --finalize` Step 9b detected the release version with:

```bash
grep -oP '## \[\Kv[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1
```

This requires a `v` prefix inside the CHANGELOG heading. **release-please** — and repos migrated off it (e.g. `roxabi-live`, whose CHANGELOG stays in that format) — write:

```
## [0.24.1](https://github.com/.../compare/roxabi-live/v0.24.0...roxabi-live/v0.24.1) (2026-07-16)
```

No `v` → detection returns **empty** → finalize cannot auto-suggest a version. Hit live finalizing `roxabi-live/v0.24.1` today (had to type the tag manually).

A naive "make the `v` optional" fix is worse than the bug: it would suggest bare `0.24.1`, and Step 9c tags `$VERSION` verbatim → tag `0.24.1`, violating the org **Release Convention A** (`<component>/vX.Y.Z`). That turns a safe failure (empty) into a dangerous one (wrong tag, one click away).

## Fix

Step 9b now:
- Matches `## [0.24.1]` **and** `## [v0.24.1]`, bare or with a trailing `(compare-url)`, anchored to heading lines (`^##\s*\[`) so inline `[x.y.z]` link refs can't false-match.
- Derives the repo's tag convention from existing tags: `<component>/vX.Y.Z` when the repo already uses one, else bare `vX.Y.Z`. The suggestion is directly usable by 9c/9d.

## Verification

Tested across the CHANGELOG-format × tag-style matrix:

| CHANGELOG heading | Existing tags | → suggested `$VERSION` |
|---|---|---|
| `## [0.24.1](url)` | `roxabi-live/v0.24.0` | `roxabi-live/v0.24.1` |
| `## [v0.1.0] - date` | `lyra/v0.1.0` | `lyra/v0.1.0` |
| `## [0.3.0]` | `v0.2.9` (bare) | `v0.3.0` |
| `## [v0.3.0] - date` | (no tags) | `v0.3.0` |
| `## [1.2.0](url)` | `voicecli/v1.1.0` | `voicecli/v1.2.0` |

- `python3 tools/validate_plugins.py` → all checks pass (incl. SKILL.md line budget)
- `vitest run plugins/dev-core/skills/promote/` → 85 passed
- Bumps `dev-core` 0.8.15 → 0.8.16

🤖 Generated with [Claude Code](https://claude.com/claude-code)