### PR TITLE
refactor(dev-core): pin APP_MINT_STEP via ACTION_PINS + local generator tests

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/shared/__tests__/github-infra.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/github-infra.test.ts
@@ -1,11 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import type { TokenMode } from '../adapters/github-infra'
 import { APP_MINT_STEP, emitAppMintStep, PAT_RETIREMENT_BANNER, REQUIRED_SECRETS } from '../adapters/github-infra'
 import { ACTION_PINS } from '../workflows/workflow-pins'
 
+const GITHUB_INFRA_SRC = join(dirname(fileURLToPath(import.meta.url)), '../adapters/github-infra.ts')
+
 describe('APP_MINT_STEP', () => {
   it('uses ACTION_PINS.createAppToken (single pin SSoT)', () => {
     expect(APP_MINT_STEP).toContain(ACTION_PINS.createAppToken)
+  })
+
+  it('source interpolates ACTION_PINS.createAppToken (not a same-SHA hardcode)', () => {
+    // Runtime toContain alone still passes if APP_MINT_STEP hardcodes the expanded
+    // pin string. Source-level lock closes that bypass after github-infra left EMITTER_PATHS (#361 review).
+    const source = readFileSync(GITHUB_INFRA_SRC, 'utf-8')
+    expect(source).toContain('${ACTION_PINS.createAppToken}')
+    expect(source).not.toMatch(/uses:\s*[\w.-]+\/[\w.-]+@[0-9a-fA-F]{7,}/)
   })
 
   it('uses ROXABI_CI_APP_ID var', () => {

--- a/plugins/dev-core/skills/shared/__tests__/github-infra.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/github-infra.test.ts
@@ -17,6 +17,7 @@ describe('APP_MINT_STEP', () => {
     // Runtime toContain alone still passes if APP_MINT_STEP hardcodes the expanded
     // pin string. Source-level lock closes that bypass after github-infra left EMITTER_PATHS (#361 review).
     const source = readFileSync(GITHUB_INFRA_SRC, 'utf-8')
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: assert source template form — intentional plain string
     expect(source).toContain('${ACTION_PINS.createAppToken}')
     expect(source).not.toMatch(/uses:\s*[\w.-]+\/[\w.-]+@[0-9a-fA-F]{7,}/)
   })

--- a/plugins/dev-core/skills/shared/__tests__/github-infra.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/github-infra.test.ts
@@ -1,16 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { TokenMode } from '../adapters/github-infra'
 import { APP_MINT_STEP, emitAppMintStep, PAT_RETIREMENT_BANNER, REQUIRED_SECRETS } from '../adapters/github-infra'
-
-const EXPECTED_SHA = 'bcd2ba49218906704ab6c1aa796996da409d3eb1'
+import { ACTION_PINS } from '../workflows/workflow-pins'
 
 describe('APP_MINT_STEP', () => {
-  it('contains the locked SHA pin', () => {
-    expect(APP_MINT_STEP).toContain(`actions/create-github-app-token@${EXPECTED_SHA}`)
-  })
-
-  it('references the version comment', () => {
-    expect(APP_MINT_STEP).toContain('# v3.2.0')
+  it('uses ACTION_PINS.createAppToken (single pin SSoT)', () => {
+    expect(APP_MINT_STEP).toContain(ACTION_PINS.createAppToken)
   })
 
   it('uses ROXABI_CI_APP_ID var', () => {

--- a/plugins/dev-core/skills/shared/__tests__/workflows.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/workflows.test.ts
@@ -1,0 +1,323 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ACTION_PINS } from '../workflows/workflow-pins'
+import {
+  classifyTestRunner,
+  generateAutoMergeYml,
+  generateCiYml,
+  generateContextLintYml,
+  generateDeployYml,
+  workflowOptsFromStack,
+  writeWorkflows,
+} from '../workflows/workflows'
+import {
+  generateDependabotAutomergeYml,
+  generateDependabotYml,
+  generateMergeOnGreenYml,
+  generateSecretScanYml,
+} from '../workflows/workflows-fleet'
+
+describe('generateAutoMergeYml', () => {
+  it('emits the App token mint step (no secrets.PAT)', () => {
+    const yml = generateAutoMergeYml()
+    expect(yml).toContain(ACTION_PINS.createAppToken)
+    expect(yml).toContain('vars.ROXABI_CI_APP_ID')
+    expect(yml).toContain('secrets.ROXABI_CI_APP_PRIVATE_KEY')
+    expect(yml).not.toContain('secrets.PAT')
+  })
+
+  it('uses steps.app.outputs.token (not PAT) for all GH_TOKEN references', () => {
+    const yml = generateAutoMergeYml()
+    const ghTokenMatches = [...yml.matchAll(/GH_TOKEN:\s*\$\{\{[^}]+\}\}/g)].map((m) => m[0])
+    expect(ghTokenMatches.length).toBeGreaterThan(0)
+    for (const match of ghTokenMatches) {
+      expect(match).toContain('steps.app.outputs.token')
+    }
+  })
+
+  it('emits SHA-pinned github-script for close-linked-issues', () => {
+    const yml = generateAutoMergeYml()
+    expect(yml).toContain(ACTION_PINS.githubScript)
+    expect(yml).not.toContain('actions/github-script@v8')
+  })
+
+  it('blocks semver-major via fetch-metadata, not the dead title regex', () => {
+    const yml = generateAutoMergeYml()
+    // The title regex never fired on grouped PRs (no versions in the title) and
+    // could misread SHA-pinned action bumps — #342 replaced it with metadata.
+    expect(yml).not.toContain('BASH_REMATCH')
+    expect(yml).not.toContain('PR_TITLE')
+    expect(yml).toContain(ACTION_PINS.dependabotFetchMetadata)
+
+    // Derive the reference from the declared id — a rename of `id:` that forgets
+    // to update the block's `if:` must fail this, not just an equality check.
+    const fetchIdMatch = yml.match(/- name: Fetch dependabot metadata\s*\n\s*id: (\S+)/)
+    if (!fetchIdMatch) throw new Error('Fetch dependabot metadata step id not found')
+    const fetchId = fetchIdMatch[1]
+
+    const blockStart = yml.indexOf('- name: Block dependabot semver-major')
+    expect(blockStart).toBeGreaterThan(-1)
+    const nextStepOffset = yml.slice(blockStart + 1).search(/\n\s*- name: /)
+    const blockRegion =
+      nextStepOffset === -1 ? yml.slice(blockStart) : yml.slice(blockStart, blockStart + 1 + nextStepOffset)
+
+    expect(blockRegion).toContain(`steps.${fetchId}.outputs.update-type == 'version-update:semver-major'`)
+    // Scoped to the Block step only — the whole YAML also has a legitimate
+    // `exit 0` elsewhere (update-behind-prs' empty-PR-list check).
+    expect(blockRegion).toContain('exit 1')
+  })
+})
+
+describe('generateCiYml', () => {
+  it('generates bun + vitest CI with SHA-pinned setup-bun', () => {
+    const yml = generateCiYml({ stack: 'bun', test: 'vitest', deploy: 'none' })
+    expect(yml).toContain(ACTION_PINS.setupBun)
+    expect(yml).toContain('bun install')
+    expect(yml).toContain('bun lint')
+    expect(yml).toContain('bun typecheck')
+    expect(yml).toContain('run: bun run test')
+    expect(yml).not.toContain('trufflehog')
+  })
+
+  it('omits lint/typecheck when disabled', () => {
+    const yml = generateCiYml({
+      stack: 'bun',
+      test: 'none',
+      deploy: 'none',
+      lint: false,
+      typecheck: false,
+    })
+    expect(yml).not.toContain('bun lint')
+    expect(yml).not.toContain('bun typecheck')
+  })
+
+  it('uses bun run test for bun/jest stacks (package-script convention)', () => {
+    const yml = generateCiYml({ stack: 'bun', test: 'jest', deploy: 'none' })
+    expect(yml).toContain('run: bun run test')
+  })
+
+  it('emits bun runner via --test bun as bun run test by default', () => {
+    const yml = generateCiYml({ stack: 'bun', test: 'bun', deploy: 'none' })
+    expect(yml).toContain('run: bun run test')
+  })
+
+  it('emits verbatim testCommand when set', () => {
+    const yml = generateCiYml({
+      stack: 'bun',
+      test: 'bun',
+      testCommand: 'bun test packages/shared',
+      deploy: 'none',
+    })
+    expect(yml).toContain('run: bun test packages/shared')
+  })
+
+  it('generates node + jest CI with SHA-pinned setup-node', () => {
+    const yml = generateCiYml({ stack: 'node', test: 'jest', deploy: 'none' })
+    expect(yml).toContain(ACTION_PINS.setupNode)
+    expect(yml).toContain('npm ci')
+    expect(yml).toContain('npm run lint')
+    expect(yml).toContain('npx tsc --noEmit')
+    expect(yml).toContain('npm test')
+  })
+
+  it('omits test step and comments when test is "none"', () => {
+    const yml = generateCiYml({ stack: 'bun', test: 'none', deploy: 'none' })
+    expect(yml).not.toMatch(/- name: Test/)
+    expect(yml).toContain('test: none — no unit test step')
+  })
+
+  it('includes optional e2e job when e2e is playwright', () => {
+    const yml = generateCiYml({ stack: 'bun', test: 'vitest', deploy: 'none', e2e: 'playwright' })
+    expect(yml).toContain('e2e:')
+    expect(yml).toContain('bun run test:e2e')
+  })
+
+  it('targets main and staging branches', () => {
+    const yml = generateCiYml({ stack: 'bun', test: 'vitest', deploy: 'none' })
+    expect(yml).toContain('branches: [main, staging]')
+  })
+})
+
+describe('generateSecretScanYml', () => {
+  it('is standalone with SHA-pinned checkout and trufflehog', () => {
+    const yml = generateSecretScanYml()
+    expect(yml).toContain('name: Secret Scan')
+    expect(yml).toContain(ACTION_PINS.checkout)
+    expect(yml).toContain(ACTION_PINS.trufflehog)
+    expect(yml).toContain('--only-verified')
+  })
+})
+
+describe('generateMergeOnGreenYml', () => {
+  it('wakes on CI and Secret Scan workflow names', () => {
+    const yml = generateMergeOnGreenYml({ stack: 'bun', test: 'none', deploy: 'none' })
+    expect(yml).toContain('name: Merge on Green')
+    expect(yml).toContain('- CI')
+    expect(yml).toContain('- Secret Scan')
+    expect(yml).toContain(ACTION_PINS.githubScript)
+  })
+})
+
+describe('generateDependabotAutomergeYml', () => {
+  it('labels dependabot patch/minor PRs reviewed', () => {
+    const yml = generateDependabotAutomergeYml()
+    expect(yml).toContain('dependabot[bot]')
+    expect(yml).toContain('semver-patch')
+    expect(yml).toContain(ACTION_PINS.createAppToken)
+    expect(yml).toContain(ACTION_PINS.dependabotFetchMetadata)
+    expect(yml).not.toContain('21025c705c08')
+  })
+})
+
+describe('generateDependabotYml', () => {
+  it('emits npm + github-actions for bun stack', () => {
+    const yml = generateDependabotYml({ stack: 'bun' })
+    expect(yml).toContain('package-ecosystem: npm')
+    expect(yml).toContain('package-ecosystem: github-actions')
+    expect(yml).toContain('default-days: 3')
+    expect(yml).not.toContain('semver-major-days')
+  })
+
+  it('emits pip ecosystem for python stack', () => {
+    const yml = generateDependabotYml({ stack: 'python' })
+    expect(yml).toContain('package-ecosystem: pip')
+    expect(yml).toContain('package-ecosystem: github-actions')
+  })
+})
+
+describe('classifyTestRunner / workflowOptsFromStack', () => {
+  it('maps bun run test (canonical vitest-on-bun) to vitest, not none', () => {
+    expect(classifyTestRunner(undefined, 'bun run test')).toBe('vitest')
+    const opts = workflowOptsFromStack({
+      runtime: 'bun',
+      commands: { test: 'bun run test' },
+    })
+    expect(opts.test).toBe('vitest')
+    expect(opts.testCommand).toBe('bun run test')
+  })
+
+  it('maps testing.unit bun + bare bun test to bun', () => {
+    expect(classifyTestRunner('bun', 'bun test')).toBe('bun')
+  })
+
+  it('prefers testing.unit vitest over command text', () => {
+    expect(classifyTestRunner('vitest', 'bun run test')).toBe('vitest')
+  })
+
+  it('emits CI test step from stack with only commands.test', () => {
+    const opts = workflowOptsFromStack({
+      runtime: 'bun',
+      commands: { test: 'bun run test', lint: 'bun lint' },
+    })
+    const yml = generateCiYml(opts)
+    expect(yml).toContain('run: bun run test')
+    expect(yml).toMatch(/- name: Test/)
+  })
+})
+
+describe('generateDeployYml', () => {
+  it('generates Vercel deploy workflow', () => {
+    const yml = generateDeployYml({ stack: 'bun', test: 'none', deploy: 'vercel' })
+    expect(yml).toContain('Deploy to Vercel')
+    expect(yml).toContain('VERCEL_TOKEN')
+    expect(yml).toContain('VERCEL_PROJECT_ID')
+  })
+
+  it('generates placeholder when deploy is "none"', () => {
+    const yml = generateDeployYml({ stack: 'bun', test: 'none', deploy: 'none' })
+    expect(yml).toContain('No deploy target configured')
+  })
+
+  it('uses SHA-pinned node setup when stack is node', () => {
+    const yml = generateDeployYml({ stack: 'node', test: 'none', deploy: 'vercel' })
+    expect(yml).toContain(ACTION_PINS.setupNode)
+    expect(yml).toContain('npm ci')
+  })
+
+  it('has workflow_dispatch trigger', () => {
+    const yml = generateDeployYml({ stack: 'bun', test: 'none', deploy: 'none' })
+    expect(yml).toContain('workflow_dispatch')
+  })
+})
+
+describe('writeWorkflows', () => {
+  // writeWorkflows writes under the cwd — every case runs in a throwaway dir so the
+  // repo's own .github/ can never be touched.
+  const opts = { stack: 'bun', test: 'vitest', deploy: 'none' } as const
+  let tmp: string
+  let origCwd: string
+
+  beforeEach(() => {
+    origCwd = process.cwd()
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'write-workflows-'))
+    process.chdir(tmp)
+  })
+
+  afterEach(() => {
+    process.chdir(origCwd)
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('does not clobber existing files by default (top-up)', async () => {
+    fs.mkdirSync('.github/workflows', { recursive: true })
+    fs.writeFileSync('.github/workflows/ci.yml', 'sentinel-ci')
+    fs.writeFileSync('.github/dependabot.yml', 'sentinel-dependabot')
+
+    const results = await writeWorkflows(opts)
+
+    expect(fs.readFileSync('.github/workflows/ci.yml', 'utf8')).toBe('sentinel-ci')
+    expect(fs.readFileSync('.github/dependabot.yml', 'utf8')).toBe('sentinel-dependabot')
+    expect(results).toContainEqual({ file: 'ci.yml', status: 'skipped' })
+    expect(results).toContainEqual({ file: 'dependabot.yml', status: 'skipped' })
+    // absent files are still topped up
+    expect(results).toContainEqual({ file: 'auto-merge.yml', status: 'created' })
+    expect(fs.readFileSync('.github/workflows/auto-merge.yml', 'utf8')).toContain('name: Auto Merge')
+  })
+
+  it('overwrites existing files with force', async () => {
+    fs.mkdirSync('.github/workflows', { recursive: true })
+    fs.writeFileSync('.github/workflows/ci.yml', 'sentinel-ci')
+    fs.writeFileSync('.github/dependabot.yml', 'sentinel-dependabot')
+
+    const results = await writeWorkflows(opts, true)
+
+    expect(fs.readFileSync('.github/workflows/ci.yml', 'utf8')).toContain('name: CI')
+    expect(fs.readFileSync('.github/dependabot.yml', 'utf8')).toContain('package-ecosystem: npm')
+    expect(results).toContainEqual({ file: 'ci.yml', status: 'updated' })
+    expect(results).toContainEqual({ file: 'dependabot.yml', status: 'updated' })
+  })
+
+  it('reports dependabot.yml alongside the workflows it writes', async () => {
+    const results = await writeWorkflows(opts)
+
+    expect(results).toContainEqual({ file: 'dependabot.yml', status: 'created' })
+    expect(fs.existsSync('.github/dependabot.yml')).toBe(true)
+    // every file touched on disk appears in the report — no silent writes
+    const reported = results.map((r) => r.file).sort()
+    const onDisk = [...fs.readdirSync('.github/workflows'), 'dependabot.yml'].sort()
+    expect(reported).toEqual(onDisk)
+  })
+
+  it('reports the deploy workflow for a cloudflare stack', async () => {
+    const results = await writeWorkflows({ stack: 'bun', test: 'vitest', deploy: 'cloudflare' })
+
+    expect(results).toContainEqual({ file: 'deploy-cloudflare.yml', status: 'created' })
+  })
+})
+
+describe('generateContextLintYml', () => {
+  it('is read-only and uses SHA-pinned checkout', () => {
+    const yml = generateContextLintYml()
+    expect(yml).toContain('permissions:\n  contents: read')
+    expect(yml).toContain(ACTION_PINS.checkout)
+    expect(yml).not.toContain('secrets.')
+  })
+
+  it('triggers only on agent-context file paths', () => {
+    const yml = generateContextLintYml()
+    expect(yml).toContain("'**/CLAUDE.md'")
+    expect(yml).toContain("'.grok/**'")
+  })
+})

--- a/plugins/dev-core/skills/shared/adapters/github-infra.ts
+++ b/plugins/dev-core/skills/shared/adapters/github-infra.ts
@@ -4,6 +4,7 @@
  */
 
 import { ConfigError } from '../domain/errors'
+import { ACTION_PINS } from '../workflows/workflow-pins'
 
 export const STANDARD_WORKFLOWS = [
   'ci.yml',
@@ -30,13 +31,13 @@ export type TokenMode = 'github-app' | 'pat'
 /**
  * SHA-pinned mint step for the roxabi-ci GitHub App.
  * Consumers reference `${{ steps.app.outputs.token }}`.
- * NEVER use a floating tag — pin is bcd2ba49218906704ab6c1aa796996da409d3eb1 (v3.2.0).
+ * Pin source of truth: ACTION_PINS.createAppToken (workflow-pins.ts) — never float a tag.
  */
 export const APP_MINT_STEP = `      # roxabi-ci App token (ephemeral, 1 h) — pushes re-trigger CI,
       # which GITHUB_TOKEN cannot do.
       - name: Mint app token (roxabi-ci)
         id: app
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: ${ACTION_PINS.createAppToken}
         with:
           app-id: \${{ vars.ROXABI_CI_APP_ID }}
           private-key: \${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}`

--- a/plugins/dev-init/skills/shared/adapters/github-infra.ts
+++ b/plugins/dev-init/skills/shared/adapters/github-infra.ts
@@ -6,6 +6,7 @@
  */
 
 import { ConfigError } from '../domain/errors'
+import { ACTION_PINS } from '../workflows/workflow-pins'
 
 export const STANDARD_WORKFLOWS = [
   'ci.yml',
@@ -32,13 +33,13 @@ export type TokenMode = 'github-app' | 'pat'
 /**
  * SHA-pinned mint step for the roxabi-ci GitHub App.
  * Consumers reference `${{ steps.app.outputs.token }}`.
- * NEVER use a floating tag — pin is bcd2ba49218906704ab6c1aa796996da409d3eb1 (v3.2.0).
+ * Pin source of truth: ACTION_PINS.createAppToken (workflow-pins.ts) — never float a tag.
  */
 export const APP_MINT_STEP = `      # roxabi-ci App token (ephemeral, 1 h) — pushes re-trigger CI,
       # which GITHUB_TOKEN cannot do.
       - name: Mint app token (roxabi-ci)
         id: app
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: ${ACTION_PINS.createAppToken}
         with:
           app-id: \${{ vars.ROXABI_CI_APP_ID }}
           private-key: \${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}`

--- a/tools/verify-action-pins.ts
+++ b/tools/verify-action-pins.ts
@@ -32,15 +32,11 @@ const REPO_ROOT = resolve(import.meta.dirname ?? '.', '..')
 const PINS_PATH = resolve(REPO_ROOT, 'plugins/dev-core/skills/shared/workflows/workflow-pins.ts')
 
 /** Sources that emit workflow YAML, all canonical in dev-core's copy-synced skills/shared.
- *  github-infra.ts keeps its create-app-token pin inline rather than importing ACTION_PINS
- *  (it now could — same skills/shared tree post-#359 — but that would couple adapters/ to
- *  workflows/); as an inline literal it is scanned here so it stays governed, and both plugin
- *  copies are listed since each carries the literal independently. */
+ *  github-infra.ts references ACTION_PINS.createAppToken (template interpolation) so it is
+ *  not an inline pin and does not need scanning here — see #361. */
 const EMITTER_PATHS = [
   'plugins/dev-core/skills/shared/workflows/workflows.ts',
   'plugins/dev-core/skills/shared/workflows/workflows-fleet.ts',
-  'plugins/dev-init/skills/shared/adapters/github-infra.ts',
-  'plugins/dev-core/skills/shared/adapters/github-infra.ts',
 ]
 
 const checkTags = process.argv.includes('--tags')


### PR DESCRIPTION
## Summary
- **#361:** `APP_MINT_STEP` imports `ACTION_PINS.createAppToken` (single pin SSoT); drop `github-infra` from `verify-action-pins` EMITTER_PATHS (template refs are not inline pins).
- **#362:** add `dev-core` local `workflows.test.ts` importing the canonical generators (pattern parity with other copy-synced shared files); keep dev-init suite as parity copy.
- Bump `dev-core` `0.8.19` → `0.8.20` (skills/ change; pre-push gate).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #361 + #362 (PR #359 follow-ups) | OPEN |
| Implementation | 1 commit on `refactor/361-362-action-pins-and-generator-tests` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (686) + `verify:pins` ✅ | Passed |

## Test Plan
- [x] `vitest` — github-infra + workflows (dev-core + dev-init) + verify-action-pins unit
- [x] `bun run verify:pins` — 9 pins resolve, 0 ungoverned
- [x] `bun run sync:shared` / shared-sources-sync check
- [ ] CI green on PR

Fixes #361
Fixes #362

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`