### PR TITLE
fix(dev-init): repair two unresolvable action pins, verify the rest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd plugins/dev-core/cli && bun test
+      - name: Verify action pins resolve
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run tools/verify-action-pins.ts
       - name: Shared detectGitHubRepo suite — caller parity (#218 SC3)
         run: |
           set -euo pipefail

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:watch": "vitest",
     "lint": "bunx biome check .",
     "typecheck": "tsc --noEmit",
-    "sync:shared": "bun run tools/sync-shared.ts"
+    "sync:shared": "bun run tools/sync-shared.ts",
+    "verify:pins": "bun run tools/verify-action-pins.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",

--- a/plugins/dev-init/skills/init/lib/workflow-pins.ts
+++ b/plugins/dev-init/skills/init/lib/workflow-pins.ts
@@ -1,9 +1,12 @@
-/** SHA-pinned GitHub Actions — fleet consensus (audit 2026-07-02). */
+/** SHA-pinned GitHub Actions — fleet consensus (audit 2026-07-02).
+ *  Dependabot cannot see these (they are not workflow files), so a wrong SHA rots
+ *  silently until a generated CI run dies at "Set up job".
+ *  Verify before committing a change here: `bun run verify:pins`. */
 export const ACTION_PINS = {
   checkout: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10', // v6
   setupBun: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6', // v2
-  setupNode: 'actions/setup-node@49933ea53b297553b1c3d69c20d3553fa2791a6', // v4
-  setupUv: 'astral-sh/setup-uv@5c5fa0c0f1e07b27cd2878e7c576d0b834b4fdb3', // v5
+  setupNode: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020', // v4
+  setupUv: 'astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86', // v5
   trufflehog: 'trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6', // v3.94.3
   githubScript: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3', // v9
   semanticPr: 'amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50', // v6

--- a/tools/verify-action-pins.ts
+++ b/tools/verify-action-pins.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+
+/**
+ * Verify every ACTION_PINS SHA is a real commit in the action's repo.
+ *
+ * Usage:
+ *   bun run tools/verify-action-pins.ts            — verify pins resolve
+ *   bun run tools/verify-action-pins.ts --tags     — also report pins that drifted off their tag
+ *
+ * These pins live in a TypeScript constant, not in a workflow file, so Dependabot
+ * never sees them and nothing else proves the SHAs exist. Two hallucinated SHAs
+ * (setup-node, setup-uv) shipped this way and would have failed every generated
+ * CI run at "Set up job". A length check is not enough — one of the two was a
+ * well-formed 40-char SHA that simply did not exist. Only the API answers that.
+ *
+ * Requires network + gh auth (GITHUB_TOKEN in CI). Exits 1 on any unresolvable pin.
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const REPO_ROOT = resolve(import.meta.dir, '..')
+const PINS_PATH = resolve(REPO_ROOT, 'plugins/dev-init/skills/init/lib/workflow-pins.ts')
+
+const checkTags = process.argv.includes('--tags')
+
+interface Pin {
+  name: string
+  action: string
+  sha: string
+  tag: string
+}
+
+function parsePins(source: string): Pin[] {
+  const re = /(\w+):\s*'([^@']+)@([0-9a-fA-F]+)',\s*\/\/\s*(\S+)/g
+  return [...source.matchAll(re)].map((m) => ({ name: m[1], action: m[2], sha: m[3], tag: m[4] }))
+}
+
+async function gh(path: string): Promise<unknown | null> {
+  const proc = Bun.spawnSync(['gh', 'api', path], { stdout: 'pipe', stderr: 'pipe' })
+  if (proc.exitCode !== 0) return null
+  try {
+    return JSON.parse(proc.stdout.toString())
+  } catch {
+    return null
+  }
+}
+
+/** Resolve a tag ref to its commit, dereferencing annotated tags (object.type === 'tag'). */
+async function commitForTag(action: string, tag: string): Promise<string | null> {
+  const ref = (await gh(`repos/${action}/git/ref/tags/${tag}`)) as { object?: { sha?: string; type?: string } } | null
+  const obj = ref?.object
+  if (!obj?.sha) return null
+  if (obj.type !== 'tag') return obj.sha
+  const deref = (await gh(`repos/${action}/git/tags/${obj.sha}`)) as { object?: { sha?: string } } | null
+  return deref?.object?.sha ?? null
+}
+
+const pins = parsePins(readFileSync(PINS_PATH, 'utf-8'))
+if (pins.length === 0) {
+  console.error(`No pins parsed from ${PINS_PATH} — the file shape changed and this check is now blind.`)
+  process.exit(1)
+}
+
+let failed = 0
+for (const pin of pins) {
+  const commit = (await gh(`repos/${pin.action}/commits/${pin.sha}`)) as { sha?: string } | null
+  if (!commit?.sha) {
+    failed++
+    const actual = await commitForTag(pin.action, pin.tag)
+    console.error(`FAIL ${pin.name}: ${pin.action}@${pin.sha} is not a commit (${pin.sha.length} chars)`)
+    if (actual) console.error(`     ${pin.tag} is ${actual}`)
+    continue
+  }
+  if (!checkTags) {
+    console.log(`ok   ${pin.name}: ${pin.action}@${pin.sha.slice(0, 12)} (${pin.tag})`)
+    continue
+  }
+  const tagSha = await commitForTag(pin.action, pin.tag)
+  const drifted = tagSha && tagSha !== pin.sha
+  console.log(
+    drifted
+      ? `drift ${pin.name}: pinned ${pin.sha.slice(0, 12)}, ${pin.tag} now ${tagSha.slice(0, 12)}`
+      : `ok   ${pin.name}: ${pin.action}@${pin.sha.slice(0, 12)} (${pin.tag})`,
+  )
+}
+
+if (failed > 0) {
+  console.error(`\n${failed}/${pins.length} pins do not resolve — generated CI would fail at "Set up job".`)
+  process.exit(1)
+}
+console.log(`\nAll ${pins.length} pins resolve.`)


### PR DESCRIPTION
## Problem

`setup-node` and `setup-uv` were pinned to SHAs that **do not exist**. Every generated CI run on a **node** or **python** stack died at `Set up job` before executing a single step.

```
$ gh api repos/actions/setup-node/commits/49933ea53b297553b1c3d69c20d3553fa2791a6
422  No commit found for SHA

$ gh api repos/astral-sh/setup-uv/commits/5c5fa0c0f1e07b27cd2878e7c576d0b834b4fdb3
422  No commit found for SHA
```

This repo is **bun-stack**, so its own CI never touched either pin — it stayed green while shipping them to every consumer.

| pin | was | now |
|---|---|---|
| `setup-node` | `49933ea53b29…` (**39 chars**) | `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4) |
| `setup-uv` | `5c5fa0c0f1e0…` (**40 chars**) | `d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86` (v5) |

Both replacements verified to resolve. `setup-uv`'s `v5` is an *annotated* tag, so it was dereferenced to its commit rather than pinned to the tag object.

## Why a length check is not the fix

The 39-char `setup-node` SHA is the obvious one. **`setup-uv` is the instructive one:** a perfectly well-formed 40-char SHA that simply does not exist. Any format/length heuristic passes it. Only the API tells them apart — which is why the guard resolves every pin against GitHub rather than inspecting shape.

## Root cause

These pins live in a **TypeScript constant**, not a workflow file. Dependabot only sees `uses:` in `.github/workflows/**`, so it has never audited them, and nothing else proved the SHAs existed. They were hand-written and rotted silently.

`tools/verify-action-pins.ts` closes that gap: it resolves all 8 pins against the GitHub API and runs in CI, where `GITHUB_TOKEN` is already available (the vitest step has no token, so a network assertion there would hit unauthenticated rate limits and go flaky). Also available locally as `bun run verify:pins`.

## Verification

Mutation-tested against **both** failure classes rather than assumed:

```
MUTANT A (39-char setup-node)      -> exit 1  FAIL setupNode: … is not a commit (39 chars)
                                                   v4 is 49933ea5288caeca8642d1e84afbd3f7d6820020
MUTANT B (40-char absent setup-uv) -> exit 1  FAIL setupUv:   … is not a commit (40 chars)
                                                   v5 is d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
RESTORED                           -> exit 0  All 8 pins resolve.
```

The other 6 pins were each confirmed to resolve **and** to match their claimed tag.

Gates: `lint` 0 errors (28 warnings, pre-existing baseline unchanged), `typecheck` clean, tests unaffected, `validate_plugins.py` green.

## Note

Found while reviewing #354, which does not touch this file — hence a separate PR. No dependency between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)