### PR TITLE
fix(dev-init): generate the fetch-metadata semver-major guard, not the dead regex

### DIFF
--- a/plugins/dev-init/skills/init/__tests__/workflows.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/workflows.test.ts
@@ -42,6 +42,16 @@ describe('generateAutoMergeYml', () => {
     expect(yml).toContain(ACTION_PINS.githubScript)
     expect(yml).not.toContain('actions/github-script@v8')
   })
+
+  it('blocks semver-major via fetch-metadata, not the dead title regex', () => {
+    const yml = generateAutoMergeYml()
+    // The title regex never fired on grouped PRs (no versions in the title) and
+    // could misread SHA-pinned action bumps — #342 replaced it with metadata.
+    expect(yml).not.toContain('BASH_REMATCH')
+    expect(yml).not.toContain('PR_TITLE')
+    expect(yml).toContain(ACTION_PINS.dependabotFetchMetadata)
+    expect(yml).toContain("steps.dependabot-meta.outputs.update-type == 'version-update:semver-major'")
+  })
 })
 
 describe('generateCiYml', () => {

--- a/plugins/dev-init/skills/init/__tests__/workflows.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/workflows.test.ts
@@ -50,7 +50,23 @@ describe('generateAutoMergeYml', () => {
     expect(yml).not.toContain('BASH_REMATCH')
     expect(yml).not.toContain('PR_TITLE')
     expect(yml).toContain(ACTION_PINS.dependabotFetchMetadata)
-    expect(yml).toContain("steps.dependabot-meta.outputs.update-type == 'version-update:semver-major'")
+
+    // Derive the reference from the declared id — a rename of `id:` that forgets
+    // to update the block's `if:` must fail this, not just an equality check.
+    const fetchIdMatch = yml.match(/- name: Fetch dependabot metadata\s*\n\s*id: (\S+)/)
+    if (!fetchIdMatch) throw new Error('Fetch dependabot metadata step id not found')
+    const fetchId = fetchIdMatch[1]
+
+    const blockStart = yml.indexOf('- name: Block dependabot semver-major')
+    expect(blockStart).toBeGreaterThan(-1)
+    const nextStepOffset = yml.slice(blockStart + 1).search(/\n\s*- name: /)
+    const blockRegion =
+      nextStepOffset === -1 ? yml.slice(blockStart) : yml.slice(blockStart, blockStart + 1 + nextStepOffset)
+
+    expect(blockRegion).toContain(`steps.${fetchId}.outputs.update-type == 'version-update:semver-major'`)
+    // Scoped to the Block step only — the whole YAML also has a legitimate
+    // `exit 0` elsewhere (update-behind-prs' empty-PR-list check).
+    expect(blockRegion).toContain('exit 1')
   })
 })
 
@@ -150,6 +166,8 @@ describe('generateDependabotAutomergeYml', () => {
     expect(yml).toContain('dependabot[bot]')
     expect(yml).toContain('semver-patch')
     expect(yml).toContain(ACTION_PINS.createAppToken)
+    expect(yml).toContain(ACTION_PINS.dependabotFetchMetadata)
+    expect(yml).not.toContain('21025c705c08')
   })
 })
 

--- a/plugins/dev-init/skills/init/lib/workflow-pins.ts
+++ b/plugins/dev-init/skills/init/lib/workflow-pins.ts
@@ -11,4 +11,5 @@ export const ACTION_PINS = {
   githubScript: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3', // v9
   semanticPr: 'amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50', // v6
   createAppToken: 'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1', // v3.2.0
+  dependabotFetchMetadata: 'dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98', // v3.1.0
 } as const

--- a/plugins/dev-init/skills/init/lib/workflows-fleet.ts
+++ b/plugins/dev-init/skills/init/lib/workflows-fleet.ts
@@ -106,7 +106,7 @@ ${APP_MINT_STEP}
 
       - name: Fetch dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2.5.0
+        uses: ${ACTION_PINS.dependabotFetchMetadata}
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
 

--- a/plugins/dev-init/skills/init/lib/workflows.ts
+++ b/plugins/dev-init/skills/init/lib/workflows.ts
@@ -60,19 +60,30 @@ jobs:
     steps:
 ${APP_MINT_STEP}
 
-      - name: Block dependabot semver-major bumps
+      # Read the real update-type from Dependabot's metadata rather than parsing the
+      # PR title: grouped PRs are titled "bump the <group> group…" with no versions,
+      # so a title regex never fires for a major hidden in a group, and it can also
+      # misread a SHA-pinned action bump ("from 08eba0b to 8f4b7f8") as a major.
+      # For a grouped PR, fetch-metadata reports the HIGHEST update-type in the group.
+      - name: Fetch dependabot metadata
+        id: dependabot-meta
         if: github.event.pull_request.user.login == 'dependabot[bot]'
+        uses: ${ACTION_PINS.dependabotFetchMetadata}
+        with:
+          github-token: \${{ steps.app.outputs.token }}
+
+      - name: Block dependabot semver-major bumps
+        if: >-
+          github.event.pull_request.user.login == 'dependabot[bot]' &&
+          steps.dependabot-meta.outputs.update-type == 'version-update:semver-major'
         env:
           GH_TOKEN: \${{ steps.app.outputs.token }}
           PR_NUMBER: \${{ github.event.pull_request.number }}
-          PR_TITLE: \${{ github.event.pull_request.title }}
         run: |
-          if [[ "$PR_TITLE" =~ from\\ v?([0-9]+)[^\\ ]*\\ to\\ v?([0-9]+) ]] && [ "\${BASH_REMATCH[1]}" != "\${BASH_REMATCH[2]}" ]; then
-            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \\
-              --body "Auto-merge refused: **semver-major** bump. Manual validation required (e2e / boot the artifact), then merge by hand."
-            echo "::error::semver-major dependency bump — auto-merge refused"
-            exit 1
-          fi
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \\
+            --body "Auto-merge refused: **semver-major** bump. Manual validation required (e2e / boot the artifact), then merge by hand."
+          echo "::error::semver-major dependency bump — auto-merge refused"
+          exit 1
 
       - name: Update branch (lazy sync for late joiners)
         if: contains(github.event.pull_request.labels.*.name, 'reviewed')

--- a/tools/__tests__/verify-action-pins.test.ts
+++ b/tools/__tests__/verify-action-pins.test.ts
@@ -1,0 +1,143 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  buildGovernedPairs,
+  findInlinePins,
+  findUngovernedPins,
+  type InlinePin,
+  parseInlinePins,
+  parsePins,
+} from '../verify-action-pins'
+
+// ─── parsePins ───────────────────────────────────────────────────────────────
+
+describe('parsePins', () => {
+  it('parses name/action/sha/tag from an ACTION_PINS-shaped source', () => {
+    const source = [
+      'export const ACTION_PINS = {',
+      "  checkout: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10', // v6",
+      '} as const',
+    ].join('\n')
+    expect(parsePins(source)).toEqual([
+      { name: 'checkout', action: 'actions/checkout', sha: 'df4cb1c069e1874edd31b4311f1884172cec0e10', tag: 'v6' },
+    ])
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    expect(parsePins('export const ACTION_PINS = {} as const')).toEqual([])
+  })
+})
+
+// ─── parseInlinePins ─────────────────────────────────────────────────────────
+
+describe('parseInlinePins', () => {
+  it('matches a literal uses: owner/repo@<sha>', () => {
+    const source = '      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6\n'
+    expect(parseInlinePins(source)).toEqual([
+      { action: 'actions/checkout', ref: 'df4cb1c069e1874edd31b4311f1884172cec0e10' },
+    ])
+  })
+
+  it('matches a floating tag ref (F3 — an unpinned action must not be invisible)', () => {
+    const source = '      - uses: actions/checkout@v3\n'
+    expect(parseInlinePins(source)).toEqual([{ action: 'actions/checkout', ref: 'v3' }])
+  })
+
+  it('does NOT match an ACTION_PINS template-interpolation ref', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: emitter template syntax — intentionally a plain string
+    const source = '      - uses: ${ACTION_PINS.checkout}\n'
+    expect(parseInlinePins(source)).toEqual([])
+  })
+
+  it('finds every literal pin across a multi-line source, skipping template refs', () => {
+    const source = [
+      '      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10',
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: emitter template syntax — intentionally a plain string
+      '      - uses: ${ACTION_PINS.setupBun}',
+      '      - uses: owner/repo@v3',
+    ].join('\n')
+    expect(parseInlinePins(source)).toEqual([
+      { action: 'actions/checkout', ref: 'df4cb1c069e1874edd31b4311f1884172cec0e10' },
+      { action: 'owner/repo', ref: 'v3' },
+    ])
+  })
+})
+
+// ─── findInlinePins ──────────────────────────────────────────────────────────
+
+describe('findInlinePins', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..')
+  const fixtureRelPath = 'tools/__tests__/.tmp-inline-pins-fixture.ts'
+  const fixtureAbsPath = path.join(repoRoot, fixtureRelPath)
+
+  afterEach(() => {
+    if (fs.existsSync(fixtureAbsPath)) fs.rmSync(fixtureAbsPath)
+  })
+
+  it('reads a file relative to the repo root and attaches its path to each pin', () => {
+    fs.writeFileSync(fixtureAbsPath, '      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10\n')
+    expect(findInlinePins([fixtureRelPath])).toEqual([
+      { file: fixtureRelPath, action: 'actions/checkout', ref: 'df4cb1c069e1874edd31b4311f1884172cec0e10' },
+    ])
+  })
+})
+
+// ─── buildGovernedPairs / findUngovernedPins ────────────────────────────────
+
+describe('findUngovernedPins', () => {
+  const governedPairs = buildGovernedPairs([
+    { name: 'checkout', action: 'owner/repo', sha: 'abc1234deadbeefabc1234deadbeefabc1234de', tag: 'v6' },
+  ])
+
+  it('does not flag a correctly governed action+sha pair', () => {
+    const pins: InlinePin[] = [{ file: 'f.ts', action: 'owner/repo', ref: 'abc1234deadbeefabc1234deadbeefabc1234de' }]
+    expect(findUngovernedPins(pins, governedPairs)).toEqual([])
+  })
+
+  it('flags a floating tag on an otherwise-governed action (F3)', () => {
+    const pins: InlinePin[] = [{ file: 'f.ts', action: 'owner/repo', ref: 'v3' }]
+    expect(findUngovernedPins(pins, governedPairs)).toEqual(pins)
+  })
+
+  it('flags a right-SHA-wrong-action pin (F2)', () => {
+    const pins: InlinePin[] = [
+      { file: 'f.ts', action: 'WRONG-ORG/wrong-action', ref: 'abc1234deadbeefabc1234deadbeefabc1234de' },
+    ]
+    expect(findUngovernedPins(pins, governedPairs)).toEqual(pins)
+  })
+
+  it('comparison is case-insensitive on both action and ref', () => {
+    const pins: InlinePin[] = [{ file: 'f.ts', action: 'OWNER/REPO', ref: 'ABC1234DEADBEEFABC1234DEADBEEFABC1234DE' }]
+    expect(findUngovernedPins(pins, governedPairs)).toEqual([])
+  })
+
+  it('does not flag anything when there are no inline pins', () => {
+    expect(findUngovernedPins([], governedPairs)).toEqual([])
+  })
+})
+
+// ─── Regression pins — mutation-confirmed real bugs ─────────────────────────
+
+describe('regression — F2: right SHA, wrong action must be flagged', () => {
+  it('WRONG-ORG/wrong-action@<a real governed sha> is ungoverned', () => {
+    const pins = parsePins(
+      [
+        'export const ACTION_PINS = {',
+        "  dependabotFetchMetadata: 'dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98', // v3.1.0",
+        '} as const',
+      ].join('\n'),
+    )
+    const governedPairs = buildGovernedPairs(pins)
+    const inline: InlinePin[] = [
+      { file: 'x.ts', action: 'WRONG-ORG/wrong-action', ref: '25dd0e34f4fe68f24cc83900b1fe3fe149efef98' },
+    ]
+    expect(findUngovernedPins(inline, governedPairs)).toEqual(inline)
+  })
+})
+
+describe('regression — F3: floating tag must not be invisible to the parser', () => {
+  it('parseInlinePins captures a bare tag ref that the old hex-only regex matched nothing on', () => {
+    expect(parseInlinePins('      - uses: owner/repo@v3\n')).toEqual([{ action: 'owner/repo', ref: 'v3' }])
+  })
+})

--- a/tools/verify-action-pins.ts
+++ b/tools/verify-action-pins.ts
@@ -16,8 +16,10 @@
  *
  * Resolving ACTION_PINS alone is also not enough: a pin written inline in a
  * generator template bypasses the constant entirely and this check with it
- * (fetch-metadata sat at v2.5.0 that way). So every `uses: owner/repo@sha`
- * literal in the emitter sources must carry a SHA that ACTION_PINS declares.
+ * (fetch-metadata sat at v2.5.0 that way). So every `uses: owner/repo@ref`
+ * literal in the emitter sources must match an (action, sha) pair that
+ * ACTION_PINS declares — matching the SHA alone would let a floating tag
+ * (unpinned) or a wrong action reusing a governed SHA slip through unflagged.
  *
  * Requires network + gh auth (GITHUB_TOKEN in CI). Exits 1 on any unresolvable
  * or ungoverned pin.
@@ -26,7 +28,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-const REPO_ROOT = resolve(import.meta.dir, '..')
+const REPO_ROOT = resolve(import.meta.dirname ?? '.', '..')
 const PINS_PATH = resolve(REPO_ROOT, 'plugins/dev-init/skills/init/lib/workflow-pins.ts')
 
 /** Sources that emit workflow YAML. github-infra.ts is copy-synced from dev-core and
@@ -40,31 +42,58 @@ const EMITTER_PATHS = [
 
 const checkTags = process.argv.includes('--tags')
 
-interface Pin {
+export interface Pin {
   name: string
   action: string
   sha: string
   tag: string
 }
 
-function parsePins(source: string): Pin[] {
+export function parsePins(source: string): Pin[] {
   const re = /(\w+):\s*'([^@']+)@([0-9a-fA-F]+)',\s*\/\/\s*(\S+)/g
   return [...source.matchAll(re)].map((m) => ({ name: m[1], action: m[2], sha: m[3], tag: m[4] }))
 }
 
-interface InlinePin {
-  file: string
+export interface InlineRef {
   action: string
-  sha: string
+  ref: string
 }
 
-/** `uses: owner/repo@<sha>` written as a literal rather than via `${ACTION_PINS.x}`. */
-function findInlinePins(files: string[]): InlinePin[] {
-  const re = /uses:\s*([\w.-]+\/[\w.-]+)@([0-9a-fA-F]{7,})/g
+export interface InlinePin extends InlineRef {
+  file: string
+}
+
+const HEX_SHA_RE = /^[0-9a-fA-F]{7,}$/
+
+/** `uses: owner/repo@<ref>` literal, `ref` being anything up to whitespace/quote/comment —
+ *  a floating tag (`@v3`) must be caught same as a SHA, or it is a worse, invisible bypass.
+ *  The action pattern (`word.-/word.-`) already excludes `${ACTION_PINS.x}` template refs:
+ *  they contain no `/` before the `@`, so the whole match fails to anchor on those lines. */
+export function parseInlinePins(source: string): InlineRef[] {
+  const re = /uses:\s*([\w.-]+\/[\w.-]+)@([^\s'"#]+)/g
+  return [...source.matchAll(re)].map((m) => ({ action: m[1], ref: m[2] }))
+}
+
+export function findInlinePins(files: string[]): InlinePin[] {
   return files.flatMap((file) => {
     const source = readFileSync(resolve(REPO_ROOT, file), 'utf-8')
-    return [...source.matchAll(re)].map((m) => ({ file, action: m[1], sha: m[2] }))
+    return parseInlinePins(source).map((pin) => ({ file, ...pin }))
   })
+}
+
+function governedKey(action: string, ref: string): string {
+  return `${action}@${ref}`.toLowerCase()
+}
+
+export function buildGovernedPairs(pins: Pin[]): Set<string> {
+  return new Set(pins.map((p) => governedKey(p.action, p.sha)))
+}
+
+/** An inline pin is governed only when its (action, ref) pair matches ACTION_PINS —
+ *  matching the ref/SHA alone would let a wrong-action reuse of a governed SHA, or a
+ *  floating tag on an otherwise-governed action, pass silently. */
+export function findUngovernedPins(inlinePins: InlinePin[], governedPairs: Set<string>): InlinePin[] {
+  return inlinePins.filter((pin) => !governedPairs.has(governedKey(pin.action, pin.ref)))
 }
 
 async function gh(path: string): Promise<unknown | null> {
@@ -87,48 +116,53 @@ async function commitForTag(action: string, tag: string): Promise<string | null>
   return deref?.object?.sha ?? null
 }
 
-const pins = parsePins(readFileSync(PINS_PATH, 'utf-8'))
-if (pins.length === 0) {
-  console.error(`No pins parsed from ${PINS_PATH} — the file shape changed and this check is now blind.`)
-  process.exit(1)
-}
-
-let failed = 0
-for (const pin of pins) {
-  const commit = (await gh(`repos/${pin.action}/commits/${pin.sha}`)) as { sha?: string } | null
-  if (!commit?.sha) {
-    failed++
-    const actual = await commitForTag(pin.action, pin.tag)
-    console.error(`FAIL ${pin.name}: ${pin.action}@${pin.sha} is not a commit (${pin.sha.length} chars)`)
-    if (actual) console.error(`     ${pin.tag} is ${actual}`)
-    continue
+async function main() {
+  const pins = parsePins(readFileSync(PINS_PATH, 'utf-8'))
+  if (pins.length === 0) {
+    console.error(`No pins parsed from ${PINS_PATH} — the file shape changed and this check is now blind.`)
+    process.exit(1)
   }
-  if (!checkTags) {
-    console.log(`ok   ${pin.name}: ${pin.action}@${pin.sha.slice(0, 12)} (${pin.tag})`)
-    continue
+
+  let failed = 0
+  for (const pin of pins) {
+    const commit = (await gh(`repos/${pin.action}/commits/${pin.sha}`)) as { sha?: string } | null
+    if (!commit?.sha) {
+      failed++
+      const actual = await commitForTag(pin.action, pin.tag)
+      console.error(`FAIL ${pin.name}: ${pin.action}@${pin.sha} is not a commit (${pin.sha.length} chars)`)
+      if (actual) console.error(`     ${pin.tag} is ${actual}`)
+      continue
+    }
+    if (!checkTags) {
+      console.log(`ok   ${pin.name}: ${pin.action}@${pin.sha.slice(0, 12)} (${pin.tag})`)
+      continue
+    }
+    const tagSha = await commitForTag(pin.action, pin.tag)
+    const drifted = tagSha && tagSha !== pin.sha
+    console.log(
+      drifted
+        ? `drift ${pin.name}: pinned ${pin.sha.slice(0, 12)}, ${pin.tag} now ${tagSha.slice(0, 12)}`
+        : `ok   ${pin.name}: ${pin.action}@${pin.sha.slice(0, 12)} (${pin.tag})`,
+    )
   }
-  const tagSha = await commitForTag(pin.action, pin.tag)
-  const drifted = tagSha && tagSha !== pin.sha
-  console.log(
-    drifted
-      ? `drift ${pin.name}: pinned ${pin.sha.slice(0, 12)}, ${pin.tag} now ${tagSha.slice(0, 12)}`
-      : `ok   ${pin.name}: ${pin.action}@${pin.sha.slice(0, 12)} (${pin.tag})`,
-  )
+
+  const governedPairs = buildGovernedPairs(pins)
+  const ungovernedPins = findUngovernedPins(findInlinePins(EMITTER_PATHS), governedPairs)
+  for (const inline of ungovernedPins) {
+    const reason = HEX_SHA_RE.test(inline.ref) ? 'not declared in ACTION_PINS' : 'floating ref, not pinned to a SHA'
+    console.error(`FAIL ${inline.file}: uses ${inline.action}@${inline.ref} — ${reason}`)
+    console.error('     Add it to workflow-pins.ts and reference it, or this pin is never verified.')
+  }
+
+  if (failed > 0 || ungovernedPins.length > 0) {
+    if (failed > 0)
+      console.error(`\n${failed}/${pins.length} pins do not resolve — generated CI would fail at "Set up job".`)
+    if (ungovernedPins.length > 0) console.error(`${ungovernedPins.length} inline pin(s) bypass ACTION_PINS.`)
+    process.exit(1)
+  }
+  console.log(`\nAll ${pins.length} pins resolve; no inline pin bypasses ACTION_PINS.`)
 }
 
-const governed = new Set(pins.map((p) => p.sha.toLowerCase()))
-let ungoverned = 0
-for (const inline of findInlinePins(EMITTER_PATHS)) {
-  if (governed.has(inline.sha.toLowerCase())) continue
-  ungoverned++
-  console.error(`FAIL ${inline.file}: uses ${inline.action}@${inline.sha.slice(0, 12)} — not declared in ACTION_PINS`)
-  console.error('     Add it to workflow-pins.ts and reference it, or this pin is never verified.')
+if (import.meta.main) {
+  await main()
 }
-
-if (failed > 0 || ungoverned > 0) {
-  if (failed > 0)
-    console.error(`\n${failed}/${pins.length} pins do not resolve — generated CI would fail at "Set up job".`)
-  if (ungoverned > 0) console.error(`${ungoverned} inline pin(s) bypass ACTION_PINS.`)
-  process.exit(1)
-}
-console.log(`\nAll ${pins.length} pins resolve; no inline pin bypasses ACTION_PINS.`)

--- a/tools/verify-action-pins.ts
+++ b/tools/verify-action-pins.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env bun
 
 /**
- * Verify every ACTION_PINS SHA is a real commit in the action's repo.
+ * Verify every action SHA the generators emit is a real commit, and that none
+ * escapes ACTION_PINS.
  *
  * Usage:
- *   bun run tools/verify-action-pins.ts            — verify pins resolve
+ *   bun run tools/verify-action-pins.ts            — verify pins resolve + are governed
  *   bun run tools/verify-action-pins.ts --tags     — also report pins that drifted off their tag
  *
  * These pins live in a TypeScript constant, not in a workflow file, so Dependabot
@@ -13,7 +14,13 @@
  * CI run at "Set up job". A length check is not enough — one of the two was a
  * well-formed 40-char SHA that simply did not exist. Only the API answers that.
  *
- * Requires network + gh auth (GITHUB_TOKEN in CI). Exits 1 on any unresolvable pin.
+ * Resolving ACTION_PINS alone is also not enough: a pin written inline in a
+ * generator template bypasses the constant entirely and this check with it
+ * (fetch-metadata sat at v2.5.0 that way). So every `uses: owner/repo@sha`
+ * literal in the emitter sources must carry a SHA that ACTION_PINS declares.
+ *
+ * Requires network + gh auth (GITHUB_TOKEN in CI). Exits 1 on any unresolvable
+ * or ungoverned pin.
  */
 
 import { readFileSync } from 'node:fs'
@@ -21,6 +28,15 @@ import { resolve } from 'node:path'
 
 const REPO_ROOT = resolve(import.meta.dir, '..')
 const PINS_PATH = resolve(REPO_ROOT, 'plugins/dev-init/skills/init/lib/workflow-pins.ts')
+
+/** Sources that emit workflow YAML. github-infra.ts is copy-synced from dev-core and
+ *  cannot import dev-init's ACTION_PINS, so its inline pin is checked, not rewritten. */
+const EMITTER_PATHS = [
+  'plugins/dev-init/skills/init/lib/workflows.ts',
+  'plugins/dev-init/skills/init/lib/workflows-fleet.ts',
+  'plugins/dev-init/skills/shared/adapters/github-infra.ts',
+  'plugins/dev-core/skills/shared/adapters/github-infra.ts',
+]
 
 const checkTags = process.argv.includes('--tags')
 
@@ -34,6 +50,21 @@ interface Pin {
 function parsePins(source: string): Pin[] {
   const re = /(\w+):\s*'([^@']+)@([0-9a-fA-F]+)',\s*\/\/\s*(\S+)/g
   return [...source.matchAll(re)].map((m) => ({ name: m[1], action: m[2], sha: m[3], tag: m[4] }))
+}
+
+interface InlinePin {
+  file: string
+  action: string
+  sha: string
+}
+
+/** `uses: owner/repo@<sha>` written as a literal rather than via `${ACTION_PINS.x}`. */
+function findInlinePins(files: string[]): InlinePin[] {
+  const re = /uses:\s*([\w.-]+\/[\w.-]+)@([0-9a-fA-F]{7,})/g
+  return files.flatMap((file) => {
+    const source = readFileSync(resolve(REPO_ROOT, file), 'utf-8')
+    return [...source.matchAll(re)].map((m) => ({ file, action: m[1], sha: m[2] }))
+  })
 }
 
 async function gh(path: string): Promise<unknown | null> {
@@ -85,8 +116,19 @@ for (const pin of pins) {
   )
 }
 
-if (failed > 0) {
-  console.error(`\n${failed}/${pins.length} pins do not resolve — generated CI would fail at "Set up job".`)
+const governed = new Set(pins.map((p) => p.sha.toLowerCase()))
+let ungoverned = 0
+for (const inline of findInlinePins(EMITTER_PATHS)) {
+  if (governed.has(inline.sha.toLowerCase())) continue
+  ungoverned++
+  console.error(`FAIL ${inline.file}: uses ${inline.action}@${inline.sha.slice(0, 12)} — not declared in ACTION_PINS`)
+  console.error('     Add it to workflow-pins.ts and reference it, or this pin is never verified.')
+}
+
+if (failed > 0 || ungoverned > 0) {
+  if (failed > 0)
+    console.error(`\n${failed}/${pins.length} pins do not resolve — generated CI would fail at "Set up job".`)
+  if (ungoverned > 0) console.error(`${ungoverned} inline pin(s) bypass ACTION_PINS.`)
   process.exit(1)
 }
-console.log(`\nAll ${pins.length} pins resolve.`)
+console.log(`\nAll ${pins.length} pins resolve; no inline pin bypasses ACTION_PINS.`)


### PR DESCRIPTION
## Problem

Every project scaffolded by `/init` or `/ci-setup` shipped a **broken** dependabot auto-merge guard. `generateAutoMergeYml()` emitted a PR-title regex:

```bash
if [[ "$PR_TITLE" =~ from\ v?([0-9]+)[^\ ]*\ to\ v?([0-9]+) ]] && [ "${BASH_REMATCH[1]}" != "${BASH_REMATCH[2]}" ]; then
```

It fails in **both** directions:
- **Never fires on grouped PRs** — Dependabot titles them `bump the <group> group…` with no versions, so a major hidden inside a group merges automatically.
- **Can false-fire on SHA-pinned action bumps** — `bump actions/checkout from 08eba0b to 8f4b7f8` — digit-leading SHAs match the regex and a patch bump gets refused.

This repo's own `auto-merge.yml` replaced it with `dependabot/fetch-metadata` in #342. The **generator** kept emitting the regex — so `/checkup` now (correctly) reports `drift:auto-merge.yml`, and every fresh scaffold inherits the bug.

## Fix

Port #342's approach into the generator: read `steps.dependabot-meta.outputs.update-type` and block on `version-update:semver-major`. For a grouped PR, `fetch-metadata` reports the **highest** update-type in the group, so a major hidden in a group is caught.

- Generated YAML **parse-checked** (both `auto-merge.yml` and `dependabot-automerge.yml`, `id`s intact).
- **Regression test** asserts `BASH_REMATCH`/`PR_TITLE` cannot return and that the block gates on the metadata output. Mutation-tested: re-inlining the regex fails the test.

## Governance gap the advisory surfaced

`fetch-metadata` was **hardcoded inline** at `v2.5.0` in `generateDependabotAutomergeYml`, bypassing `ACTION_PINS` — and therefore bypassing the `verify:pins` guard from #355. It is now an `ACTION_PINS` entry (`v3.1.0`, matching #342), referenced from both generators.

`tools/verify-action-pins.ts` is extended so this class cannot recur: it now scans the emitter sources for `uses: owner/repo@sha` literals and **fails any SHA not declared in `ACTION_PINS`**. Mutation-tested against re-inlining `v2.5.0`:

```
MUTANT (inline v2.5.0)  -> exit 1  FAIL …/workflows-fleet.ts: uses dependabot/fetch-metadata@21025c705c08 — not declared in ACTION_PINS
RESTORED                -> exit 0  All 9 pins resolve; no inline pin bypasses ACTION_PINS.
```

## Trap checked, not assumed

`fetch-metadata` `v3.0.0`'s only breaking change is requiring **node24 on the runner** — `ubuntu-latest` supplies it. The `update-type` outputs are unchanged from `v2`, and the SHA (`25dd0e34…`) is exactly this repo's `v3.1.0`, which blocked #306 in production. No new secret/permission: the generated workflow already mints the App token (`steps.app.outputs.token`).

## Gates

`lint` 0 errors, `typecheck` clean, **593 tests** pass, `validate_plugins.py` green, `verify:pins` green (9 pins, no bypass).

## Scope

Advisory Q2. Q1 (the cross-plugin ownership decision) and Q3 (widening the cooldown-unsupported ecosystem set, pending a doc re-check) are deliberately separate. No dependency on the open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)