### PR TITLE
docs(dev-core): route users to /dev-init:init and /env-setup

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-core",
-  "version": "0.8.20",
-  "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
+  "version": "0.8.21",
+  "description": "Full development workflow \u2014 frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"
   }

--- a/plugins/dev-core/README.md
+++ b/plugins/dev-core/README.md
@@ -35,15 +35,17 @@ Without this step, recently-added skills (e.g. `/recheck`) won't appear in your 
 
 ## Getting Started
 
-After installing, run init to configure your project:
+After installing **dev-core** and **dev-init**, run the full project harness:
 
 ```
-/init
+/dev-init:init
 ```
 
-Auto-detects your GitHub repo. Writes `.claude/dev-core.yml` (primary config) and `.env` (legacy fallback), registers the project in `~/.roxabi-vault/workspace.json`, generates a self-healing `roxabi` shim, and creates the `artifacts/` directory. Works for any project type. Re-run with `/init --force` to reconfigure.
+> **Not** bare `/init` — that is Claude Code's built-in (scaffolds a `CLAUDE.md` only). The Roxabi harness is namespaced: `/dev-init:init`.
 
-Then configure the agent stack:
+Auto-detects your GitHub repo. Writes `.claude/dev-core.yml` (primary config) and `.env` (legacy fallback), registers the project in `~/.roxabi-vault/workspace.json`, generates a self-healing `roxabi` shim, and creates the `artifacts/` directory. Works for any project type. Re-run with `/dev-init:init --force` to reconfigure.
+
+Then configure the agent stack (also available standalone as `/env-setup` / `/stack-setup` without the full harness):
 
 ```
 /stack-setup
@@ -51,7 +53,7 @@ Then configure the agent stack:
 
 Auto-discovers your runtime, framework, test tooling, and linter from the codebase, shows a confirmation screen, and writes `.claude/stack.yml` so all agents know where things live.
 
-**Project-agnostic:** All skills and agents read commands and paths from `.claude/stack.yml` at runtime — `{commands.test}`, `{commands.lint}`, `{package_manager}`, `{backend.path}`, etc. If a required field is missing, the agent immediately tells you to run `/init` or `/stack-setup`. This means dev-core works with any stack — Bun/npm/pnpm/yarn, NestJS/Express/Django, Vitest/Jest/Pytest.
+**Project-agnostic:** All skills and agents read commands and paths from `.claude/stack.yml` at runtime — `{commands.test}`, `{commands.lint}`, `{package_manager}`, `{backend.path}`, etc. If a required field is missing, the agent immediately tells you to run `/env-setup` or `/stack-setup`. This means dev-core works with any stack — Bun/npm/pnpm/yarn, NestJS/Express/Django, Vitest/Jest/Pytest.
 
 **Note:** dev-core is issues-only — no GitHub Project V2 board. Issue triage (labels for size/priority/lane/type, blocked-by deps, parent/child sub-issues) lives in the separate **`roxabi-issues`** plugin (Roxabi/roxabi-live); dev-core's `/dev` lifecycle reads issues but no longer mutates them.
 
@@ -72,7 +74,7 @@ Where `#N` is a GitHub issue number. The orchestrator scans existing artifacts, 
 | Skill | Phase | Description |
 |-------|-------|-------------|
 | `init` | Setup | Configures project for dev-core (CI/CD workflows, branch protection, env vars, workspace.json registration, VS Code MDX preview, LSP plugin install). Pushes workflow files directly via GitHub REST API — no local git required. Auto-sets PAT secret after workflow creation. TypeScript CLI with subcommands, SKILL.md orchestrates via user decision decisions |
-| `env-setup` | Setup | Set up local dev environment — stack.yml, CLAUDE.md Critical Rules, docs scaffolding, VS Code MDX, LSP. Triggered by `/init` or standalone |
+| `env-setup` | Setup | Set up local dev environment — stack.yml, CLAUDE.md Critical Rules, docs scaffolding, VS Code MDX, LSP. Triggered by `/dev-init:init` or standalone `/env-setup` |
 | `ci-setup` | Setup | Set up CI/CD — GitHub Actions workflows, TruffleHog, Dependabot, pre-commit hooks, marketplace plugins. Discovers Roxabi plugins live from `marketplace.json` and endorsed external marketplaces from `curated-marketplaces.json` |
 | `stack-setup` | Setup | Auto-discovers runtime, framework, test tooling, and linter from the codebase, then writes `.claude/stack.yml`. Single confirmation screen — no wizard questions |
 | `doctor` | Setup | Project-type-aware health check — verifies prerequisites, GitHub config, labels, CI/CD workflows (checks both local files and remote via REST API), required secrets (PAT for auto-merge.yml), branch protection, stack.yml, workspace.json registration, VS Code MDX preview, and LSP plugin install (typescript-lsp / pyright-lsp with auto-fix). Distinguishes ❌ blocking errors from ⚠️ optional warnings; exits 0 when warnings-only |

--- a/plugins/dev-core/agents/architect.md
+++ b/plugins/dev-core/agents/architect.md
@@ -20,7 +20,7 @@ maxTurns: 50
 
 Let: C := confidence score (0–100) | SA := `{standards.architecture}` | SD := `{standards.dev_process}` | SC := `{standards.contributing}`
 
-SA undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
+SA undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/env-setup`."
 SD undefined → warn: "standards.dev_process not set in stack.yml — proceeding without dev process standards." and continue.
 SC undefined → warn: "standards.contributing not set in stack.yml — proceeding without contributing standards." and continue.
 

--- a/plugins/dev-core/agents/backend-dev.md
+++ b/plugins/dev-core/agents/backend-dev.md
@@ -20,7 +20,7 @@ maxTurns: 50
 
 Let: C := confidence score (0–100) | BP := `{backend.path}` | SB := `{standards.backend}` | ST := `{standards.testing}`
 
-BP undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
+BP undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/env-setup`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).

--- a/plugins/dev-core/agents/devops.md
+++ b/plugins/dev-core/agents/devops.md
@@ -20,7 +20,7 @@ maxTurns: 50
 
 Let: C := confidence score (0–100) | PM := `{package_manager}` | BO := `{build.orchestrator}`
 
-PM undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
+PM undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/env-setup`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).

--- a/plugins/dev-core/agents/doc-writer.md
+++ b/plugins/dev-core/agents/doc-writer.md
@@ -20,7 +20,7 @@ maxTurns: 30
 
 Let: DP := `{docs.path}` | DF := `{docs.framework}` | FMT := `{docs.format}` | SC := `{standards.contributing}`
 
-DP undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
+DP undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/env-setup`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).

--- a/plugins/dev-core/agents/fixer.md
+++ b/plugins/dev-core/agents/fixer.md
@@ -20,7 +20,7 @@ maxTurns: 50
 
 Let: φ := finding | Φ := finding set | C := confidence (0–100) | ST := `{shared.types}` | SU := `{shared.ui}`
 
-`{commands.lint}` undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
+`{commands.lint}` undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/env-setup`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).

--- a/plugins/dev-core/agents/frontend-dev.md
+++ b/plugins/dev-core/agents/frontend-dev.md
@@ -20,7 +20,7 @@ maxTurns: 50
 
 Let: C := confidence (0–100) | β := `{frontend.path}` | μ := `{frontend.ui_src}` | ν := `{frontend.ui_package}`
 
-β undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
+β undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/env-setup`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).

--- a/plugins/dev-core/agents/product-lead.md
+++ b/plugins/dev-core/agents/product-lead.md
@@ -21,7 +21,7 @@ maxTurns: 50
 
 Let: C := confidence (0–100) | α := `{artifacts.analyses}` | ρ := `{artifacts.specs}`
 
-α undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
+α undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/env-setup`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).

--- a/plugins/dev-core/agents/security-auditor.md
+++ b/plugins/dev-core/agents/security-auditor.md
@@ -20,7 +20,7 @@ maxTurns: 30
 
 Let: C := confidence (0–100) | φ := finding | Φ := finding set | E := exclusion list | σ := severity | π := `{package_manager}`
 
-π undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
+π undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/env-setup`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).

--- a/plugins/dev-core/agents/tester.md
+++ b/plugins/dev-core/agents/tester.md
@@ -20,7 +20,7 @@ maxTurns: 50
 
 Let: C := confidence (0–100) | ς := `{standards.testing}`
 
-ς undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/init`."
+ς undefined → output: "`.claude/stack.yml` not found in context. Add `@.claude/stack.yml` as the first line of your CLAUDE.md, then run `/env-setup`."
 
 **Communication:** Report status, blockers, and handoffs in your final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work where possible.
 **Research order:** codebase (Glob/Grep/Read) → WebSearch (last resort, ¬for internal project questions).

--- a/plugins/dev-core/references/issue-taxonomy.md
+++ b/plugins/dev-core/references/issue-taxonomy.md
@@ -6,7 +6,7 @@ Single fact source for issue metadata across every Roxabi repo.
 
 > **ProjectV2 board path removed (#268).** The hub Project V2 board integration — `config-helpers.ts` field IDs, `addToProject`, `isProjectConfigured()`, and the `migrate-*` scripts — was deleted from the code. Every write is now a label or native field; there is no board path. See §7 for the migration history that produced this issues-only model.
 
-**Who reads this:** `dev-core:issue-triage` (writer) · `dev-core:github-setup` (label/type bootstrap) · `lyra/scripts/dep-graph` · `roxabi-live` worker (repo-centric GraphQL readers).
+**Who reads this:** `roxabi-issues:issue-triage` (writer) · label/type bootstrap via `/dev-init:init` / org tooling · `lyra/scripts/dep-graph` · `roxabi-live` worker (repo-centric GraphQL readers).
 
 ---
 

--- a/plugins/dev-core/skills/env-setup/SKILL.md
+++ b/plugins/dev-core/skills/env-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: env-setup
 argument-hint: '[--force]'
-description: 'Set up local dev environment — stack.yml, CLAUDE.md Critical Rules, docs scaffolding, VS Code MDX, LSP. Triggered by /init or standalone. Triggers: "env setup" | "setup environment" | "configure stack" | "scaffold rules".'
+description: 'Set up local dev environment — stack.yml, CLAUDE.md Critical Rules, docs scaffolding, VS Code MDX, LSP. Triggered by /dev-init:init or standalone /env-setup. Triggers: "env setup" | "setup environment" | "configure stack" | "scaffold rules".'
 version: 0.1.0
 allowed-tools: Bash, Read, Write, Edit, ToolSearch
 ---
@@ -240,7 +240,7 @@ Env Setup Complete
   LSP               ✅ Configured / ✅ Already set / ⏭ Disabled / ⏭ Skipped
   Worktree-setup    ✅ Scaffolded / ✅ Already configured / ⏭ Skipped
 
-Next: run /seed-docs to populate docs stubs, or /github-setup to connect GitHub Project.
+Next: run /seed-docs to populate docs stubs. Issue triage (labels, blocked-by, parent/child) lives in the separate **roxabi-issues** plugin.
 ```
 
 ## Safety Rules


### PR DESCRIPTION
## Summary
- README: post-install is `/dev-init:init` (not bare `/init`); missing stack → `/env-setup`
- 9 agents: hard-stop message → `/env-setup`
- env-setup: drop deleted `/github-setup` next-step
- issue-taxonomy: issue-triage → `roxabi-issues`; bootstrap via init harness
- Bump `0.8.20` → `0.8.21`

## Test Plan
- [x] Grep agents for bare `/init` hard-stop → gone
- [x] README fenced block is `/dev-init:init`

Fixes #343