### PR TITLE
fix(ci): gate dependabot majors on fetch-metadata, not the PR title

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,14 @@ updates:
       github-actions:
         patterns:
           - "*"
+        # Majors excluded from the group → emitted as individual PRs so the
+        # auto-merge semver-major guard reviews each one on its own.
+        update-types:
+          - minor
+          - patch
     cooldown:
       default-days: 3
-      semver-major-days: 3
+      semver-major-days: 7
       semver-minor-days: 3
       semver-patch-days: 3
   - package-ecosystem: npm
@@ -21,8 +26,13 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+        # Majors excluded from the group → emitted as individual PRs so the
+        # auto-merge semver-major guard reviews each one on its own.
+        update-types:
+          - minor
+          - patch
     cooldown:
       default-days: 3
-      semver-major-days: 3
+      semver-major-days: 7
       semver-minor-days: 3
       semver-patch-days: 3

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -44,19 +44,31 @@ jobs:
           app-id: ${{ vars.ROXABI_CI_APP_ID }}
           private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
 
-      - name: Block dependabot semver-major bumps
+      # Read the real update-type from Dependabot's metadata instead of parsing
+      # the PR title. The old title-regex only matched single-dependency titles
+      # ("bump X from A to B"); grouped PRs are titled "bump the <group> group…"
+      # with no versions, so the guard never fired for a grouped major. For a
+      # grouped PR, fetch-metadata reports the HIGHEST update-type across the
+      # group — so a major hidden inside a group is caught.
+      - name: Fetch dependabot metadata
+        id: dependabot-meta
         if: github.event.pull_request.user.login == 'dependabot[bot]'
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3.1.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+
+      - name: Block dependabot semver-major bumps
+        if: >-
+          github.event.pull_request.user.login == 'dependabot[bot]' &&
+          steps.dependabot-meta.outputs.update-type == 'version-update:semver-major'
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ "$PR_TITLE" =~ from\ v?([0-9]+)[^\ ]*\ to\ v?([0-9]+) ]] && [ "${BASH_REMATCH[1]}" != "${BASH_REMATCH[2]}" ]; then
-            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-              --body "Auto-merge refusé : bump **semver-major**. Validation manuelle requise (e2e / boot de l'artefact), puis merge à la main."
-            echo "::error::semver-major dependency bump — auto-merge refused"
-            exit 1
-          fi
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --body "Auto-merge refusé : bump **semver-major**. Validation manuelle requise (e2e / boot de l'artefact), puis merge à la main."
+          echo "::error::semver-major dependency bump — auto-merge refused"
+          exit 1
 
       - name: Update branch (lazy sync for late joiners)
         if: contains(github.event.pull_request.labels.*.name, 'reviewed')


### PR DESCRIPTION
## Problem

The `Block dependabot semver-major bumps` step in `auto-merge.yml` has been **inert since dependabot grouping was enabled**. It parses `from X to Y` out of the PR *title* — a shape only single-dependency Dependabot PRs have. Both ecosystems are grouped (`patterns: ["*"]`), so every Dependabot PR is titled `bump the <group> group across 1 directory with N updates`, with no versions in the title. The regex never matches → the guard silently no-ops.

The workflow's own header comment ("semver-major bumps are never auto-merged — the vite 8 SSR regression stayed dormant 10 weeks") documents a control that does not exist.

Verified against the two open Dependabot PRs, each containing a real major:

| PR | Title | Old regex |
|----|-------|-----------|
| #306 | `bump the github-actions group across 1 directory with 2 updates` (checkout 6→7) | **passes** (no block) |
| #338 | `bump the npm-dependencies group across 1 directory with 6 updates` (typescript 6→7) | **passes** (no block) |

Both are one `reviewed` label away from auto-merging a major.

## Fix (root cause, two layers)

- **`auto-merge.yml`** — replace the title-regex with [`dependabot/fetch-metadata`](https://github.com/dependabot/fetch-metadata) (SHA-pinned `@25dd0e34…` = v3.1.0), gating on `update-type == 'version-update:semver-major'`. For grouped PRs, fetch-metadata reports the **highest** update-type across the group — so a major hidden inside a group is caught, which a title parse never could be.
- **`dependabot.yml`** — exclude majors from both groups (`update-types: [minor, patch]`) so majors arrive as individually-titled, individually-reviewable PRs instead of riding inside a `chore(deps)` group. Bump `semver-major-days` cooldown 3→7 for soak.

## Effect on the open PRs

Once this lands, Dependabot re-evaluates its config and re-emits #306/#338: the safe minor/patch bumps stay grouped, and each major (checkout 6→7, typescript 6→7) breaks out into its own PR — where the guard now blocks auto-merge and forces manual validation. TS 7 in particular breaks this repo's LSP (`typescript-language-server` needs the `tsserver` binary that TS 7 removed) — see the review on #338.

## Test notes

- YAML of both files validated (`yaml.safe_load`).
- `fetch-metadata` only runs on `pull_request` activity where `github.event.pull_request.user.login == 'dependabot[bot]'`; the `check_suite`/`push` triggers have no PR context and skip the step (no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
