### PR TITLE
fix(ci): drop unsupported semver-*-days cooldown from github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,11 @@ updates:
         update-types:
           - minor
           - patch
+    # github-actions supports ONLY `default-days` — `semver-*-days` are rejected
+    # for this ecosystem and made the whole config fail validation. Undefined
+    # semver-*-days fall back to default-days, so 3 days applies to every bump.
     cooldown:
       default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 3
   - package-ecosystem: npm
     directory: /
     schedule:


### PR DESCRIPTION
## Problem

Running **Insights → Dependency graph → Dependabot → "Check for updates"** surfaced that the Dependabot job is **rejecting our config**:

```
The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

Per the **cooldown support table** in the [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference):

> "The `default-days` option is supported for all package managers listed, while `semver-major-days`, `semver-minor-days`, and `semver-patch-days` are supported only where indicated."

| Package manager | `default-days` | `semver-*-days` |
|---|---|---|
| GitHub Actions | ✅ Supported | ❌ **Not supported** |
| NPM and Yarn | ✅ Supported | ✅ Supported |

The `cooldown` block itself **is** valid for `github-actions` — only the three `semver-*-days` lines are illegal, so this removes just those rather than the whole block. npm keeps its `semver-*-days` (supported there).

## No behaviour lost

> "If `semver-major-days`, `semver-minor-days`, or `semver-patch-days` are not defined, the `default-days` settings will take precedence for cooldown-based updates."

Our github-actions minor/patch were already `3`, so `default-days: 3` reproduces them exactly. The only intent dropped is the major-7 soak for that ecosystem — unachievable there regardless.

## Pre-existing, not introduced by #342

The `semver-*-days` were already on the `github-actions` entry before #342 (which only changed major `3 → 7`). **This config has been failing validation since `cooldown` was introduced** — silently, because nobody had run the job manually and read the log.

## Why this matters beyond the error message

This is the **prime suspect** for why #342's `update-types: [minor, patch]` split never took effect: `@dependabot recreate` on #306/#338 kept their semver-majors grouped even though the split is live on `staging`, and a **parse-time rejection of the config file** would explain both ecosystems ignoring it at once — the error is phrased at file scope ("when parsing your .github/dependabot.yml").

Stated honestly: **the blast radius of a per-entry validation error is undocumented.** I could not find whether it rejects the whole file, skips only `updates[0]`, or ignores only the offending property. So this is a hypothesis, not a conclusion.

**Test after merge:** re-run "Check for updates" on the npm manifest and read the job log. If the group PR drops `typescript` and a standalone major PR appears, the split works and the config error was the cause. If it still groups the major, the cause is elsewhere (most likely `recreate`/grouping re-derivation) and #306/#338 need separate treatment.

Either way the safety property is unaffected: the semver-major auto-merge guard from #342 is **verified working live** (it blocked #306 with `update-type: version-update:semver-major`), and it catches grouped majors, which is exactly the case the split is meant to prevent from arising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
