### PR TITLE
fix(dev-init): stop protect-branches from resurrecting a retired branch

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/checkup/cookbooks/devcore-checks.md
+++ b/plugins/dev-core/skills/checkup/cookbooks/devcore-checks.md
@@ -24,7 +24,7 @@
 | `tools/licenseChecker.ts` missing | Run `/init` Phase 10d |
 | trufflehog not in lefthook | Run `/init` Phase 10d — regenerates `lefthook.yml` |
 | license check not in lefthook | Run `/init` Phase 10d — regenerates `lefthook.yml` |
-| `PR_Main` ruleset missing | `bun $I_TS protect-branches --repo <owner/repo>` |
+| `PR_Main` ruleset missing | `bun $I_TS protect-branches --repo <owner/repo>` — a protected branch that does not exist is reported `skipped` and left alone. Pass `--create-missing` only when bootstrapping a fresh repo: on a trunk-mode repo the absent branch (`staging`) was retired on purpose, and creating it resurrects it. |
 | `PR_Main` allowed_merge_methods ≠ `["merge"]` | **Rulesets PUT is a full replace — never send a partial body (it wipes the other rules + bypass actors).** Fetch, mutate, send whole object: `gh api repos/:owner/:repo/rulesets/<id> \| jq '(.rules[] \| select(.type=="pull_request") \| .parameters.allowed_merge_methods) = ["merge"]' \| gh api repos/:owner/:repo/rulesets/<id> --method PUT --input -` — merge-commit only, see `shared/references/release-convention.md` |
 | `PR_Main` ¬targets default branch | Same full-replace rule: `gh api repos/:owner/:repo/rulesets/<id> \| jq '.conditions.ref_name.include = ["~DEFAULT_BRANCH"]' \| gh api repos/:owner/:repo/rulesets/<id> --method PUT --input -` — a ruleset pinned to `main` protects nothing when default is `staging` |
 | secret scanning / push protection disabled | `printf '%s' '{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}' \| gh api repos/<owner>/<repo> --method PATCH --input -` — free on public repos (printf: POSIX-safe, `<<<` is bash-only) |

--- a/plugins/dev-init/skills/init/__tests__/protection.test.ts
+++ b/plugins/dev-init/skills/init/__tests__/protection.test.ts
@@ -66,7 +66,7 @@ describe('protectBranches', () => {
     expect(result.ruleset).toBe(true)
   })
 
-  it('creates branch if it does not exist', async () => {
+  it('creates branch if it does not exist, when createMissing is opted into', async () => {
     // Branch does not exist
     spawnSyncSpy.mockReturnValue({
       stdout: new Uint8Array(),
@@ -82,12 +82,40 @@ describe('protectBranches', () => {
     } as unknown as ReturnType<typeof Bun.spawn>)
 
     const { protectBranches } = await import('../lib/protection')
-    const _result = await protectBranches('Org/repo')
+    const _result = await protectBranches('Org/repo', { createMissing: true })
 
     // run() should have been called for git branch + git push for each branch
     expect(mockRun).toHaveBeenCalled()
     const branchCalls = mockRun.mock.calls.filter((c: string[][]) => c[0].includes('git'))
     expect(branchCalls.length).toBeGreaterThan(0)
+  })
+
+  it('skips a missing branch by default instead of resurrecting it', async () => {
+    // Branch does not exist locally — the state a trunk repo is left in after
+    // `staging` is retired (#376). Recreating it here would undo the migration.
+    spawnSyncSpy.mockReturnValue({
+      stdout: new Uint8Array(),
+      stderr: new Uint8Array(),
+      exitCode: 1,
+      success: false,
+    } as unknown as ReturnType<typeof Bun.spawnSync>)
+
+    spawnSpy.mockReturnValue({
+      exited: Promise.resolve(0),
+      stdout: new ReadableStream(),
+      stderr: new ReadableStream(),
+    } as unknown as ReturnType<typeof Bun.spawn>)
+
+    const { protectBranches } = await import('../lib/protection')
+    const result = await protectBranches('Org/repo')
+
+    expect(result.branches.main).toBe('skipped')
+    expect(result.branches.staging).toBe('skipped')
+
+    // No branch was created and nothing was pushed to the remote.
+    const pushCalls = mockRun.mock.calls.filter((c: string[][]) => c[0].includes('push'))
+    expect(pushCalls).toHaveLength(0)
+    expect(mockRun).not.toHaveBeenCalled()
   })
 
   it('deletes PR review requirement after applying protection', async () => {

--- a/plugins/dev-init/skills/init/init.ts
+++ b/plugins/dev-init/skills/init/init.ts
@@ -133,10 +133,10 @@ switch (command) {
     const { protectBranches } = await import('./lib/protection')
     const repo = parseFlag('--repo', '')
     if (!repo) {
-      console.error('Usage: init.ts protect-branches --repo <owner/repo>')
+      console.error('Usage: init.ts protect-branches --repo <owner/repo> [--create-missing]')
       process.exit(1)
     }
-    const result = await protectBranches(repo)
+    const result = await protectBranches(repo, { createMissing: hasFlag('--create-missing') })
     console.log(JSON.stringify(result, null, 2))
     break
   }

--- a/plugins/dev-init/skills/init/lib/protection.ts
+++ b/plugins/dev-init/skills/init/lib/protection.ts
@@ -10,12 +10,25 @@ import {
   PROTECTED_BRANCHES,
 } from '../../shared/adapters/github-infra'
 
+/** Per-branch outcome. `'skipped'` = the branch does not exist and was left alone. */
+export type BranchOutcome = boolean | 'skipped'
+
 export interface ProtectionResult {
-  branches: Record<string, boolean>
+  branches: Record<string, BranchOutcome>
   ruleset: boolean
 }
 
-export async function protectBranches(repo: string): Promise<ProtectionResult> {
+export interface ProtectOptions {
+  /**
+   * Create and push a protected branch that does not exist yet. Off by default:
+   * a missing branch is a deliberate repo state far more often than an oversight
+   * (a trunk-mode repo has retired `staging` on purpose), and inventing it here
+   * silently undoes that decision. Opt in when bootstrapping a fresh repo.
+   */
+  createMissing?: boolean
+}
+
+export async function protectBranches(repo: string, opts: ProtectOptions = {}): Promise<ProtectionResult> {
   const result: ProtectionResult = { branches: {}, ruleset: false }
   let hasSecretScan = false
   try {
@@ -26,9 +39,15 @@ export async function protectBranches(repo: string): Promise<ProtectionResult> {
 
   for (const branch of PROTECTED_BRANCHES) {
     try {
-      // Ensure branch exists
+      // Ensure branch exists — but never invent one unless explicitly asked.
+      // Mirrors the read side, which reports an absent branch as a skip rather
+      // than a failure (checkup's doctor-github.ts).
       const branchExists = Bun.spawnSync(['git', 'rev-parse', '--verify', branch], { stdout: 'pipe', stderr: 'pipe' })
       if (branchExists.exitCode !== 0) {
+        if (!opts.createMissing) {
+          result.branches[branch] = 'skipped'
+          continue
+        }
         await run(['git', 'branch', branch])
         await run(['git', 'push', '-u', 'origin', branch])
       }


### PR DESCRIPTION
`protectBranches` created and pushed any `PROTECTED_BRANCHES` entry that was missing locally (`protection.ts:27-34`). Once a repo retires `staging` — which #376 is about to do here — a routine `/checkup` remediation would recreate it on the remote and **silently undo the migration**. The `PR_Main` ruleset has no `creation` rule to stop it.

## Fix

Creation is now opt-in via `--create-missing`. By default a missing branch is reported `skipped` and left alone, mirroring the read side, which already treats an absent branch as a skip rather than a failure (`doctor-github.ts:152-158`).

## Why opt-in rather than gating on `release.model`

The recon suggested gating on the release model. Explicit opt-in is strictly safer and smaller:

- **Fails closed for every repo**, not only trunk ones. A staging-train repo with a transiently-missing branch also stops getting one invented.
- **No plumbing.** dev-init's `StackConfig` has no `release` field and `loadStack` does not parse one, so gating on the model would mean extending both plus the CLI — more surface, shipped to the whole fleet, to express a weaker guarantee.

## Not touched

`PROTECTED_BRANCHES` stays `['main', 'staging']`. Narrowing it to `['main']` would drop staging protection on **roxabi-factory** and **roxabi-live**, which are still staging-train — a security regression exported to other repos.

## Verification

- `ProtectionResult.branches` widened to `boolean | 'skipped'`; `tsc --noEmit` clean.
- Existing "creates branch if it does not exist" test updated to pass `{ createMissing: true }` — it asserted the old default and would otherwise have gone green while testing nothing.
- New test asserts the default path marks both branches `skipped` and issues **no** `run()` call at all, so nothing reaches the remote.
- Full suite: 47 files, 823 passed / 4 skipped.

Refs #376