### PR TITLE
chore(dev-init): repoint base.md notation legend to canonical glossary

### DIFF
--- a/plugins/dev-init/skills/shared/references/base.md
+++ b/plugins/dev-init/skills/shared/references/base.md
@@ -13,4 +13,4 @@ codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project que
 
 ## Notation
 
-`¬` not | `→` then/maps-to | `∨` or | `∧` and | `∃` exists | `∀` for all | `≥/≤` threshold | `✓/✗` pass/fail | `S*` next-step variable | `Σ` state dict
+Legend → canonical glossary: `${CLAUDE_PLUGIN_ROOT}/../shared/references/notation.md` (repo: `plugins/shared/references/notation.md`)

--- a/tools/validate_plugins.py
+++ b/tools/validate_plugins.py
@@ -47,6 +47,7 @@ SKILL_LINE_BUDGETS = {'compress': 110}
 NOTATION_LEGEND_FILES = [
     PLUGINS_DIR / 'dev-core' / 'skills' / 'shared' / 'references' / 'base.md',
     PLUGINS_DIR / 'dev-core' / 'agents' / 'doc-writer.md',
+    PLUGINS_DIR / 'dev-init' / 'skills' / 'shared' / 'references' / 'base.md',
 ]
 NOTATION_GLOSSARY = PLUGINS_DIR / 'shared' / 'references' / 'notation.md'
 COMPRESS_SKILL = PLUGINS_DIR / 'compress' / 'skills' / 'compress' / 'SKILL.md'


### PR DESCRIPTION
## Summary
- Repoint `plugins/dev-init/skills/shared/references/base.md` § Notation to `notation.md` (same pointer as dev-core)
- Add path to `tools/validate_plugins.py::NOTATION_LEGEND_FILES`
- No dev-init version bump (version-less plugin.json → SHA shipping)

## Test Plan
- [x] `python3 tools/validate_plugins.py --check notation-legends`

Fixes #330