### PR TITLE
fix(dev-core,dev-init): init shim, bun:test CI, dependabot, scaffold facts

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/hooks/lib/parse-stack-yml.cjs
+++ b/plugins/dev-core/hooks/lib/parse-stack-yml.cjs
@@ -174,22 +174,43 @@ function parseCommand(text, key) {
 }
 
 /**
- * Parse `testing.e2e` from stack.yml text.
+ * Parse a key under the `testing:` section from stack.yml text.
  *
  * @param {string} text
+ * @param {string} key
  * @returns {string|null}
  */
-function parseTestingE2e(text) {
+function parseTestingKey(text, key) {
   if (!text) return null
   const section = text.match(/^testing:\s*$/m)
   if (!section) return null
   const after = text.slice(section.index + 'testing:'.length)
   const nextTop = after.match(/\n\S/)
   const block = nextTop ? after.slice(0, nextTop.index) : after
-  const match = block.match(/^\s+e2e:\s*(\S+)/m)
+  const match = block.match(new RegExp(`^\\s+${key}:\\s*(\\S+)`, 'm'))
   if (!match) return null
   const val = match[1]
   return val === 'none' ? null : val
+}
+
+/**
+ * Parse `testing.e2e` from stack.yml text.
+ *
+ * @param {string} text
+ * @returns {string|null}
+ */
+function parseTestingE2e(text) {
+  return parseTestingKey(text, 'e2e')
+}
+
+/**
+ * Parse `testing.unit` from stack.yml text (vitest | jest | pytest | bun).
+ *
+ * @param {string} text
+ * @returns {string|null}
+ */
+function parseTestingUnit(text) {
+  return parseTestingKey(text, 'unit')
 }
 
 /**
@@ -259,6 +280,7 @@ function parseStandards(text) {
  *   standards: Record<string, string>|null,
  *   runtime: string|null,
  *   commands: {lint: string|null, typecheck: string|null, test: string|null},
+ *   testingUnit: string|null,
  *   testingE2e: string|null,
  *   ciMerge: string|null
  * }}
@@ -277,6 +299,7 @@ function parseStackYml(text) {
       typecheck: parseCommand(text, 'typecheck'),
       test: parseCommand(text, 'test'),
     },
+    testingUnit: parseTestingUnit(text),
     testingE2e: parseTestingE2e(text),
     ciMerge: parseCiMerge(text),
   }
@@ -292,6 +315,7 @@ module.exports = {
   parseStandards,
   parseRuntime,
   parseCommand,
+  parseTestingUnit,
   parseTestingE2e,
   parseCiMerge,
 }

--- a/plugins/dev-core/hooks/lib/parse-stack-yml.d.cts
+++ b/plugins/dev-core/hooks/lib/parse-stack-yml.d.cts
@@ -18,6 +18,7 @@ export interface StackYml {
   standards: Record<string, string> | null
   runtime: string | null
   commands: StackCommands
+  testingUnit: string | null
   testingE2e: string | null
   ciMerge: string | null
 }
@@ -31,5 +32,6 @@ export declare function parsePackageManager(text: string | null): string | null
 export declare function parseStandards(text: string | null): Record<string, string> | null
 export declare function parseRuntime(text: string | null): string | null
 export declare function parseCommand(text: string | null, key: string): string | null
+export declare function parseTestingUnit(text: string | null): string | null
 export declare function parseTestingE2e(text: string | null): string | null
 export declare function parseCiMerge(text: string | null): string | null

--- a/plugins/dev-core/skills/checkup/__tests__/dependabot-cooldown.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/dependabot-cooldown.test.ts
@@ -1,0 +1,147 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { checkSecurity, detectDependabotCooldownViolations } from '../doctor-local'
+
+/**
+ * Dependabot cooldown validity.
+ * `semver-*-days` is supported for npm/yarn but not for github-actions; GitHub
+ * rejects the whole file at parse time when it appears there, so a presence-only
+ * check passes on a config that is entirely inert.
+ */
+
+// The repo's own valid config, inlined so the test does not read .github/.
+const VALID = [
+  'version: 2',
+  'updates:',
+  '  - package-ecosystem: github-actions',
+  '    directory: /',
+  '    schedule:',
+  '      interval: weekly',
+  '    groups:',
+  '      github-actions:',
+  '        patterns:',
+  '          - "*"',
+  '        update-types:',
+  '          - minor',
+  '          - patch',
+  '    cooldown:',
+  '      default-days: 3',
+  '  - package-ecosystem: npm',
+  '    directory: /',
+  '    schedule:',
+  '      interval: weekly',
+  '    groups:',
+  '      npm-dependencies:',
+  '        patterns:',
+  '          - "*"',
+  '        update-types:',
+  '          - minor',
+  '          - patch',
+  '    cooldown:',
+  '      default-days: 3',
+  '      semver-major-days: 7',
+  '      semver-minor-days: 3',
+  '      semver-patch-days: 3',
+].join('\n')
+
+// The config GitHub rejected for weeks: semver-*-days under github-actions.
+const BROKEN = VALID.replace(
+  ['    cooldown:', '      default-days: 3', '  - package-ecosystem: npm'].join('\n'),
+  ['    cooldown:', '      default-days: 3', '      semver-major-days: 7', '  - package-ecosystem: npm'].join('\n'),
+)
+
+describe('detectDependabotCooldownViolations', () => {
+  it('does not flag the valid config, where only npm carries semver-*-days', () => {
+    expect(detectDependabotCooldownViolations(VALID)).toEqual([])
+  })
+
+  it('flags semver-major-days under github-actions', () => {
+    expect(detectDependabotCooldownViolations(BROKEN)).toEqual([
+      { ecosystem: 'github-actions', property: 'semver-major-days' },
+    ])
+  })
+
+  it('flags every offending key, not just the first', () => {
+    const yml = [
+      'updates:',
+      '  - package-ecosystem: github-actions',
+      '    cooldown:',
+      '      default-days: 3',
+      '      semver-major-days: 7',
+      '      semver-minor-days: 3',
+      '      semver-patch-days: 3',
+    ].join('\n')
+    expect(detectDependabotCooldownViolations(yml).map((v) => v.property)).toEqual([
+      'semver-major-days',
+      'semver-minor-days',
+      'semver-patch-days',
+    ])
+  })
+
+  it('ignores semver-*-days named in a comment inside a github-actions block', () => {
+    const yml = [
+      'updates:',
+      '  - package-ecosystem: github-actions',
+      '    # semver-major-days: 7 is rejected here — do not add it back',
+      '    cooldown:',
+      '      default-days: 3',
+    ].join('\n')
+    expect(detectDependabotCooldownViolations(yml)).toEqual([])
+  })
+
+  it('does not attribute a later npm key to an earlier github-actions block', () => {
+    const yml = [
+      'updates:',
+      '  - package-ecosystem: github-actions',
+      '    cooldown:',
+      '      default-days: 3',
+      '  - package-ecosystem: npm',
+      '    cooldown:',
+      '      semver-major-days: 7',
+    ].join('\n')
+    expect(detectDependabotCooldownViolations(yml)).toEqual([])
+  })
+
+  it('does not flag keys outside a cooldown mapping', () => {
+    const yml = ['updates:', '  - package-ecosystem: github-actions', '    groups:', '      semver-major-days: 7'].join(
+      '\n',
+    )
+    expect(detectDependabotCooldownViolations(yml)).toEqual([])
+  })
+})
+
+describe('checkSecurity dependabot.yml status', () => {
+  const original = process.cwd()
+  let tmpDir: string
+
+  function writeDependabot(content: string) {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dependabot-test-'))
+    fs.mkdirSync(path.join(tmpDir, '.github'))
+    fs.writeFileSync(path.join(tmpDir, '.github/dependabot.yml'), content)
+    process.chdir(tmpDir)
+  }
+
+  function dependabotCheck() {
+    return checkSecurity().checks.find((c) => c.name === 'dependabot.yml')
+  }
+
+  afterEach(() => {
+    process.chdir(original)
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('passes the valid config', () => {
+    writeDependabot(VALID)
+    expect(dependabotCheck()?.status).toBe('pass')
+  })
+
+  it('fails the config GitHub rejects, naming the property and the ecosystem', () => {
+    writeDependabot(BROKEN)
+    const check = dependabotCheck()
+    expect(check?.status).toBe('fail')
+    expect(check?.detail).toContain('semver-major-days')
+    expect(check?.detail).toContain('github-actions')
+  })
+})

--- a/plugins/dev-core/skills/checkup/__tests__/workflow-drift.test.ts
+++ b/plugins/dev-core/skills/checkup/__tests__/workflow-drift.test.ts
@@ -22,7 +22,7 @@ describe('checkWorkflowDrift', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  it('passes when ci.yml matches generator output for stack.yml', () => {
+  it('passes when ci.yml matches generator output for stack.yml', async () => {
     fs.writeFileSync(
       '.claude/stack.yml',
       `runtime: bun
@@ -38,26 +38,47 @@ deploy:
       generateCiYml({ stack: 'bun', test: 'none', deploy: 'none', lint: true, typecheck: true }),
     )
 
-    const checks = checkWorkflowDrift()
+    const checks = await checkWorkflowDrift()
     const ci = checks.find((c) => c.name === 'drift:ci.yml')
     expect(ci?.status).toBe('pass')
     expect(ci?.detail).toContain('matches generator')
   })
 
-  it('warns when on-disk ci.yml differs from generator', () => {
+  it('warns when on-disk ci.yml differs from generator', async () => {
     fs.writeFileSync('.claude/stack.yml', 'runtime: bun\ndeploy:\n  platform: none\n')
     fs.writeFileSync('.github/workflows/ci.yml', 'name: CI\non: push\njobs: {}\n')
 
-    const checks = checkWorkflowDrift()
+    const checks = await checkWorkflowDrift()
     const ci = checks.find((c) => c.name === 'drift:ci.yml')
     expect(ci?.status).toBe('warn')
   })
 
-  it('skips drift check when workflow file is absent', () => {
+  it('skips drift check when workflow file is absent', async () => {
     fs.writeFileSync('.claude/stack.yml', 'runtime: bun\ndeploy:\n  platform: none\n')
 
-    const checks = checkWorkflowDrift()
+    const checks = await checkWorkflowDrift()
     const ci = checks.find((c) => c.name === 'drift:ci.yml')
     expect(ci?.status).toBe('skip')
+  })
+
+  it('degrades to skip when dev-init is not installed', async () => {
+    const prevRoot = process.env.CLAUDE_PLUGIN_ROOT
+    const prevHome = process.env.HOME
+    // Both resolution paths must miss: plugin root (flat siblings + derived cache) and the ~/.claude fallback.
+    process.env.CLAUDE_PLUGIN_ROOT = path.join(tmpDir, 'plugins', 'dev-core')
+    process.env.HOME = tmpDir
+    try {
+      fs.writeFileSync('.claude/stack.yml', 'runtime: bun\ndeploy:\n  platform: none\n')
+
+      const checks = await checkWorkflowDrift()
+      expect(checks).toHaveLength(1)
+      expect(checks[0].status).toBe('skip')
+      expect(checks[0].detail).toContain('dev-init')
+    } finally {
+      if (prevRoot === undefined) delete process.env.CLAUDE_PLUGIN_ROOT
+      else process.env.CLAUDE_PLUGIN_ROOT = prevRoot
+      if (prevHome === undefined) delete process.env.HOME
+      else process.env.HOME = prevHome
+    }
   })
 })

--- a/plugins/dev-core/skills/checkup/doctor-local.ts
+++ b/plugins/dev-core/skills/checkup/doctor-local.ts
@@ -87,6 +87,61 @@ export function checkProjectStructure(): Section {
   return { name: 'Project', checks }
 }
 
+export interface DependabotCooldownFinding {
+  ecosystem: string
+  property: string
+}
+
+/** Ecosystems whose cooldown accepts `default-days` only — per the Dependabot options reference. */
+const SEMVER_COOLDOWN_UNSUPPORTED = new Set(['github-actions'])
+
+const SEMVER_COOLDOWN_KEY = /^(semver-(?:major|minor|patch)-days)\s*:/
+
+function indentOf(line: string): number {
+  return line.length - line.trimStart().length
+}
+
+function stripComment(line: string): string {
+  const hash = line.indexOf('#')
+  return hash === -1 ? line : line.slice(0, hash)
+}
+
+/**
+ * Detect `semver-*-days` cooldown keys under ecosystems that do not support them.
+ * Scoping matters in both directions: npm legitimately carries `semver-major-days`,
+ * so a whole-file match would flag a valid config; each key must be attributed to
+ * the `- package-ecosystem:` list item that contains it.
+ * Hand-parsed — no YAML parser is available to this plugin.
+ */
+export function detectDependabotCooldownViolations(content: string): DependabotCooldownFinding[] {
+  const lines = content.split('\n').map(stripComment)
+  const starts: number[] = []
+  lines.forEach((line, i) => {
+    if (/^\s*-\s*package-ecosystem\s*:/.test(line)) starts.push(i)
+  })
+
+  const findings: DependabotCooldownFinding[] = []
+  for (let b = 0; b < starts.length; b++) {
+    const block = lines.slice(starts[b], starts[b + 1] ?? lines.length)
+    const ecosystem = block[0].match(/package-ecosystem\s*:\s*['"]?([\w-]+)/)?.[1]
+    if (!ecosystem || !SEMVER_COOLDOWN_UNSUPPORTED.has(ecosystem)) continue
+
+    let cooldownIndent: number | null = null
+    for (const line of block) {
+      if (!line.trim()) continue
+      if (cooldownIndent !== null && indentOf(line) <= cooldownIndent) cooldownIndent = null
+      if (/^\s*cooldown\s*:/.test(line)) {
+        cooldownIndent = indentOf(line)
+        continue
+      }
+      if (cooldownIndent === null) continue
+      const key = line.trim().match(SEMVER_COOLDOWN_KEY)?.[1]
+      if (key) findings.push({ ecosystem, property: key })
+    }
+  }
+  return findings
+}
+
 export function checkSecurity(): Section {
   const checks: Check[] = []
 
@@ -113,7 +168,15 @@ export function checkSecurity(): Section {
     const depYml = fs.readFileSync(dependabotPath, 'utf8') as string
     const hasGha = /package-ecosystem:\s*github-actions/.test(depYml)
     const hasApp = /package-ecosystem:\s*(npm|pip)/.test(depYml)
-    if (hasGha && hasApp) {
+    const cooldownViolations = detectDependabotCooldownViolations(depYml)
+    if (cooldownViolations.length > 0) {
+      const offenders = [...new Set(cooldownViolations.map((v) => `${v.property} under '${v.ecosystem}'`))].join(', ')
+      checks.push({
+        name: 'dependabot.yml',
+        status: 'fail',
+        detail: `invalid cooldown property: ${offenders} — GitHub rejects the entire dependabot.yml at parse time, so every ecosystem's update-types split silently stops applying. Keep only default-days there.`,
+      })
+    } else if (hasGha && hasApp) {
       checks.push({
         name: 'dependabot.yml',
         status: 'pass',

--- a/plugins/dev-core/skills/checkup/doctor-local.ts
+++ b/plugins/dev-core/skills/checkup/doctor-local.ts
@@ -100,13 +100,33 @@ export function checkSecurity(): Section {
       : 'not installed — pre-commit hook will fail. Install: brew install trufflehog or https://github.com/trufflesecurity/trufflehog/releases',
   })
 
-  // .github/dependabot.yml
-  const dependabotExists = fs.existsSync('.github/dependabot.yml')
-  checks.push({
-    name: 'dependabot.yml',
-    status: dependabotExists ? 'pass' : 'warn',
-    detail: dependabotExists ? 'found' : 'missing — run /init to create (automated dependency updates)',
-  })
+  // .github/dependabot.yml — require ecosystem + github-actions (partial = fail)
+  const dependabotPath = '.github/dependabot.yml'
+  const dependabotExists = fs.existsSync(dependabotPath)
+  if (!dependabotExists) {
+    checks.push({
+      name: 'dependabot.yml',
+      status: 'warn',
+      detail: 'missing — run /init or /ci-setup to create (automated dependency updates)',
+    })
+  } else {
+    const depYml = fs.readFileSync(dependabotPath, 'utf8') as string
+    const hasGha = /package-ecosystem:\s*github-actions/.test(depYml)
+    const hasApp = /package-ecosystem:\s*(npm|pip)/.test(depYml)
+    if (hasGha && hasApp) {
+      checks.push({
+        name: 'dependabot.yml',
+        status: 'pass',
+        detail: 'found (ecosystem + github-actions)',
+      })
+    } else {
+      checks.push({
+        name: 'dependabot.yml',
+        status: 'warn',
+        detail: `partial — missing ${!hasApp ? 'npm|pip ecosystem' : ''}${!hasApp && !hasGha ? ' and ' : ''}${!hasGha ? 'github-actions' : ''} block — re-run /ci-setup (generator owns full file)`,
+      })
+    }
+  }
 
   // lock file + license checker — inferred from stack.yml package_manager
   let lockFile: string | null = null

--- a/plugins/dev-core/skills/checkup/doctor-shared.ts
+++ b/plugins/dev-core/skills/checkup/doctor-shared.ts
@@ -86,7 +86,10 @@ export interface StackInfo {
   hasTypecheck: boolean
   e2e: string | null
   mergeStrategy: 'auto-merge' | 'merge-on-green' | null
+  /** σ.commands.test */
   test: string | null
+  /** σ.testing.unit */
+  unit: string | null
 }
 
 export function readStackYml(): StackInfo {
@@ -104,6 +107,7 @@ export function readStackYml(): StackInfo {
       e2e: stack.testingE2e,
       mergeStrategy: merge,
       test: stack.commands.test,
+      unit: stack.testingUnit ?? null,
     }
   } catch {
     return {
@@ -116,6 +120,7 @@ export function readStackYml(): StackInfo {
       e2e: null,
       mergeStrategy: null,
       test: null,
+      unit: null,
     }
   }
 }

--- a/plugins/dev-core/skills/checkup/doctor.ts
+++ b/plugins/dev-core/skills/checkup/doctor.ts
@@ -46,7 +46,7 @@ const sections: Section[] = [
   checkPrereqsSection(prereqs),
   checkGitHubConfig(ghOk, owner, repo),
   checkWorkflows(ghOk, owner, repo),
-  { name: 'Workflow drift', checks: checkWorkflowDrift() },
+  { name: 'Workflow drift', checks: await checkWorkflowDrift() },
   checkSecrets(ghOk, owner, repo),
   checkBranchProtection(ghOk, owner, repo),
   checkRulesets(ghOk, owner, repo, meta),

--- a/plugins/dev-core/skills/checkup/workflow-drift.ts
+++ b/plugins/dev-core/skills/checkup/workflow-drift.ts
@@ -40,8 +40,13 @@ export function checkWorkflowDrift(): Check[] {
     deployPlatform: stack.deployPlatform ?? undefined,
     merge: detectMergeStrategy(stack.mergeStrategy),
     e2e: stack.e2e ?? undefined,
-    test: stack.test ?? undefined,
-    commands: { lint: stack.hasLint ? 'lint' : '', typecheck: stack.hasTypecheck ? 'tc' : '' },
+    unit: stack.unit ?? undefined,
+    test: stack.unit ?? stack.test ?? undefined,
+    commands: {
+      lint: stack.hasLint ? 'lint' : '',
+      typecheck: stack.hasTypecheck ? 'tc' : '',
+      test: stack.test ?? '',
+    },
   })
   const expected: Record<string, string> = {
     'ci.yml': generateCiYml(opts),

--- a/plugins/dev-core/skills/checkup/workflow-drift.ts
+++ b/plugins/dev-core/skills/checkup/workflow-drift.ts
@@ -1,22 +1,35 @@
 import { createHash } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
-import {
-  generateAutoMergeYml,
-  generateCiYml,
-  generateContextLintYml,
-  generateDeployYml,
-  generatePrTitleYml,
-  workflowOptsFromStack,
-} from '../../../dev-init/skills/init/lib/workflows'
-import {
-  generateCloudflareDeployYml,
-  generateDependabotAutomergeYml,
-  generateMergeOnGreenYml,
-  generateSecretScanYml,
-} from '../../../dev-init/skills/init/lib/workflows-fleet'
+import { dirname, join } from 'node:path'
+import { tryResolveDevInitEntry } from '../init/init'
 import type { Check, StackInfo } from './doctor-shared'
 import { readStackYml } from './doctor-shared'
+
+type WorkflowsLib = typeof import('../../../dev-init/skills/init/lib/workflows')
+type WorkflowsFleetLib = typeof import('../../../dev-init/skills/init/lib/workflows-fleet')
+
+type LoadResult = { ok: true; workflows: WorkflowsLib; fleet: WorkflowsFleetLib } | { ok: false; detail: string }
+
+/**
+ * The generators live in dev-init, whose cache dir is a commit SHA — no static relative path
+ * can reach it from dev-core, so they are resolved and imported at call time.
+ * Absent dev-init is a supported state: /checkup must degrade, not fail to load.
+ */
+async function loadGenerators(): Promise<LoadResult> {
+  const entry = tryResolveDevInitEntry()
+  if (!entry) {
+    return { ok: false, detail: 'dev-init plugin not installed — workflow generators unavailable, drift not compared' }
+  }
+  const lib = join(dirname(entry), 'lib')
+  try {
+    const workflows = (await import(join(lib, 'workflows.ts'))) as WorkflowsLib
+    const fleet = (await import(join(lib, 'workflows-fleet.ts'))) as WorkflowsFleetLib
+    return { ok: true, workflows, fleet }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { ok: false, detail: `dev-init workflow generators failed to load — ${msg}` }
+  }
+}
 
 function normalizeYml(s: string): string {
   return s.replace(/\r\n/g, '\n').trim()
@@ -33,7 +46,26 @@ function detectMergeStrategy(stackMerge: StackInfo['mergeStrategy']): 'auto-merg
 }
 
 /** P3 #318 — compare on-disk workflows vs generator output for this stack.yml. */
-export function checkWorkflowDrift(): Check[] {
+export async function checkWorkflowDrift(): Promise<Check[]> {
+  const generators = await loadGenerators()
+  if (!generators.ok) {
+    return [{ name: 'drift', status: 'skip', detail: generators.detail }]
+  }
+  const {
+    generateAutoMergeYml,
+    generateCiYml,
+    generateContextLintYml,
+    generateDeployYml,
+    generatePrTitleYml,
+    workflowOptsFromStack,
+  } = generators.workflows
+  const {
+    generateCloudflareDeployYml,
+    generateDependabotAutomergeYml,
+    generateMergeOnGreenYml,
+    generateSecretScanYml,
+  } = generators.fleet
+
   const stack = readStackYml()
   const opts = workflowOptsFromStack({
     runtime: stack.runtime ?? undefined,

--- a/plugins/dev-core/skills/ci-setup/cookbooks/scanning.md
+++ b/plugins/dev-core/skills/ci-setup/cookbooks/scanning.md
@@ -59,14 +59,32 @@ skip → D⏭("TruffleHog").
 
 ## Phase 1c — Dependabot
 
+**Owner:** the workflows generator (`bun $I_TS workflows`) writes the full file (ecosystem + github-actions). This phase **verifies / tops up** — never treat path existence alone as complete.
+
 Ask: **Set up Dependabot** | **Skip**.
 yes:
-1. Auto-detect ecosystem from σ `package_manager`: `uv`/`pip` → `pip` | `bun`/`npm`/`pnpm`/`yarn` → `npm`. Unknown → Ask: **pip**|**npm**|**Skip**.
-2. Generate `.github/dependabot.yml` (github-actions block always included; 72h cooldown on fleet):
+1. Auto-detect ecosystem from σ `package_manager` / `runtime`: `uv`/`pip`/`python` → `pip` | `bun`/`npm`/`pnpm`/`yarn`/`node` → `npm`. Unknown → Ask: **pip**|**npm**|**Skip**.
+2. Check content (not just path):
+   ```bash
+   test -f .github/dependabot.yml && \
+     grep -q 'package-ecosystem: github-actions' .github/dependabot.yml && \
+     grep -qE 'package-ecosystem: (npm|pip)' .github/dependabot.yml \
+     && echo complete || echo incomplete
+   ```
+   - **complete** → D("Dependabot", "✅ Already complete (ecosystem + github-actions)"), skip write.
+   - **incomplete / missing** → re-run generator (preferred) so SSOT stays single:
+     ```bash
+     # Prefer generator (same stack as Phase 1). --force only if intentional overwrite.
+     bun $I_TS workflows --owner <owner> --repo <repo> \
+       --stack <stack> --test <test> --deploy <deploy> \
+       --merge <merge> --e2e <e2e> --lint <lint> --typecheck <typecheck> \
+       --force   # only when topping up a partial dependabot.yml; review other workflow diffs first
+     ```
+     Or write the fleet shape locally when offline (must match `generateDependabotYml`):
    ```yaml
    version: 2
    updates:
-     - package-ecosystem: <ecosystem>
+     - package-ecosystem: <ecosystem>   # npm | pip
        directory: /
        schedule:
          interval: weekly
@@ -74,7 +92,9 @@ yes:
        open-pull-requests-limit: 10
        groups:
          minor-and-patch:
-           update-types: [minor, patch]
+           update-types:
+             - minor
+             - patch
        labels:
          - dependencies
 
@@ -85,15 +105,14 @@ yes:
          day: monday
        open-pull-requests-limit: 5
        cooldown:
-         default-days: 3
-         semver-major-days: 3
-         semver-minor-days: 3
-         semver-patch-days: 3
+         default-days: 3   # semver-*-days rejected by GitHub for github-actions
        labels:
          - dependencies
          - ci
    ```
 3. `dependabot-automerge.yml` is pushed by `bun $I_TS workflows` (labels patch/minor dependabot PRs `reviewed`; semver-major excluded).
-4. D("Dependabot", "✅ .github/dependabot.yml created (<ecosystem> + github-actions)").
+4. D("Dependabot", "✅ .github/dependabot.yml created/topped-up (<ecosystem> + github-actions)").
 
 skip → D⏭("Dependabot").
+
+Note: bun → Dependabot `npm` ecosystem (fleet convention). Lockfile support for `bun.lock` is GitHub-side — not re-verified here.

--- a/plugins/dev-core/skills/ci-setup/cookbooks/workflows.md
+++ b/plugins/dev-core/skills/ci-setup/cookbooks/workflows.md
@@ -28,7 +28,11 @@ Standard set: `ci.yml`, `secret-scan.yml`, `dependabot-automerge.yml`, `pr-title
 
 3. Auto-detect from σ:
    - `stack` ← `runtime`
-   - `test` ← `commands.test` (vitest→vitest, jest→jest, pytest→pytest, else→none)
+   - `test` ← `testing.unit` first (vitest|jest|pytest|bun|none); if unset, classify `commands.test`:
+     - contains `vitest` → vitest | `jest` → jest | `pytest` → pytest
+     - `bun test` (not `bun run test`) → bun | `bun run test` → vitest (package script convention)
+     - else non-empty command → vitest | empty → none
+   - `test-command` ← `commands.test` verbatim (emitted as CI `run:` when set — do not re-derive)
    - `deploy` ← `deploy.platform` (`vercel` | `cloudflare` for `cloudflare*` | `none`)
    - `lint` ← `commands.lint` present → `true`, else `false`
    - `typecheck` ← `commands.typecheck` present → `true`, else `false`
@@ -38,7 +42,7 @@ Standard set: `ci.yml`, `secret-scan.yml`, `dependabot-automerge.yml`, `pr-title
 
 5. yes:
    - Ask stack (pre-select detected): **Bun** | **Node** | **Python (uv)**
-   - Ask test (pre-select): **Vitest** | **Jest** | **Pytest** | **None**
+   - Ask test (pre-select): **Vitest** | **Jest** | **Pytest** | **Bun** (native bun:test) | **None**
    - Ask deploy (pre-select): **Vercel** | **Cloudflare** | **None**
    - **Merge strategy** — detect native auto-merge availability:
      ```bash
@@ -53,7 +57,8 @@ Standard set: `ci.yml`, `secret-scan.yml`, `dependabot-automerge.yml`, `pr-title
        --stack <stack> --test <test> --deploy <deploy> \
        --merge <auto-merge|merge-on-green> \
        --e2e <playwright|none> \
-       --lint <true|false> --typecheck <true|false>
+       --lint <true|false> --typecheck <true|false> \
+       --test-command "<commands.test from σ, if set>"
      ```
      > **Top-up par défaut** : les fichiers déjà présents sur le repo sont **skippés** — les repos font évoluer leur `ci.yml` bien au-delà du template (multi-job, e2e, etc.). Ajouter `--force` UNIQUEMENT pour régénérer volontairement, après diff explicite des fichiers qui seraient écrasés.
    - **App token provisioning** (always — PAT mode retired):

--- a/plugins/dev-core/skills/env-setup/SKILL.md
+++ b/plugins/dev-core/skills/env-setup/SKILL.md
@@ -134,19 +134,26 @@ Generate governance rules (dev process, decision protocol, git conventions, etc.
 σ ∄ → D("Critical Rules", "⏭ Skipped — requires stack.yml"), skip to Phase 3.
 
 1. Run: `bun $I_TS scaffold-rules --stack-path .claude/stack.yml --claude-md CLAUDE.md`
-2. Parse JSON → extract `projectType`, `sections`, `markdown`, `existing`.
+2. Parse JSON → extract `projectType`, `sections`, `markdown`, `existing`, `facts`.
 3. Display:
    ```
    Project type: {projectType}
-   Sections to scaffold: {sections.length} ({section ids joined by ", "})
+   Repo facts:   baseBranch={facts.baseBranch}  pm={facts.packageManager}  .env.example={facts.hasEnvExample}
+   Parent CLAUDE.md: {existing.parentPaths joined | "none"}
+   Parent @imports:  {existing.parentImports joined | "none"}  ← machine-local; not auto-skip authority
+   Local sections:   {existing.sectionIds or "none"}
+   Sections to scaffold: {sections.length} ({section ids})
    ```
-4. Check `existing.sectionIds`:
-   - ∅ existing → Ask: **Scaffold Critical Rules** (append to CLAUDE.md) | **Skip**
-   - partial (some present, some missing) → list missing; Ask: **Merge** (append missing only) | **Replace** (rewrite all) | **Skip**
-   - all present → D("Critical Rules", "✅ Already complete"), skip.
-5. Scaffold/Replace → append or replace `## Critical Rules` block with `markdown`. Preserve content before and after.
-6. Merge → ∀ section ∈ generated ∧ section.id ∉ existing.sectionIds → append after last existing Critical Rules heading.
-7. D("Critical Rules", "✅ Scaffolded ({sections.length} sections for {projectType})")
+   > Parent context is **reporting only**. Silent auto-skip is forbidden — parent/ssot paths are often machine-local; committed CLAUDE.md must stay portable for clones without that parent.
+4. Present choice (always a gate — user is the gate):
+   - **Scaffold full** — all generated sections (portable governance for any clone)
+   - **Scaffold project-local only** — tldr + artifact-model + coding-standards + gotchas (when parent already loads fleet rules)
+   - **Merge** — append only section ids missing from `existing.sectionIds` (local titles only)
+   - **Skip**
+   When `existing.sectionIds` already covers all expected → still show table; default bias **Skip** / already complete.
+5. Scaffold full / project-local / Replace → write `markdown` (for project-local: filter sections to ids ∈ {tldr, artifact-model, coding-standards, gotchas}, renumber). Preserve content before/after `## Critical Rules` if present.
+6. Merge → ∀ section ∈ chosen set ∧ section.id ∉ existing.sectionIds → append after last existing Critical Rules heading.
+7. D("Critical Rules", "✅ Scaffolded ({N} sections for {projectType}, base={facts.baseBranch})")
 
 ## Phase 3 — Documentation Scaffolding (Optional)
 

--- a/plugins/dev-core/skills/init/__tests__/init-shim.test.ts
+++ b/plugins/dev-core/skills/init/__tests__/init-shim.test.ts
@@ -1,0 +1,58 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveDevInitEntry } from '../init'
+
+describe('resolveDevInitEntry', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'init-shim-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  function writeEntry(dir: string) {
+    const entry = join(dir, 'skills', 'init', 'init.ts')
+    mkdirSync(join(dir, 'skills', 'init'), { recursive: true })
+    writeFileSync(entry, '// stub\n')
+    return entry
+  }
+
+  it('prefers flat sibling over versioned cache', () => {
+    const mp = join(tmp, 'plugins')
+    const flat = writeEntry(join(mp, 'dev-init'))
+    const cacheInit = join(tmp, 'cache', 'roxabi-marketplace', 'dev-init', 'oldhash')
+    writeEntry(cacheInit)
+    const root = join(mp, 'dev-core')
+    mkdirSync(root, { recursive: true })
+
+    expect(resolveDevInitEntry(root)).toBe(flat)
+  })
+
+  it('resolves versioned cache when flat sibling missing', () => {
+    const cacheRoot = join(tmp, 'cache', 'roxabi-marketplace')
+    const versionDir = join(cacheRoot, 'dev-init', 'abc123')
+    const entry = writeEntry(versionDir)
+    const root = join(cacheRoot, 'dev-core', '0.8.16')
+    mkdirSync(root, { recursive: true })
+
+    expect(resolveDevInitEntry(root)).toBe(entry)
+  })
+
+  it('skips orphaned version dirs', () => {
+    const cacheRoot = join(tmp, 'cache', 'roxabi-marketplace')
+    const orphaned = join(cacheRoot, 'dev-init', 'old')
+    writeEntry(orphaned)
+    writeFileSync(join(orphaned, '.orphaned_at'), '1')
+    const good = join(cacheRoot, 'dev-init', 'new')
+    const entry = writeEntry(good)
+    const root = join(cacheRoot, 'dev-core', '0.8.16')
+    mkdirSync(root, { recursive: true })
+
+    expect(resolveDevInitEntry(root)).toBe(entry)
+  })
+})

--- a/plugins/dev-core/skills/init/__tests__/init-shim.test.ts
+++ b/plugins/dev-core/skills/init/__tests__/init-shim.test.ts
@@ -1,17 +1,23 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { resolveDevInitEntry } from '../init'
+import { resolveDevInitEntry, tryResolveDevInitEntry } from '../init'
 
 describe('resolveDevInitEntry', () => {
   let tmp: string
+  let prevHome: string | undefined
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), 'init-shim-'))
+    // Keep the ~/.claude cache fallback out of resolution — the real one exists on dev machines.
+    prevHome = process.env.HOME
+    process.env.HOME = tmp
   })
 
   afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
     rmSync(tmp, { recursive: true, force: true })
   })
 
@@ -20,6 +26,10 @@ describe('resolveDevInitEntry', () => {
     mkdirSync(join(dir, 'skills', 'init'), { recursive: true })
     writeFileSync(entry, '// stub\n')
     return entry
+  }
+
+  function setMtime(dir: string, epochSeconds: number) {
+    utimesSync(dir, epochSeconds, epochSeconds)
   }
 
   it('prefers flat sibling over versioned cache', () => {
@@ -43,16 +53,30 @@ describe('resolveDevInitEntry', () => {
     expect(resolveDevInitEntry(root)).toBe(entry)
   })
 
-  it('skips orphaned version dirs', () => {
+  it('skips orphaned version dirs even when they are the newest', () => {
     const cacheRoot = join(tmp, 'cache', 'roxabi-marketplace')
-    const orphaned = join(cacheRoot, 'dev-init', 'old')
+    const good = join(cacheRoot, 'dev-init', 'good')
+    const entry = writeEntry(good)
+    const orphaned = join(cacheRoot, 'dev-init', 'orphaned')
     writeEntry(orphaned)
     writeFileSync(join(orphaned, '.orphaned_at'), '1')
-    const good = join(cacheRoot, 'dev-init', 'new')
-    const entry = writeEntry(good)
+    // Orphaned wins on newest-mtime, so only the .orphaned_at guard can exclude it.
+    setMtime(good, 1_000)
+    setMtime(orphaned, 2_000)
     const root = join(cacheRoot, 'dev-core', '0.8.16')
     mkdirSync(root, { recursive: true })
 
     expect(resolveDevInitEntry(root)).toBe(entry)
+  })
+
+  it('returns null when the only version dir is orphaned', () => {
+    const cacheRoot = join(tmp, 'cache', 'roxabi-marketplace')
+    const orphaned = join(cacheRoot, 'dev-init', 'orphaned')
+    writeEntry(orphaned)
+    writeFileSync(join(orphaned, '.orphaned_at'), '1')
+    const root = join(cacheRoot, 'dev-core', '0.8.16')
+    mkdirSync(root, { recursive: true })
+
+    expect(tryResolveDevInitEntry(root)).toBeNull()
   })
 })

--- a/plugins/dev-core/skills/init/init.ts
+++ b/plugins/dev-core/skills/init/init.ts
@@ -7,10 +7,13 @@
  *   1. Flat siblings — marketplace clone, repo plugins/, --plugin-dir
  *   2. Versioned cache — ~/.claude/plugins/cache/<mp>/dev-init/<ver>/…
  *      skips dirs with .orphaned_at; picks newest mtime (mirrors scaffold SHIM_CONTENT)
+ *
+ * tryResolveDevInitEntry() is the reusable core; resolveDevInitEntry() is the CLI wrapper that exits.
  */
 import { existsSync, readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const ENTRY = join('skills', 'init', 'init.ts')
 
@@ -52,7 +55,13 @@ function cacheBaseFromDevCoreRoot(root: string): string | null {
   return join(match[1], 'cache', match[2], 'dev-init')
 }
 
-export function resolveDevInitEntry(root = process.env.CLAUDE_PLUGIN_ROOT ?? join(import.meta.dir, '../..')): string {
+/** Default dev-core plugin root: import.meta.url so the resolver also works off the Bun runtime. */
+function defaultRoot(): string {
+  return process.env.CLAUDE_PLUGIN_ROOT ?? join(dirname(fileURLToPath(import.meta.url)), '../..')
+}
+
+/** Non-exiting resolver — importable by non-CLI callers (e.g. /checkup) that must degrade, not die. */
+export function tryResolveDevInitEntry(root: string = defaultRoot()): string | null {
   // 1. Flat siblings first — --plugin-dir / marketplace / monorepo source
   const flat = [join(dirname(root), 'dev-init', ENTRY), join(root, '..', 'dev-init', ENTRY)]
   for (const candidate of flat) {
@@ -72,6 +81,13 @@ export function resolveDevInitEntry(root = process.env.CLAUDE_PLUGIN_ROOT ?? joi
     const hit = resolveVersionedCache(base)
     if (hit) return hit
   }
+
+  return null
+}
+
+export function resolveDevInitEntry(root?: string): string {
+  const entry = tryResolveDevInitEntry(root ?? defaultRoot())
+  if (entry) return entry
 
   console.error(
     'dev-init plugin not found — install dev-init from roxabi-marketplace (sibling of dev-core). Cache layout is version-scoped: …/dev-init/<version>/skills/init/init.ts',

--- a/plugins/dev-core/skills/init/init.ts
+++ b/plugins/dev-core/skills/init/init.ts
@@ -2,27 +2,90 @@
 /**
  * dev-core shim — delegates to dev-init init CLI.
  * Resolves ${CLAUDE_PLUGIN_ROOT}/skills/init/init.ts when dev-core is the active plugin root.
+ *
+ * Resolution order (source-of-truth first):
+ *   1. Flat siblings — marketplace clone, repo plugins/, --plugin-dir
+ *   2. Versioned cache — ~/.claude/plugins/cache/<mp>/dev-init/<ver>/…
+ *      skips dirs with .orphaned_at; picks newest mtime (mirrors scaffold SHIM_CONTENT)
  */
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
-function resolveDevInitEntry(): string {
-  const root = process.env.CLAUDE_PLUGIN_ROOT ?? join(import.meta.dir, '../..')
-  const candidates = [
-    join(dirname(root), 'dev-init', 'skills', 'init', 'init.ts'),
-    join(root, '..', 'dev-init', 'skills', 'init', 'init.ts'),
-  ]
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate
+const ENTRY = join('skills', 'init', 'init.ts')
+
+function isEntry(path: string): boolean {
+  return existsSync(path)
+}
+
+/** Newest non-orphaned version dir under cacheBase that contains ENTRY. */
+function resolveVersionedCache(cacheBase: string): string | null {
+  if (!existsSync(cacheBase)) return null
+  let best: { path: string; mtime: number } | null = null
+  for (const name of readdirSync(cacheBase)) {
+    if (name.startsWith('.')) continue
+    const versionDir = join(cacheBase, name)
+    try {
+      if (!statSync(versionDir).isDirectory()) continue
+    } catch {
+      continue
+    }
+    if (existsSync(join(versionDir, '.orphaned_at'))) continue
+    const entry = join(versionDir, ENTRY)
+    if (!isEntry(entry)) continue
+    let mtime = 0
+    try {
+      mtime = statSync(versionDir).mtimeMs
+    } catch {
+      continue
+    }
+    if (!best || mtime > best.mtime) best = { path: entry, mtime }
   }
-  console.error('dev-init plugin not found — install dev-init from roxabi-marketplace (sibling of dev-core).')
+  return best?.path ?? null
+}
+
+/** Derive …/cache/<mp>/dev-init from …/cache/<mp>/dev-core/<ver>. */
+function cacheBaseFromDevCoreRoot(root: string): string | null {
+  const normalized = root.replace(/\\/g, '/')
+  const match = normalized.match(/^(.*)\/cache\/([^/]+)\/dev-core\/[^/]+\/?$/)
+  if (!match) return null
+  return join(match[1], 'cache', match[2], 'dev-init')
+}
+
+export function resolveDevInitEntry(root = process.env.CLAUDE_PLUGIN_ROOT ?? join(import.meta.dir, '../..')): string {
+  // 1. Flat siblings first — --plugin-dir / marketplace / monorepo source
+  const flat = [join(dirname(root), 'dev-init', ENTRY), join(root, '..', 'dev-init', ENTRY)]
+  for (const candidate of flat) {
+    if (isEntry(candidate)) return candidate
+  }
+
+  // 2. Versioned plugin cache
+  const derived = cacheBaseFromDevCoreRoot(root)
+  const bases = [
+    ...(derived ? [derived] : []),
+    join(homedir(), '.claude', 'plugins', 'cache', 'roxabi-marketplace', 'dev-init'),
+  ]
+  const seen = new Set<string>()
+  for (const base of bases) {
+    if (seen.has(base)) continue
+    seen.add(base)
+    const hit = resolveVersionedCache(base)
+    if (hit) return hit
+  }
+
+  console.error(
+    'dev-init plugin not found — install dev-init from roxabi-marketplace (sibling of dev-core). Cache layout is version-scoped: …/dev-init/<version>/skills/init/init.ts',
+  )
   process.exit(1)
 }
 
-const target = resolveDevInitEntry()
-const proc = Bun.spawnSync(['bun', target, ...process.argv.slice(2)], {
-  stdin: 'inherit',
-  stdout: 'inherit',
-  stderr: 'inherit',
-})
-process.exit(proc.exitCode ?? 1)
+// Only run when executed as CLI (not when imported by tests)
+if (import.meta.main) {
+  const target = resolveDevInitEntry()
+  const proc = Bun.spawnSync(['bun', target, ...process.argv.slice(2)], {
+    stdin: 'inherit',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  process.exit(proc.exitCode ?? 1)
+}

--- a/plugins/dev-core/skills/shared/__tests__/parse-stack-yml.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/parse-stack-yml.test.ts
@@ -14,6 +14,7 @@ const { parseStackYml } = require('../../../hooks/lib/parse-stack-yml.cjs') as {
     standards: Record<string, string> | null
     runtime: string | null
     commands: { lint: string | null; typecheck: string | null; test: string | null }
+    testingUnit: string | null
     testingE2e: string | null
     ciMerge: string | null
   }
@@ -75,8 +76,20 @@ describe('parseStackYml — edge cases', () => {
     expect(result.standards).toBeNull()
     expect(result.runtime).toBeNull()
     expect(result.commands).toEqual({ lint: null, typecheck: null, test: null })
+    expect(result.testingUnit).toBeNull()
     expect(result.testingE2e).toBeNull()
     expect(result.ciMerge).toBeNull()
+  })
+
+  it('parses testing.unit', () => {
+    const result = parseStackYml(`
+runtime: bun
+testing:
+  unit: bun
+  e2e: none
+`)
+    expect(result.testingUnit).toBe('bun')
+    expect(result.testingE2e).toBeNull()
   })
 
   it('parses runtime, commands, testing.e2e, and ci.merge', () => {

--- a/plugins/dev-core/stack.yml.example
+++ b/plugins/dev-core/stack.yml.example
@@ -47,7 +47,7 @@ build:
   #     ext: [".py"]
 
 testing:
-  unit: vitest                    # vitest | jest | pytest | none
+  unit: vitest                    # vitest | jest | pytest | bun | none  (bun = native bun:test runner)
   e2e: playwright                 # playwright | cypress | none
 
 hooks:

--- a/plugins/dev-init/skills/init/__tests__/scaffold-rules.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/scaffold-rules.test.ts
@@ -433,6 +433,86 @@ Commit rules
       expect(result.existing.hasImport).toBe(false)
       expect(result.existing.sectionIds).toEqual([])
     })
+
+    it('reports parent CLAUDE.md and @imports without using them as skip authority', () => {
+      const parentDir = join(tmp, 'parent')
+      const childDir = join(parentDir, 'child')
+      mkdirSync(join(childDir, '.claude'), { recursive: true })
+      writeFileSync(join(parentDir, 'CLAUDE.md'), '@ssot/operator.ssot.md\n@ssot/conventions.ssot.md\n')
+      writeFileSync(join(childDir, '.claude', 'stack.yml'), 'runtime: bun\npackage_manager: bun\n')
+      writeFileSync(join(childDir, 'CLAUDE.md'), '@.claude/stack.yml\n')
+
+      const result = scaffoldRules({
+        stackPath: join(childDir, '.claude', 'stack.yml'),
+        claudeMdPath: join(childDir, 'CLAUDE.md'),
+        projectName: 'child',
+      })
+
+      expect(
+        result.existing.parentPaths.some((p) => p.endsWith('parent/CLAUDE.md') || p.endsWith('parent\\CLAUDE.md')),
+      ).toBe(true)
+      expect(result.existing.parentImports).toEqual(
+        expect.arrayContaining(['ssot/operator.ssot.md', 'ssot/conventions.ssot.md']),
+      )
+      // parent has no Critical Rules headings → local sectionIds still empty of parent noise
+      expect(result.existing.sectionIds).toEqual([])
+    })
+  })
+
+  describe('repo facts', () => {
+    it('uses package_manager from stack for install command', () => {
+      writeStack(`
+runtime: bun
+package_manager: pnpm
+backend:
+  framework: nestjs
+frontend:
+  framework: nextjs
+`)
+      const result = scaffoldRules({
+        stackPath: join(tmp, '.claude', 'stack.yml'),
+        claudeMdPath: join(tmp, 'CLAUDE.md'),
+        projectName: 'app',
+      })
+      expect(result.facts.packageManager).toBe('pnpm')
+      expect(result.markdown).toContain('pnpm install')
+      expect(result.markdown).not.toContain('bun install')
+    })
+
+    it('omits cp .env.example when file is absent', () => {
+      writeStack(`
+runtime: bun
+backend:
+  framework: nestjs
+frontend:
+  framework: nextjs
+`)
+      const result = scaffoldRules({
+        stackPath: join(tmp, '.claude', 'stack.yml'),
+        claudeMdPath: join(tmp, 'CLAUDE.md'),
+        projectName: 'app',
+      })
+      expect(result.facts.hasEnvExample).toBe(false)
+      expect(result.markdown).not.toContain('cp .env.example')
+    })
+
+    it('includes cp .env.example when present', () => {
+      writeStack(`
+runtime: bun
+backend:
+  framework: nestjs
+frontend:
+  framework: nextjs
+`)
+      writeFileSync(join(tmp, '.env.example'), 'FOO=1\n')
+      const result = scaffoldRules({
+        stackPath: join(tmp, '.claude', 'stack.yml'),
+        claudeMdPath: join(tmp, 'CLAUDE.md'),
+        projectName: 'app',
+      })
+      expect(result.facts.hasEnvExample).toBe(true)
+      expect(result.markdown).toContain('cp .env.example .env')
+    })
   })
 
   describe('expectedSections', () => {

--- a/plugins/dev-init/skills/init/__tests__/workflows.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/workflows.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ACTION_PINS } from '../lib/workflow-pins'
 import {
   classifyTestRunner,
@@ -7,6 +10,7 @@ import {
   generateContextLintYml,
   generateDeployYml,
   workflowOptsFromStack,
+  writeWorkflows,
 } from '../lib/workflows'
 import {
   generateDependabotAutomergeYml,
@@ -207,6 +211,71 @@ describe('generateDeployYml', () => {
   it('has workflow_dispatch trigger', () => {
     const yml = generateDeployYml({ stack: 'bun', test: 'none', deploy: 'none' })
     expect(yml).toContain('workflow_dispatch')
+  })
+})
+
+describe('writeWorkflows', () => {
+  // writeWorkflows writes under the cwd — every case runs in a throwaway dir so the
+  // repo's own .github/ can never be touched.
+  const opts = { stack: 'bun', test: 'vitest', deploy: 'none' } as const
+  let tmp: string
+  let origCwd: string
+
+  beforeEach(() => {
+    origCwd = process.cwd()
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'write-workflows-'))
+    process.chdir(tmp)
+  })
+
+  afterEach(() => {
+    process.chdir(origCwd)
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('does not clobber existing files by default (top-up)', async () => {
+    fs.mkdirSync('.github/workflows', { recursive: true })
+    fs.writeFileSync('.github/workflows/ci.yml', 'sentinel-ci')
+    fs.writeFileSync('.github/dependabot.yml', 'sentinel-dependabot')
+
+    const results = await writeWorkflows(opts)
+
+    expect(fs.readFileSync('.github/workflows/ci.yml', 'utf8')).toBe('sentinel-ci')
+    expect(fs.readFileSync('.github/dependabot.yml', 'utf8')).toBe('sentinel-dependabot')
+    expect(results).toContainEqual({ file: 'ci.yml', status: 'skipped' })
+    expect(results).toContainEqual({ file: 'dependabot.yml', status: 'skipped' })
+    // absent files are still topped up
+    expect(results).toContainEqual({ file: 'auto-merge.yml', status: 'created' })
+    expect(fs.readFileSync('.github/workflows/auto-merge.yml', 'utf8')).toContain('name: Auto Merge')
+  })
+
+  it('overwrites existing files with force', async () => {
+    fs.mkdirSync('.github/workflows', { recursive: true })
+    fs.writeFileSync('.github/workflows/ci.yml', 'sentinel-ci')
+    fs.writeFileSync('.github/dependabot.yml', 'sentinel-dependabot')
+
+    const results = await writeWorkflows(opts, true)
+
+    expect(fs.readFileSync('.github/workflows/ci.yml', 'utf8')).toContain('name: CI')
+    expect(fs.readFileSync('.github/dependabot.yml', 'utf8')).toContain('package-ecosystem: npm')
+    expect(results).toContainEqual({ file: 'ci.yml', status: 'updated' })
+    expect(results).toContainEqual({ file: 'dependabot.yml', status: 'updated' })
+  })
+
+  it('reports dependabot.yml alongside the workflows it writes', async () => {
+    const results = await writeWorkflows(opts)
+
+    expect(results).toContainEqual({ file: 'dependabot.yml', status: 'created' })
+    expect(fs.existsSync('.github/dependabot.yml')).toBe(true)
+    // every file touched on disk appears in the report — no silent writes
+    const reported = results.map((r) => r.file).sort()
+    const onDisk = [...fs.readdirSync('.github/workflows'), 'dependabot.yml'].sort()
+    expect(reported).toEqual(onDisk)
+  })
+
+  it('reports the deploy workflow for a cloudflare stack', async () => {
+    const results = await writeWorkflows({ stack: 'bun', test: 'vitest', deploy: 'cloudflare' })
+
+    expect(results).toContainEqual({ file: 'deploy-cloudflare.yml', status: 'created' })
   })
 })
 

--- a/plugins/dev-init/skills/init/__tests__/workflows.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/workflows.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import { ACTION_PINS } from '../lib/workflow-pins'
-import { generateAutoMergeYml, generateCiYml, generateContextLintYml, generateDeployYml } from '../lib/workflows'
-import { generateDependabotAutomergeYml, generateMergeOnGreenYml, generateSecretScanYml } from '../lib/workflows-fleet'
+import {
+  classifyTestRunner,
+  generateAutoMergeYml,
+  generateCiYml,
+  generateContextLintYml,
+  generateDeployYml,
+  workflowOptsFromStack,
+} from '../lib/workflows'
+import {
+  generateDependabotAutomergeYml,
+  generateDependabotYml,
+  generateMergeOnGreenYml,
+  generateSecretScanYml,
+} from '../lib/workflows-fleet'
 
 describe('generateAutoMergeYml', () => {
   it('emits the App token mint step (no secrets.PAT)', () => {
@@ -51,9 +63,24 @@ describe('generateCiYml', () => {
     expect(yml).not.toContain('bun typecheck')
   })
 
-  it('uses the native bun runner for non-vitest bun stacks', () => {
+  it('uses bun run test for bun/jest stacks (package-script convention)', () => {
     const yml = generateCiYml({ stack: 'bun', test: 'jest', deploy: 'none' })
-    expect(yml).toContain('run: bun test')
+    expect(yml).toContain('run: bun run test')
+  })
+
+  it('emits bun runner via --test bun as bun run test by default', () => {
+    const yml = generateCiYml({ stack: 'bun', test: 'bun', deploy: 'none' })
+    expect(yml).toContain('run: bun run test')
+  })
+
+  it('emits verbatim testCommand when set', () => {
+    const yml = generateCiYml({
+      stack: 'bun',
+      test: 'bun',
+      testCommand: 'bun test packages/shared',
+      deploy: 'none',
+    })
+    expect(yml).toContain('run: bun test packages/shared')
   })
 
   it('generates node + jest CI with SHA-pinned setup-node', () => {
@@ -65,10 +92,10 @@ describe('generateCiYml', () => {
     expect(yml).toContain('npm test')
   })
 
-  it('omits test step when test is "none"', () => {
+  it('omits test step and comments when test is "none"', () => {
     const yml = generateCiYml({ stack: 'bun', test: 'none', deploy: 'none' })
-    expect(yml).not.toContain('bun test')
     expect(yml).not.toMatch(/- name: Test/)
+    expect(yml).toContain('test: none — no unit test step')
   })
 
   it('includes optional e2e job when e2e is playwright', () => {
@@ -109,6 +136,52 @@ describe('generateDependabotAutomergeYml', () => {
     expect(yml).toContain('dependabot[bot]')
     expect(yml).toContain('semver-patch')
     expect(yml).toContain(ACTION_PINS.createAppToken)
+  })
+})
+
+describe('generateDependabotYml', () => {
+  it('emits npm + github-actions for bun stack', () => {
+    const yml = generateDependabotYml({ stack: 'bun' })
+    expect(yml).toContain('package-ecosystem: npm')
+    expect(yml).toContain('package-ecosystem: github-actions')
+    expect(yml).toContain('default-days: 3')
+    expect(yml).not.toContain('semver-major-days')
+  })
+
+  it('emits pip ecosystem for python stack', () => {
+    const yml = generateDependabotYml({ stack: 'python' })
+    expect(yml).toContain('package-ecosystem: pip')
+    expect(yml).toContain('package-ecosystem: github-actions')
+  })
+})
+
+describe('classifyTestRunner / workflowOptsFromStack', () => {
+  it('maps bun run test (canonical vitest-on-bun) to vitest, not none', () => {
+    expect(classifyTestRunner(undefined, 'bun run test')).toBe('vitest')
+    const opts = workflowOptsFromStack({
+      runtime: 'bun',
+      commands: { test: 'bun run test' },
+    })
+    expect(opts.test).toBe('vitest')
+    expect(opts.testCommand).toBe('bun run test')
+  })
+
+  it('maps testing.unit bun + bare bun test to bun', () => {
+    expect(classifyTestRunner('bun', 'bun test')).toBe('bun')
+  })
+
+  it('prefers testing.unit vitest over command text', () => {
+    expect(classifyTestRunner('vitest', 'bun run test')).toBe('vitest')
+  })
+
+  it('emits CI test step from stack with only commands.test', () => {
+    const opts = workflowOptsFromStack({
+      runtime: 'bun',
+      commands: { test: 'bun run test', lint: 'bun lint' },
+    })
+    const yml = generateCiYml(opts)
+    expect(yml).toContain('run: bun run test')
+    expect(yml).toMatch(/- name: Test/)
   })
 })
 

--- a/plugins/dev-init/skills/init/init.ts
+++ b/plugins/dev-init/skills/init/init.ts
@@ -2,20 +2,26 @@
 /**
  * Init CLI — router that delegates to subcommand modules.
  * All subcommands output JSON for the SKILL.md orchestrator to parse.
- *
- * Usage:
- *   bun init.ts prereqs [--json]
- *   bun init.ts discover [--json]
- *   bun init.ts workflows --owner <owner> --repo <repo> --stack <bun|node|python> --test <vitest|jest|pytest|bun|none> --deploy <vercel|cloudflare|none> [--merge auto-merge|merge-on-green] [--e2e playwright|none] [--lint true|false] [--typecheck true|false] [--test-command <cmd>] [--branch <branch>] [--force]
- *   bun init.ts push-workflows --owner <owner> --repo <repo> [--branch <branch>] [--force]  # generic only (auto-merge + pr-title + context-lint)
- *   bun init.ts push-context-lint --owner <owner> --repo <repo> [--branch <branch>]  # context-lint.yml only (always updates)
- *   (both default to TOP-UP: existing workflow files are skipped; --force overwrites)
- *   bun init.ts protect-branches --repo <owner/repo>
- *   bun init.ts scaffold-rules [--stack-path .claude/stack.yml] [--project-name <name>] [--claude-md CLAUDE.md]
- *   bun init.ts scaffold --github-repo <owner/repo> [--vercel-token <token>] [--vercel-project-id <id>] [--vercel-team-id <id>] [--force]
- *   bun init.ts scaffold-fumadocs [--root <path>] [--docs-path <path>]
- *   bun init.ts scaffold-fumadocs-vercel [--root <path>] [--orchestrator <turbo|none>]
+ * `bun init.ts --help` prints USAGE.
  */
+
+const USAGE = `Init CLI — router that delegates to subcommand modules.
+
+Usage:
+  bun init.ts prereqs [--json]
+  bun init.ts discover [--json]
+  bun init.ts workflows (--owner <owner> --repo <repo> | --local) --stack <bun|node|python> --test <vitest|jest|pytest|bun|none> --deploy <vercel|cloudflare|none> [--merge auto-merge|merge-on-green] [--e2e playwright|none] [--lint true|false] [--typecheck true|false] [--test-command <cmd>] [--branch <branch>] [--force]
+      --owner + --repo push via the GitHub REST API; --local writes into ./.github instead
+      (offline use — no gh auth, no remote). The two are mutually exclusive.
+  bun init.ts push-workflows --owner <owner> --repo <repo> [--branch <branch>] [--force]  # generic only (auto-merge + pr-title + context-lint)
+  bun init.ts push-context-lint --owner <owner> --repo <repo> [--branch <branch>]  # context-lint.yml only (always updates)
+  (workflows/push-workflows default to TOP-UP: existing files are skipped; --force overwrites)
+  bun init.ts protect-branches --repo <owner/repo>
+  bun init.ts scaffold-docs [--format md|mdx] [--path docs]
+  bun init.ts scaffold-rules [--stack-path .claude/stack.yml] [--project-name <name>] [--claude-md CLAUDE.md]
+  bun init.ts scaffold --github-repo <owner/repo> [--vercel-token <token>] [--vercel-project-id <id>] [--vercel-team-id <id>] [--force]
+  bun init.ts scaffold-fumadocs [--root <path>] [--docs-path <path>]
+  bun init.ts scaffold-fumadocs-vercel [--root <path>] [--orchestrator <turbo|none>]`
 
 const args = process.argv.slice(2)
 const command = args[0] ?? 'prereqs'
@@ -29,6 +35,11 @@ function parseFlag(flag: string, fallback: string): string {
 
 function hasFlag(flag: string): boolean {
   return rest.includes(flag)
+}
+
+if (command === '--help' || command === '-h' || hasFlag('--help') || hasFlag('-h')) {
+  console.log(USAGE)
+  process.exit(0)
 }
 
 switch (command) {
@@ -58,7 +69,8 @@ switch (command) {
     const e2e = parseFlag('--e2e', 'none') as 'playwright' | 'none'
     const lint = parseFlag('--lint', 'true') === 'true'
     const typecheck = parseFlag('--typecheck', 'true') === 'true'
-    const force = process.argv.includes('--force')
+    const force = hasFlag('--force')
+    const local = hasFlag('--local')
     const opts = {
       stack,
       test,
@@ -69,13 +81,24 @@ switch (command) {
       lint,
       typecheck,
     }
-    if (owner && repo) {
+    // Local write is opt-in, never the fallback for missing flags — a typo'd --owner
+    // must not silently rewrite the current repo's .github/.
+    if (local && (owner || repo)) {
+      console.error('Error: --local writes to ./.github and is mutually exclusive with --owner/--repo.')
+      process.exit(1)
+    }
+    if (!local && !(owner && repo)) {
+      console.error(
+        'Usage: init.ts workflows --owner <owner> --repo <repo> [...]  (or --local to write into ./.github)',
+      )
+      process.exit(1)
+    }
+    if (local) {
+      const result = await writeWorkflows(opts, force)
+      console.log(JSON.stringify({ written: result }, null, 2))
+    } else {
       const result = await pushWorkflows(owner, repo, opts, branch, force)
       console.log(JSON.stringify({ pushed: result }, null, 2))
-    } else {
-      // fallback: local write (no owner/repo provided)
-      const result = await writeWorkflows(opts)
-      console.log(JSON.stringify({ written: result }, null, 2))
     }
     break
   }
@@ -173,8 +196,6 @@ switch (command) {
 
   default:
     console.error(`Unknown command: ${command}`)
-    console.error(
-      'Usage: init.ts [prereqs|discover|workflows|push-workflows|protect-branches|scaffold-docs|scaffold-rules|scaffold|scaffold-fumadocs|scaffold-fumadocs-vercel]',
-    )
+    console.error(USAGE)
     process.exit(1)
 }

--- a/plugins/dev-init/skills/init/init.ts
+++ b/plugins/dev-init/skills/init/init.ts
@@ -6,7 +6,7 @@
  * Usage:
  *   bun init.ts prereqs [--json]
  *   bun init.ts discover [--json]
- *   bun init.ts workflows --owner <owner> --repo <repo> --stack <bun|node|python> --test <vitest|jest|pytest|none> --deploy <vercel|cloudflare|none> [--merge auto-merge|merge-on-green] [--e2e playwright|none] [--lint true|false] [--typecheck true|false] [--branch <branch>] [--force]
+ *   bun init.ts workflows --owner <owner> --repo <repo> --stack <bun|node|python> --test <vitest|jest|pytest|bun|none> --deploy <vercel|cloudflare|none> [--merge auto-merge|merge-on-green] [--e2e playwright|none] [--lint true|false] [--typecheck true|false] [--test-command <cmd>] [--branch <branch>] [--force]
  *   bun init.ts push-workflows --owner <owner> --repo <repo> [--branch <branch>] [--force]  # generic only (auto-merge + pr-title + context-lint)
  *   bun init.ts push-context-lint --owner <owner> --repo <repo> [--branch <branch>]  # context-lint.yml only (always updates)
  *   (both default to TOP-UP: existing workflow files are skipped; --force overwrites)
@@ -51,14 +51,24 @@ switch (command) {
     const repo = parseFlag('--repo', '')
     const branch = parseFlag('--branch', 'main')
     const stack = parseFlag('--stack', 'bun') as 'bun' | 'node' | 'python'
-    const test = parseFlag('--test', 'vitest') as 'vitest' | 'jest' | 'pytest' | 'none'
+    const test = parseFlag('--test', 'vitest') as 'vitest' | 'jest' | 'pytest' | 'bun' | 'none'
+    const testCommand = parseFlag('--test-command', '')
     const deploy = parseFlag('--deploy', 'none') as 'vercel' | 'cloudflare' | 'none'
     const merge = parseFlag('--merge', 'auto-merge') as 'auto-merge' | 'merge-on-green'
     const e2e = parseFlag('--e2e', 'none') as 'playwright' | 'none'
     const lint = parseFlag('--lint', 'true') === 'true'
     const typecheck = parseFlag('--typecheck', 'true') === 'true'
     const force = process.argv.includes('--force')
-    const opts = { stack, test, deploy, merge, e2e, lint, typecheck }
+    const opts = {
+      stack,
+      test,
+      testCommand: testCommand || undefined,
+      deploy,
+      merge,
+      e2e,
+      lint,
+      typecheck,
+    }
     if (owner && repo) {
       const result = await pushWorkflows(owner, repo, opts, branch, force)
       console.log(JSON.stringify({ pushed: result }, null, 2))

--- a/plugins/dev-init/skills/init/lib/scaffold-rules.ts
+++ b/plugins/dev-init/skills/init/lib/scaffold-rules.ts
@@ -11,7 +11,8 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs'
-import { basename, resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { basename, dirname, join, resolve } from 'node:path'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -42,6 +43,14 @@ interface ScaffoldRulesResult {
   projectType: ProjectType
   sections: Section[]
   markdown: string
+}
+
+/** Repo facts used in generated snippets — never hardcode fleet defaults. */
+export interface ScaffoldFacts {
+  baseBranch: string
+  packageInstall: string
+  hasEnvExample: boolean
+  packageManager: string
 }
 
 // ---------------------------------------------------------------------------
@@ -139,17 +148,55 @@ function detectProjectName(explicit?: string): string {
   return sanitizeName(basename(process.cwd()))
 }
 
+/** Mirror of lib.sh detect_base_branch: origin/staging → main → master, else main. */
+export function detectBaseBranch(cwd = process.cwd()): string {
+  const candidates = ['staging', 'main', 'master']
+  for (const ref of candidates) {
+    for (const prefix of ['origin/', '']) {
+      const r = Bun.spawnSync(['git', 'rev-parse', '--verify', `${prefix}${ref}`], {
+        cwd,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      if (r.exitCode === 0) return ref
+    }
+  }
+  return 'main'
+}
+
+export function detectPackageInstall(stack: StackConfig): { packageManager: string; packageInstall: string } {
+  const pm = (stack.package_manager ?? stack.runtime ?? 'bun').toLowerCase()
+  if (pm === 'npm') return { packageManager: 'npm', packageInstall: 'npm install' }
+  if (pm === 'pnpm') return { packageManager: 'pnpm', packageInstall: 'pnpm install' }
+  if (pm === 'yarn') return { packageManager: 'yarn', packageInstall: 'yarn' }
+  if (pm === 'uv' || pm === 'pip' || pm === 'python')
+    return { packageManager: pm === 'python' ? 'uv' : pm, packageInstall: 'uv sync' }
+  return { packageManager: 'bun', packageInstall: 'bun install' }
+}
+
+export function detectScaffoldFacts(stack: StackConfig, cwd = process.cwd()): ScaffoldFacts {
+  const { packageManager, packageInstall } = detectPackageInstall(stack)
+  return {
+    baseBranch: detectBaseBranch(cwd),
+    packageInstall,
+    hasEnvExample: existsSync(join(cwd, '.env.example')),
+    packageManager,
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Section generators
 // ---------------------------------------------------------------------------
 
-function tldr(_stack: StackConfig, projectName: string, projectType: ProjectType): Section {
+function tldr(_stack: StackConfig, projectName: string, projectType: ProjectType, facts: ScaffoldFacts): Section {
   const parts: string[] = []
 
   parts.push(`- **Project:** ${projectName}`)
 
   if (projectType !== 'docs-content' && projectType !== 'stub') {
-    parts.push(`- **All code changes** → worktree: \`git worktree add ../${projectName}-XXX -b feat/XXX-slug staging\``)
+    parts.push(
+      `- **All code changes** → worktree: \`git worktree add ../${projectName}-XXX -b feat/XXX-slug ${facts.baseBranch}\``,
+    )
   }
 
   if (projectType === 'full-app' || projectType === 'backend-only' || projectType === 'frontend-only') {
@@ -225,14 +272,15 @@ function artifactModel(stack: StackConfig): Section {
   return { id: 'artifact-model', title: 'Artifact Model', content }
 }
 
-function mandatoryWorktree(projectName: string): Section {
+function mandatoryWorktree(projectName: string, facts: ScaffoldFacts): Section {
+  const envPart = facts.hasEnvExample ? 'cp .env.example .env && ' : ''
   const content = `\`\`\`bash
-git worktree add ../${projectName}-XXX -b feat/XXX-slug staging
-cd ../${projectName}-XXX && cp .env.example .env && bun install
+git worktree add ../${projectName}-XXX -b feat/XXX-slug ${facts.baseBranch}
+cd ../${projectName}-XXX && ${envPart}${facts.packageInstall}
 \`\`\`
 
 Worktree **mandatory** for all tiers (XS, S, F-lite, F-full) — no exceptions. Only skipped for \`/dev\` pre-implementation artifacts (frame, analysis, spec, plan) and \`/promote\` release artifacts.
-**Never code on main/staging without worktree.**`
+**Never code on main/${facts.baseBranch} without worktree.**`
 
   return { id: 'mandatory-worktree', title: 'Mandatory Worktree', content }
 }
@@ -314,17 +362,22 @@ const SECTION_MAP: Record<ProjectType, string[]> = {
 // Main generator
 // ---------------------------------------------------------------------------
 
-function generateSections(stack: StackConfig, projectType: ProjectType, projectName: string): Section[] {
+function generateSections(
+  stack: StackConfig,
+  projectType: ProjectType,
+  projectName: string,
+  facts: ScaffoldFacts,
+): Section[] {
   const sectionIds = SECTION_MAP[projectType]
 
   const generators: Record<string, () => Section> = {
-    tldr: () => tldr(stack, projectName, projectType),
+    tldr: () => tldr(stack, projectName, projectType, facts),
     'dev-process': () => devProcess(stack, projectType),
     'orchestrator-delegation': () => orchestratorDelegation(),
     'parallel-execution': () => parallelExecution(),
     git: () => gitRules(),
     'artifact-model': () => artifactModel(stack),
-    'mandatory-worktree': () => mandatoryWorktree(projectName),
+    'mandatory-worktree': () => mandatoryWorktree(projectName, facts),
     'code-review': () => codeReview(stack),
     'coding-standards': () => codingStandards(stack, projectType),
     'skills-agents': () => skillsAndAgents(),
@@ -332,6 +385,13 @@ function generateSections(stack: StackConfig, projectType: ProjectType, projectN
   }
 
   return sectionIds.map((id) => generators[id]?.()).filter((s): s is Section => s !== undefined)
+}
+
+/** Project-local subset — for users who inherit fleet governance from a parent CLAUDE.md. */
+const PROJECT_LOCAL_IDS = new Set(['tldr', 'coding-standards', 'gotchas', 'artifact-model'])
+
+export function filterProjectLocalSections(sections: Section[]): Section[] {
+  return sections.filter((s) => PROJECT_LOCAL_IDS.has(s.id))
 }
 
 function sectionsToMarkdown(sections: Section[]): string {
@@ -359,11 +419,63 @@ function sectionsToMarkdown(sections: Section[]): string {
 interface ExistingSections {
   hasImport: boolean
   sectionIds: string[]
+  /** Parent CLAUDE.md paths found walking up from the repo (until $HOME). */
+  parentPaths: string[]
+  /** First-hop @imports collected from parent CLAUDE.md files (reporting only). */
+  parentImports: string[]
+}
+
+function collectAtImports(content: string): string[] {
+  const imports: string[] = []
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const m = trimmed.match(/^@(\S+)/)
+    if (m) {
+      imports.push(m[1])
+      continue
+    }
+    // stop after leading import/comment block
+    if (!trimmed.startsWith('#')) break
+  }
+  return imports
+}
+
+/** Walk parent dirs for CLAUDE.md — signal only, never auto-skip authority. */
+export function discoverParentClaudeMd(claudeMdPath: string): {
+  parentPaths: string[]
+  parentImports: string[]
+} {
+  const parentPaths: string[] = []
+  const parentImports: string[] = []
+  const home = resolve(homedir())
+  let current = dirname(resolve(claudeMdPath))
+
+  // Start from parent of the target file's directory
+  current = dirname(current)
+  while (current && current !== '/' && current !== home) {
+    const candidate = join(current, 'CLAUDE.md')
+    if (existsSync(candidate)) {
+      parentPaths.push(candidate)
+      try {
+        parentImports.push(...collectAtImports(readFileSync(candidate, 'utf-8')))
+      } catch {
+        /* ignore */
+      }
+    }
+    const next = dirname(current)
+    if (next === current) break
+    current = next
+  }
+
+  return { parentPaths, parentImports: [...new Set(parentImports)] }
 }
 
 function analyzeExistingClaudeMd(claudeMdPath: string): ExistingSections {
+  const parents = discoverParentClaudeMd(claudeMdPath)
+
   if (!existsSync(claudeMdPath)) {
-    return { hasImport: false, sectionIds: [] }
+    return { hasImport: false, sectionIds: [], ...parents }
   }
 
   const content = readFileSync(claudeMdPath, 'utf-8')
@@ -371,7 +483,7 @@ function analyzeExistingClaudeMd(claudeMdPath: string): ExistingSections {
 
   const hasImport = lines[0]?.trim() === '@.claude/stack.yml'
 
-  // Detect which Critical Rules sections already exist
+  // Detect which Critical Rules sections already exist (local only — title match)
   const sectionPatterns: Record<string, RegExp> = {
     tldr: /^## TL;DR/i,
     'dev-process': /^###?\s*(?:\d+[.\s]*)?Dev Process/i,
@@ -395,7 +507,7 @@ function analyzeExistingClaudeMd(claudeMdPath: string): ExistingSections {
     }
   }
 
-  return { hasImport, sectionIds: found }
+  return { hasImport, sectionIds: found, ...parents }
 }
 
 // ---------------------------------------------------------------------------
@@ -410,18 +522,21 @@ export interface ScaffoldRulesOptions {
 
 export function scaffoldRules(
   options: ScaffoldRulesOptions = {},
-): ScaffoldRulesResult & { existing: ExistingSections } {
+): ScaffoldRulesResult & { existing: ExistingSections; facts: ScaffoldFacts } {
   const stackPath = resolve(options.stackPath ?? '.claude/stack.yml')
   const claudeMdPath = resolve(options.claudeMdPath ?? 'CLAUDE.md')
+  // Prefer repo root from stack.yml path: <repo>/.claude/stack.yml
+  const repoRoot = basename(dirname(stackPath)) === '.claude' ? dirname(dirname(stackPath)) : process.cwd()
 
   const stack = loadStack(stackPath)
   const projectType = detectProjectType(stack)
   const projectName = detectProjectName(options.projectName)
-  const sections = generateSections(stack, projectType, projectName)
+  const facts = detectScaffoldFacts(stack, repoRoot)
+  const sections = generateSections(stack, projectType, projectName, facts)
   const markdown = sectionsToMarkdown(sections)
   const existing = analyzeExistingClaudeMd(claudeMdPath)
 
-  return { projectType, sections, markdown, existing }
+  return { projectType, sections, markdown, existing, facts }
 }
 
 /**

--- a/plugins/dev-init/skills/init/lib/workflow-types.ts
+++ b/plugins/dev-init/skills/init/lib/workflow-types.ts
@@ -1,6 +1,10 @@
+export type WorkflowTestRunner = 'vitest' | 'jest' | 'pytest' | 'bun' | 'none'
+
 export interface WorkflowOpts {
   stack: 'bun' | 'node' | 'python'
-  test: 'vitest' | 'jest' | 'pytest' | 'none'
+  test: WorkflowTestRunner
+  /** Verbatim σ.commands.test — preferred for the CI `run:` line when set. */
+  testCommand?: string
   deploy: 'vercel' | 'cloudflare' | 'none'
   /** merge-on-green for private free-plan repos; default auto-merge */
   merge?: 'auto-merge' | 'merge-on-green'
@@ -13,6 +17,7 @@ export function normalizeWorkflowOpts(opts: WorkflowOpts): Required<WorkflowOpts
   return {
     stack: opts.stack,
     test: opts.test,
+    testCommand: opts.testCommand ?? '',
     deploy: opts.deploy,
     merge: opts.merge ?? 'auto-merge',
     e2e: opts.e2e ?? 'none',

--- a/plugins/dev-init/skills/init/lib/workflows-fleet.ts
+++ b/plugins/dev-init/skills/init/lib/workflows-fleet.ts
@@ -40,9 +40,36 @@ jobs:
 `
 }
 
-export function generateDependabotYml(): string {
+/** Map stack → Dependabot package-ecosystem (bun/node → npm; python → pip). */
+export function dependabotEcosystemFromStack(stack: WorkflowOpts['stack'] | string): 'npm' | 'pip' {
+  return stack === 'python' ? 'pip' : 'npm'
+}
+
+/**
+ * Full dependabot.yml — application ecosystem + github-actions.
+ * Generator owns this file (Phase 1); Phase 1c verifies content completeness.
+ * github-actions cooldown: default-days only (semver-*-days rejected by GitHub for gha).
+ */
+export function generateDependabotYml(
+  opts: { stack: WorkflowOpts['stack'] } | { ecosystem: 'npm' | 'pip' } = { stack: 'bun' },
+): string {
+  const ecosystem = 'ecosystem' in opts ? opts.ecosystem : dependabotEcosystemFromStack(opts.stack)
   return `version: 2
 updates:
+  - package-ecosystem: ${ecosystem}
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -51,9 +78,9 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 3
-      semver-major-days: 3
-      semver-minor-days: 3
-      semver-patch-days: 3
+    labels:
+      - dependencies
+      - ci
 `
 }
 

--- a/plugins/dev-init/skills/init/lib/workflows.ts
+++ b/plugins/dev-init/skills/init/lib/workflows.ts
@@ -287,6 +287,21 @@ export async function pushContextLintYml(
   })
 }
 
+/** Resolve the CI test `run:` command — prefer verbatim commands.test when set. */
+export function resolveTestRunCommand(opts: Required<WorkflowOpts>): string | null {
+  if (opts.test === 'none') return null
+  if (opts.testCommand) return opts.testCommand
+  if (opts.stack === 'python') return opts.test === 'pytest' ? 'uv run pytest' : 'uv run pytest'
+  if (opts.stack === 'bun') {
+    // Prefer bun run test (package script) over bare bun test — aligns with agent hook + monorepos
+    if (opts.test === 'vitest' || opts.test === 'bun' || opts.test === 'jest') return 'bun run test'
+    return 'bun run test'
+  }
+  // node
+  if (opts.test === 'jest' || opts.test === 'vitest') return 'npm test'
+  return 'npm test'
+}
+
 export function generateCiYml(opts: WorkflowOpts): string {
   const o = normalizeWorkflowOpts(opts)
   let setupStep: string
@@ -300,16 +315,11 @@ export function generateCiYml(opts: WorkflowOpts): string {
         run: uv sync --frozen --all-extras`
     if (o.lint) lintStep = '\n      - name: Lint\n        run: uv run ruff check .'
     if (o.typecheck) typecheckStep = '\n      - name: Typecheck\n        run: uv run pyright'
-    if (o.test === 'pytest') testStep = '\n      - name: Test\n        run: uv run pytest'
   } else if (o.stack === 'bun') {
     setupStep = `      - uses: ${ACTION_PINS.setupBun}
       - run: bun install`
     if (o.lint) lintStep = '\n      - name: Lint\n        run: bun lint'
     if (o.typecheck) typecheckStep = '\n      - name: Typecheck\n        run: bun typecheck'
-    if (o.test !== 'none') {
-      const bunTestCmd = o.test === 'vitest' ? 'bun run test' : 'bun test'
-      testStep = `\n      - name: Test\n        run: ${bunTestCmd}`
-    }
   } else {
     setupStep = `      - uses: ${ACTION_PINS.setupNode}
         with:
@@ -317,7 +327,16 @@ export function generateCiYml(opts: WorkflowOpts): string {
       - run: npm ci`
     if (o.lint) lintStep = '\n      - name: Lint\n        run: npm run lint'
     if (o.typecheck) typecheckStep = '\n      - name: Typecheck\n        run: npx tsc --noEmit'
-    if (o.test !== 'none') testStep = '\n      - name: Test\n        run: npm test'
+  }
+
+  const testCmd = resolveTestRunCommand(o)
+  if (testCmd) {
+    testStep = `\n      - name: Test\n        run: ${testCmd}`
+  } else {
+    // Explicit comment — silent-green CI without tests is worse than a red one
+    testStep =
+      '\n      # test: none — no unit test step (commands.test unset / --test none).\n' +
+      '      # If this is wrong, set commands.test + testing.unit and re-run /ci-setup.'
   }
 
   return `name: CI
@@ -476,11 +495,17 @@ export async function pushWorkflows(
     })
     results.push({ file: name, status })
   }
-  const dependabotStatus = await pushWorkflowFile(owner, repo, '.github/dependabot.yml', generateDependabotYml(), {
-    branch,
-    message: 'chore: add dependabot.yml (github-actions + ecosystem)',
-    skipExisting: !force,
-  })
+  const dependabotStatus = await pushWorkflowFile(
+    owner,
+    repo,
+    '.github/dependabot.yml',
+    generateDependabotYml({ stack: o.stack }),
+    {
+      branch,
+      message: 'chore: add dependabot.yml (ecosystem + github-actions)',
+      skipExisting: !force,
+    },
+  )
   results.push({ file: 'dependabot.yml', status: dependabotStatus })
   return results
 }
@@ -541,7 +566,7 @@ export async function writeWorkflows(opts: WorkflowOpts): Promise<string[]> {
   written.push('dependabot-automerge.yml')
 
   fs.mkdirSync('.github', { recursive: true })
-  fs.writeFileSync('.github/dependabot.yml', generateDependabotYml())
+  fs.writeFileSync('.github/dependabot.yml', generateDependabotYml({ stack: o.stack }))
 
   if (o.deploy === 'vercel') {
     fs.writeFileSync(`${dir}/deploy-preview.yml`, generateDeployYml(o))
@@ -555,9 +580,36 @@ export async function writeWorkflows(opts: WorkflowOpts): Promise<string[]> {
   return written
 }
 
+/** Classify unit test runner from testing.unit and/or commands.test. */
+export function classifyTestRunner(unit: string | undefined, command: string | undefined): WorkflowOpts['test'] {
+  const u = (unit ?? '').trim()
+  const c = (command ?? '').trim()
+  if (!u && !c) return 'none'
+  if (/^none$/i.test(u) || (/^none$/i.test(c) && !u)) return 'none'
+
+  // testing.unit is authoritative when set to a known runner
+  if (/^vitest$/i.test(u) || /vitest/i.test(u)) return 'vitest'
+  if (/^jest$/i.test(u) || /jest/i.test(u)) return 'jest'
+  if (/^pytest$/i.test(u) || /pytest/i.test(u)) return 'pytest'
+  if (/^bun$/i.test(u) || /bun:test/i.test(u)) return 'bun'
+
+  // Fall back to commands.test heuristics
+  if (/vitest/i.test(c)) return 'vitest'
+  if (/jest/i.test(c)) return 'jest'
+  if (/pytest/i.test(c)) return 'pytest'
+  // bare `bun test` → native bun runner; `bun run test` → package script (vitest-or-bun script)
+  if (/\bbun\s+test\b/.test(c) && !/\bbun\s+run\s+test\b/.test(c)) return 'bun'
+  if (/\bbun\s+run\s+test\b/.test(c)) return 'vitest' // stack.yml.example convention + hook policy
+  if (c) return 'vitest' // unknown non-empty command still runs — classify generically
+  return 'none'
+}
+
 /** Build WorkflowOpts from stack.yml-shaped fields (ci-setup / checkup drift). */
 export function workflowOptsFromStack(stack: {
   runtime?: string
+  /** testing.unit when available */
+  unit?: string
+  /** legacy alias — testing.unit or commands.test */
   test?: string
   deployPlatform?: string
   e2e?: string
@@ -565,11 +617,10 @@ export function workflowOptsFromStack(stack: {
   merge?: 'auto-merge' | 'merge-on-green'
 }): WorkflowOpts {
   const runtime = (stack.runtime ?? 'bun') as WorkflowOpts['stack']
-  const testRaw = stack.test ?? stack.commands?.test ?? 'none'
-  let test: WorkflowOpts['test'] = 'none'
-  if (/vitest/i.test(testRaw)) test = 'vitest'
-  else if (/jest/i.test(testRaw)) test = 'jest'
-  else if (/pytest/i.test(testRaw)) test = 'pytest'
+  const unit = stack.unit ?? (stack.test && !stack.commands?.test ? stack.test : undefined)
+  const testCommand = stack.commands?.test ?? ''
+  // Prefer unit field; stack.test may be either unit or command depending on caller
+  const test = classifyTestRunner(unit ?? stack.test, testCommand || stack.test)
   let deploy: WorkflowOpts['deploy'] = 'none'
   const platform = stack.deployPlatform ?? ''
   if (platform === 'vercel') deploy = 'vercel'
@@ -577,6 +628,7 @@ export function workflowOptsFromStack(stack: {
   return normalizeWorkflowOpts({
     stack: runtime === 'python' || runtime === 'node' ? runtime : 'bun',
     test,
+    testCommand: testCommand || undefined,
     deploy,
     merge: stack.merge,
     e2e: stack.e2e === 'playwright' ? 'playwright' : 'none',

--- a/plugins/dev-init/skills/init/lib/workflows.ts
+++ b/plugins/dev-init/skills/init/lib/workflows.ts
@@ -457,6 +457,51 @@ export interface PushResult {
   status: 'created' | 'updated' | 'skipped'
 }
 
+interface WorkflowFile {
+  /** Report name — the basename, as callers and the SKILL.md orchestrator refer to it. */
+  name: string
+  /** Repo-relative path — `.github/dependabot.yml` does not live under `workflows/`. */
+  path: string
+  content: string
+  message?: string
+}
+
+/** The full file set for a stack. Single source for both the REST pusher and the local
+ *  writer — the two paths must emit the same files, or one silently ships a subset. */
+function workflowFileSet(o: Required<WorkflowOpts>): WorkflowFile[] {
+  const mergeFile =
+    o.merge === 'merge-on-green'
+      ? { name: 'merge-on-green.yml', content: generateMergeOnGreenYml(o) }
+      : { name: 'auto-merge.yml', content: generateAutoMergeYml() }
+  const workflows: Array<{ name: string; content: string }> = [
+    mergeFile,
+    { name: 'pr-title.yml', content: generatePrTitleYml() },
+    { name: 'context-lint.yml', content: generateContextLintYml() },
+    { name: 'secret-scan.yml', content: generateSecretScanYml() },
+    { name: 'ci.yml', content: generateCiYml(o) },
+    { name: 'dependabot-automerge.yml', content: generateDependabotAutomergeYml() },
+  ]
+  if (o.deploy === 'vercel') {
+    workflows.push({ name: 'deploy-preview.yml', content: generateDeployYml(o) })
+  }
+  if (o.deploy === 'cloudflare') {
+    workflows.push({ name: 'deploy-cloudflare.yml', content: generateCloudflareDeployYml() })
+  }
+
+  const files: WorkflowFile[] = workflows.map(({ name, content }) => ({
+    name,
+    path: `.github/workflows/${name}`,
+    content,
+  }))
+  files.push({
+    name: 'dependabot.yml',
+    path: '.github/dependabot.yml',
+    content: generateDependabotYml({ stack: o.stack }),
+    message: 'chore: add dependabot.yml (ecosystem + github-actions)',
+  })
+  return files
+}
+
 /** Push all workflow files to a remote repo via GitHub REST API. No local git required.
  *  Default is TOP-UP: files already present on the repo are skipped (repos evolve
  *  their ci.yml far past the template). `force` overwrites. */
@@ -468,45 +513,15 @@ export async function pushWorkflows(
   force = false,
 ): Promise<PushResult[]> {
   const o = normalizeWorkflowOpts(opts)
-  const mergeFile =
-    o.merge === 'merge-on-green'
-      ? { name: 'merge-on-green.yml', content: generateMergeOnGreenYml(o) }
-      : { name: 'auto-merge.yml', content: generateAutoMergeYml() }
-  const files: Array<{ name: string; content: string }> = [
-    mergeFile,
-    { name: 'pr-title.yml', content: generatePrTitleYml() },
-    { name: 'context-lint.yml', content: generateContextLintYml() },
-    { name: 'secret-scan.yml', content: generateSecretScanYml() },
-    { name: 'ci.yml', content: generateCiYml(o) },
-    { name: 'dependabot-automerge.yml', content: generateDependabotAutomergeYml() },
-  ]
-  if (o.deploy === 'vercel') {
-    files.push({ name: 'deploy-preview.yml', content: generateDeployYml(o) })
-  }
-  if (o.deploy === 'cloudflare') {
-    files.push({ name: 'deploy-cloudflare.yml', content: generateCloudflareDeployYml() })
-  }
-
   const results: PushResult[] = []
-  for (const { name, content } of files) {
-    const status = await pushWorkflowFile(owner, repo, `.github/workflows/${name}`, content, {
+  for (const { name, path, content, message } of workflowFileSet(o)) {
+    const status = await pushWorkflowFile(owner, repo, path, content, {
       branch,
+      message,
       skipExisting: !force,
     })
     results.push({ file: name, status })
   }
-  const dependabotStatus = await pushWorkflowFile(
-    owner,
-    repo,
-    '.github/dependabot.yml',
-    generateDependabotYml({ stack: o.stack }),
-    {
-      branch,
-      message: 'chore: add dependabot.yml (ecosystem + github-actions)',
-      skipExisting: !force,
-    },
-  )
-  results.push({ file: 'dependabot.yml', status: dependabotStatus })
   return results
 }
 
@@ -534,50 +549,25 @@ export async function pushGenericWorkflows(
   return results
 }
 
-/** Write workflow files to the local filesystem (legacy / offline use). */
-export async function writeWorkflows(opts: WorkflowOpts): Promise<string[]> {
+/** Write workflow files under the cwd's `.github/` (offline use — no gh auth, no remote).
+ *  Same top-up default as pushWorkflows: existing files are skipped unless `force`.
+ *  Every file in the set is reported, including `.github/dependabot.yml`. */
+export async function writeWorkflows(opts: WorkflowOpts, force = false): Promise<PushResult[]> {
   const fs = require('node:fs')
-  const dir = '.github/workflows'
-  fs.mkdirSync(dir, { recursive: true })
+  fs.mkdirSync('.github/workflows', { recursive: true })
   const o = normalizeWorkflowOpts(opts)
-  const written: string[] = []
 
-  fs.writeFileSync(`${dir}/ci.yml`, generateCiYml(o))
-  written.push('ci.yml')
-
-  if (o.merge === 'merge-on-green') {
-    fs.writeFileSync(`${dir}/merge-on-green.yml`, generateMergeOnGreenYml(o))
-    written.push('merge-on-green.yml')
-  } else {
-    fs.writeFileSync(`${dir}/auto-merge.yml`, generateAutoMergeYml())
-    written.push('auto-merge.yml')
+  const results: PushResult[] = []
+  for (const { name, path, content } of workflowFileSet(o)) {
+    const existing = fs.existsSync(path)
+    if (existing && !force) {
+      results.push({ file: name, status: 'skipped' })
+      continue
+    }
+    fs.writeFileSync(path, content)
+    results.push({ file: name, status: existing ? 'updated' : 'created' })
   }
-
-  fs.writeFileSync(`${dir}/secret-scan.yml`, generateSecretScanYml())
-  written.push('secret-scan.yml')
-
-  fs.writeFileSync(`${dir}/pr-title.yml`, generatePrTitleYml())
-  written.push('pr-title.yml')
-
-  fs.writeFileSync(`${dir}/context-lint.yml`, generateContextLintYml())
-  written.push('context-lint.yml')
-
-  fs.writeFileSync(`${dir}/dependabot-automerge.yml`, generateDependabotAutomergeYml())
-  written.push('dependabot-automerge.yml')
-
-  fs.mkdirSync('.github', { recursive: true })
-  fs.writeFileSync('.github/dependabot.yml', generateDependabotYml({ stack: o.stack }))
-
-  if (o.deploy === 'vercel') {
-    fs.writeFileSync(`${dir}/deploy-preview.yml`, generateDeployYml(o))
-    written.push('deploy-preview.yml')
-  }
-  if (o.deploy === 'cloudflare') {
-    fs.writeFileSync(`${dir}/deploy-cloudflare.yml`, generateCloudflareDeployYml())
-    written.push('deploy-cloudflare.yml')
-  }
-
-  return written
+  return results
 }
 
 /** Classify unit test runner from testing.unit and/or commands.test. */


### PR DESCRIPTION
## Summary

Closes the four demo-mcp `/env-setup` + `/ci-setup` defects, with panel-validated shapes.

| Issue | Fix |
|-------|-----|
| **#345** | `dev-core` init shim: flat sibling first, then versioned cache (`…/dev-init/<ver>/…`), skip `.orphaned_at` |
| **#347** | Parse `testing.unit`; classify `bun run test` ≠ none; emit `commands.test` in CI; `--test bun`; comment when no test step |
| **#348** | `generateDependabotYml(stack)` → ecosystem + github-actions; doctor content check; Phase 1c verifies/top-ups |
| **#346** | Scaffold facts from repo (base branch, PM, `.env.example`); parent CLAUDE.md report; Phase 2 user gate (no silent auto-skip) |

dev-core **0.8.17**.

## Test plan

- [x] Full vitest suite (578 pass)
- [x] pre-commit lint + typecheck + trufflehog
- [ ] Re-run `/env-setup` Phase 2 on a child of `~/projects/` — parent paths shown, facts correct
- [ ] `bun $I_TS workflows --stack bun --test bun --test-command "bun run test"` → CI has Test step
- [ ] Generated dependabot.yml has `npm` + `github-actions` (gha cooldown `default-days` only)