### PR TITLE
fix(dev-core/promote): give auto-release.sh a committer identity for git tag -a

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/promote/__tests__/auto-release.test.ts
+++ b/plugins/dev-core/skills/promote/__tests__/auto-release.test.ts
@@ -97,6 +97,72 @@ function autoRelease(repo: string, args: string[]): RunResult {
   return { stdout: (r.stdout ?? '').trim(), stderr: r.stderr ?? '', code: r.status ?? -1 }
 }
 
+/**
+ * Bare `origin` + a `gh` shim, i.e. everything the non-dry-run path needs to run
+ * for real without a network. Returns the env to invoke the orchestrator with.
+ */
+function enactmentFixture(repo: string): { runEnv: NodeJS.ProcessEnv; ghLog: string } {
+  const origin = mkdtempSync(join(tmpdir(), 'auto-release-origin-'))
+  createdRepos.push(origin)
+  git(origin, ['init', '-q', '--bare', '-b', 'main'])
+  git(repo, ['remote', 'add', 'origin', origin])
+  git(repo, ['push', '-q', 'origin', 'main'])
+
+  const bin = mkdtempSync(join(tmpdir(), 'auto-release-bin-'))
+  createdRepos.push(bin)
+  const ghLog = join(bin, 'gh.log')
+  const marker = join(bin, 'release.created')
+  const ghShim = join(bin, 'gh')
+  writeFileSync(
+    ghShim,
+    [
+      '#!/usr/bin/env bash',
+      'echo "gh $*" >> "$GH_SHIM_LOG"',
+      'case "$1 $2" in',
+      '  "release view")   [ -f "$GH_SHIM_MARKER" ] && exit 0 || exit 1 ;;',
+      '  "release create") : > "$GH_SHIM_MARKER"; exit 0 ;;',
+      '  *) exit 0 ;;',
+      'esac',
+    ].join('\n'),
+  )
+  chmodSync(ghShim, 0o755)
+
+  return {
+    ghLog,
+    runEnv: {
+      ...gitEnv(),
+      PATH: `${bin}:${process.env.PATH ?? ''}`,
+      GH_SHIM_LOG: ghLog,
+      GH_SHIM_MARKER: marker,
+      GH_TOKEN: 'shim',
+    },
+  }
+}
+
+/** Strip every committer/author identity var — the state a bare CI runner is in. */
+function withoutIdentity(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {}
+  for (const [key, value] of Object.entries(env)) {
+    if (key.startsWith('GIT_AUTHOR_') || key.startsWith('GIT_COMMITTER_')) continue
+    out[key] = value
+  }
+  return out
+}
+
+/**
+ * Force the runner's exact failure mode, deterministically.
+ *
+ * Stripping GIT_COMMITTER_* is NOT enough: git still auto-derives an identity
+ * from the passwd entry, so on a dev box with a populated gecos field the tag
+ * succeeds and the regression hides. The runner failed precisely because its
+ * gecos is empty — it derived an email (`runner@runnervm...`) but no NAME, hence
+ * `fatal: empty ident name`. useConfigOnly makes git refuse to derive either,
+ * reproducing that on any host instead of only on gecos-less ones.
+ */
+function forbidDerivedIdentity(repo: string): void {
+  git(repo, ['config', 'user.useConfigOnly', 'true'])
+}
+
 // ─── S2-T4 — derivation topologies (dry-run: decide, do not push) ───────────────
 
 describe('auto-release.sh — derivation topologies (#371 S2)', () => {
@@ -298,5 +364,69 @@ describe('auto-release.sh — real enactment path (W3)', () => {
     const ghCalls = readFileSync(ghLog, 'utf8')
     expect(ghCalls).toMatch(/gh release create comp\/v0\.8\.0/)
     expect((ghCalls.match(/release create /g) ?? []).length).toBe(1)
+  })
+})
+
+// ─── W4 — annotated-tag identity on a bare runner (#376 dogfood regression) ────
+//
+// The W3 case above runs the enactment path for real, but through gitEnv(), which
+// exports GIT_COMMITTER_NAME/EMAIL. A GitHub runner exports neither and has no
+// git config, so `git tag -a` died `fatal: empty ident name` (exit 128) on the
+// very first Model-B release — after price.sh had correctly derived v0.5.0. The
+// harness supplied the one thing production lacked, so 823 green tests said
+// nothing. These cases remove it.
+
+describe('auto-release.sh — annotated tag with no committer identity (#376)', () => {
+  it('bare runner (no git config, no GIT_COMMITTER_*) → still tags, pushes, releases', () => {
+    const repo = initRepo()
+    commit(repo, 'chore: init')
+    tag(repo, 'comp/v0.7.0')
+    git(repo, ['checkout', '-q', '-b', 'feature'])
+    commit(repo, 'feat: x')
+    git(repo, ['checkout', '-q', 'main'])
+    const m = mergeNoFf(repo, 'feature', 'Merge feature') // derived → 0.8.0
+
+    const { runEnv, ghLog } = enactmentFixture(repo)
+    forbidDerivedIdentity(repo)
+    const r = spawnSync('bash', [AUTO_RELEASE_SH, 'comp', m], {
+      cwd: repo,
+      encoding: 'utf8',
+      env: withoutIdentity(runEnv),
+    })
+
+    expect(r.status, `stderr:\n${r.stderr}`).toBe(0)
+    expect(r.stderr).not.toMatch(/empty ident name/)
+    // The annotated tag really exists at M and reached origin.
+    expect(git(repo, ['cat-file', '-t', 'comp/v0.8.0'])).toBe('tag')
+    expect(git(repo, ['rev-list', '-n1', 'comp/v0.8.0'])).toBe(m)
+    expect(git(repo, ['ls-remote', '--tags', 'origin'])).toContain('comp/v0.8.0')
+    expect(readFileSync(ghLog, 'utf8')).toMatch(/gh release create comp\/v0\.8\.0/)
+  })
+
+  it('a configured identity is left alone (gap-fill, not override)', () => {
+    const repo = initRepo()
+    commit(repo, 'chore: init')
+    tag(repo, 'comp/v0.7.0')
+    git(repo, ['checkout', '-q', '-b', 'feature'])
+    commit(repo, 'feat: x')
+    git(repo, ['checkout', '-q', 'main'])
+    const m = mergeNoFf(repo, 'feature', 'Merge feature')
+
+    const { runEnv } = enactmentFixture(repo)
+    forbidDerivedIdentity(repo)
+    git(repo, ['config', 'user.name', 'Repo Owner'])
+    git(repo, ['config', 'user.email', 'owner@example.com'])
+
+    const r = spawnSync('bash', [AUTO_RELEASE_SH, 'comp', m], {
+      cwd: repo,
+      encoding: 'utf8',
+      env: withoutIdentity(runEnv),
+    })
+
+    expect(r.status, `stderr:\n${r.stderr}`).toBe(0)
+    expect(git(repo, ['config', '--get', 'user.email'])).toBe('owner@example.com')
+    expect(git(repo, ['for-each-ref', '--format=%(taggeremail)', 'refs/tags/comp/v0.8.0'])).toContain(
+      'owner@example.com',
+    )
   })
 })

--- a/plugins/dev-core/skills/promote/auto-release.sh
+++ b/plugins/dev-core/skills/promote/auto-release.sh
@@ -125,6 +125,18 @@ for _ in 1 2 3; do
     tag)
       echo "tag: $VERSION -> $M"
       [ "$DRY_RUN" = true ] && break
+      # `git tag -a` writes a tagger ident, and a bare CI runner has none —
+      # `fatal: empty ident name`, exit 128, no tag, no release. The workflow
+      # cannot supply it: auto-release.yml is byte-gated against the generator
+      # output (N11), so it is fixed here, where the annotated tag is created,
+      # which also covers every other caller. Gap-fill only: a developer running
+      # this locally, and any env already exporting GIT_COMMITTER_*, keep theirs.
+      if [ -z "$(git config --get user.email 2>/dev/null || true)" ] && [ -z "${GIT_COMMITTER_EMAIL:-}" ]; then
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+      fi
+      if [ -z "$(git config --get user.name 2>/dev/null || true)" ] && [ -z "${GIT_COMMITTER_NAME:-}" ]; then
+        git config user.name 'github-actions[bot]'
+      fi
       git tag -a "$VERSION" -m "Release $VERSION" "$M"
       git push origin "$VERSION"
       ;;


### PR DESCRIPTION
The first real Model-B release (#379, `c2d8095`) **failed**. `price.sh` did its job — `tag: roxabi-plugins/v0.5.0 -> c2d8095` — and then:

```
fatal: empty ident name (for <runner@runnervm3jd5f...internal.cloudapp.net>) not allowed
##[error]Process completed with exit code 128.
```

`auto-release.sh:128` creates an **annotated** tag (`git tag -a`), which needs a committer ident. A GitHub runner exports no `GIT_COMMITTER_*`, has no git config, and its passwd gecos is empty — so git derives an email but **no name**.

No bad artifact was produced: the failure is loud, the floor is untouched (`v0.4.0` still latest), nothing was published.

## Why the fix is in the script, not the workflow

`auto-release.yml` is byte-gated against the generator output (`/checkup` N11). Fixing it there means editing `workflow-generators.ts` (copy-synced to dev-init), regenerating, and revalidating the gate — and consumer repos would only benefit once they regenerate their own workflow. Fixing the script reaches every caller immediately.

Gap-fill only: an existing `git config user.*` or `GIT_COMMITTER_*` wins, so local runs keep the developer's identity.

## Why 823 green tests said nothing

Three layers of the same blind spot:

1. Every derivation test passes `--dry-run`, which `break`s at `auto-release.sh:127` — one line before the tag.
2. The single enactment test (W3) runs through `gitEnv()`, which exports `GIT_COMMITTER_NAME`/`EMAIL`. **The harness supplied precisely what production lacked.**
3. Stripping those vars is *still* not enough — git falls back to the passwd entry, so the bug hides on any dev box with a populated gecos. My first attempt at this test passed without the fix.

The new W4 cases set `user.useConfigOnly=true`, which makes git refuse to derive an identity at all, reproducing the runner's state on any host.

## Verification — falsification, not just green

| | result |
|---|---|
| W4 **without** the fix | ❌ RED — `expect(r.stderr).not.toMatch(/empty ident name/)` fails |
| W4 **with** the fix | ✅ 14/14 |
| full suite | 47 files, **825** passed / 4 skipped (was 823) |
| annotated tag really created | `git cat-file -t` → `tag`, at M, present on `origin` |
| existing identity preserved | tagger email stays `owner@example.com` |

## After this merges

`auto-release.yml` fires again on the push to `main` and should cut `roxabi-plugins/v0.5.0` for real. That is still the #376 proof-of-life — the default-branch flip stays blocked until a tag actually lands.

Refs #376, #371