### PR TITLE
chore(repo): repoint staging references to main after the trunk cutover

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,8 +3,9 @@
 # GitHub natively waits for all required status checks before merging.
 #
 # Project convention: merge commits only (¬squash) — see ~/projects/CLAUDE.md
-# "Release Convention". Squash merges flatten the per-commit history that
-# staging→main promotions rely on.
+# "Release Convention". auto-release.sh REFUSEs any merge to main that is not
+# a 2-parent merge (D3), and price.sh walks per-commit history to derive the
+# bump — a squash breaks both.
 #
 # Dependabot guard: semver-major bumps are never auto-merged — they require
 # manual validation (the vite 8 SSR regression stayed dormant 10 weeks).
@@ -19,7 +20,7 @@ on:
   check_suite:
     types: [completed]
   push:
-    branches: [staging, main]
+    branches: [main]
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main, staging]
+    branches: [main]
   pull_request:
-    branches: [main, staging]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/context-lint.yml
+++ b/.github/workflows/context-lint.yml
@@ -9,7 +9,7 @@ on:
       - '.grok/**'
       - '.agents/**'
   push:
-    branches: [main, staging]
+    branches: [main]
     paths:
       - '**/CLAUDE.md'
       - '**/AGENTS.md'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ name: PR Title
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    branches: [main, staging]
+    branches: [main]
 
 permissions:
   pull-requests: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-Entries are generated automatically by `/promote` and committed to staging before the promotion PR.
+Historical. Releases are now cut by `.github/workflows/auto-release.yml` on every merge to
+`main`, and the generated GitHub Release notes are the source of truth. Entries below `[0.4.0]`
+predate that and were produced by release-please or `/promote`.
 
 ## Unreleased
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,11 @@
 ## Workflow
 
 ```
-feature/fix branch → PR → staging → (promote) → main
+feature/fix branch → PR → main → auto-release cuts roxabi-plugins/vX.Y.Z
 ```
 
-1. Create a branch from `staging`: `feat/plugins/new-skill`, `fix/plugins/compress-edge-case`
-2. Open a PR targeting `staging`
+1. Create a branch from `main`: `feat/plugins/new-skill`, `fix/plugins/compress-edge-case`
+2. Open a PR targeting `main`
 3. Pass CI (`bun lint`, `bun typecheck`, `bun test`)
 4. Merge
 

--- a/docs/CREATE-PLUGIN-GUIDE.md
+++ b/docs/CREATE-PLUGIN-GUIDE.md
@@ -89,7 +89,7 @@ claude plugin validate .
 bun lint && bun typecheck && bun test
 ```
 
-CI (`bun lint`, `bun typecheck`, `bun test`) runs automatically on push to `main`/`staging` via `.github/workflows/ci.yml`. PRs must be green before merging.
+CI (`bun lint`, `bun typecheck`, `bun test`) runs automatically on push to `main` via `.github/workflows/ci.yml`. PRs must be green before merging.
 
 Then commit with the standard format:
 

--- a/plugins/dev-core/README.md
+++ b/plugins/dev-core/README.md
@@ -25,7 +25,7 @@ claude plugin install dev-core
 
 ### Keeping your install up to date
 
-`dev-core` ships through a hash-keyed cache at `~/.claude/plugins/cache/roxabi-marketplace/dev-core/<hash>/`. When new versions land on `staging`/`main`, pull the latest by re-installing from the marketplace:
+`dev-core` ships through a hash-keyed cache at `~/.claude/plugins/cache/roxabi-marketplace/dev-core/<hash>/`. When new versions land on `main`, pull the latest by re-installing from the marketplace:
 
 ```bash
 claude plugin install dev-core
@@ -94,7 +94,7 @@ Where `#N` is a GitHub issue number. The orchestrator scans existing artifacts, 
 | `fix` | Verify | Applies fixes from review feedback |
 | `validate` | Verify | Validates implementation against spec |
 | `cleanup` | Ship | Post-merge cleanup |
-| `promote` | Ship | Promotes to staging/production |
+| `promote` | Ship | Staging-train repos: promotes staging→main. Trunk repos: pre-flight only — auto-release owns the cut |
 | `test` | Supporting | Runs and manages tests |
 | `adr` | Supporting | Creates Architecture Decision Records |
 | `clarify` | Supporting | Intent-first architecture recap — 6-section view (intent → biz-arch → UX flows → data flow per layer → use cases × layers → open intent Qs). Phase-agnostic, ephemeral, no artifact. Defers technical implementation until user approves framing |

--- a/scripts/__tests__/check-gates.test.ts
+++ b/scripts/__tests__/check-gates.test.ts
@@ -128,7 +128,7 @@ describe('check-skill-version.sh', () => {
     const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-r2-bare-'))
     const work = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-r2-work-'))
 
-    // Build initial commit in work dir, then push to bare as origin/staging
+    // Build initial commit in work dir, then push to bare as origin/main
     git('git init -q', work)
 
     const pluginDir = path.join(work, 'plugins', opts.pluginName, '.claude-plugin')
@@ -144,16 +144,16 @@ describe('check-skill-version.sh', () => {
     git('git add -A', work)
     git('git -c user.email=t@t -c user.name=t commit -q -m "init"', work)
 
-    // Create bare repo and push the base commit as staging
+    // Create bare repo and push the base commit as main
     git('git init -q --bare', bare)
     git(`git remote add origin ${bare}`, work)
-    git('git push -q origin HEAD:staging', work)
+    git('git push -q origin HEAD:main', work)
 
     return { work, bare }
   }
 
-  it('exits 1 when a plugin has an unchanged version and skills/ changed on HEAD vs origin/staging', () => {
-    // Arrange — plugin "foo" has version "1.0.0" on origin/staging, unchanged on HEAD
+  it('exits 1 when a plugin has an unchanged version and skills/ changed on HEAD vs origin/main', () => {
+    // Arrange — plugin "foo" has version "1.0.0" on origin/main, unchanged on HEAD
     const { work, bare } = setupOriginWithPlugin({ pluginName: 'foo', version: '1.0.0' })
     workDir = work
     bareDir = bare
@@ -211,8 +211,8 @@ describe('check-skill-version.sh', () => {
     expect(code).toBe(0)
   })
 
-  it('exits 1 when a plugin has an unchanged version and commands/ changed on HEAD vs origin/staging', () => {
-    // Arrange — plugin "qux" has version "2.0.0" on origin/staging
+  it('exits 1 when a plugin has an unchanged version and commands/ changed on HEAD vs origin/main', () => {
+    // Arrange — plugin "qux" has version "2.0.0" on origin/main
     const { work, bare } = setupOriginWithPlugin({ pluginName: 'qux', version: '2.0.0' })
     workDir = work
     bareDir = bare
@@ -231,8 +231,8 @@ describe('check-skill-version.sh', () => {
     expect(code).toBe(1)
   })
 
-  it('exits 0 and emits an origin/staging-unreachable SKIP when origin/staging is not reachable', () => {
-    // Arrange — repo with no remote at all (no origin/staging)
+  it('exits 0 and emits an origin/main-unreachable SKIP when origin/main is not reachable', () => {
+    // Arrange — repo with no remote at all (no origin/main)
     workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-r2-noremote-'))
     git('git init -q', workDir)
     const pluginDir = path.join(workDir, 'plugins', 'nop', '.claude-plugin')
@@ -249,6 +249,6 @@ describe('check-skill-version.sh', () => {
 
     // Assert — guard skips with exit 0 and prints a visible SKIP line to stderr
     expect(code).toBe(0)
-    expect(stderr).toMatch(/origin\/staging unreachable/)
+    expect(stderr).toMatch(/origin\/main unreachable/)
   })
 })

--- a/scripts/check-skill-version.sh
+++ b/scripts/check-skill-version.sh
@@ -2,15 +2,15 @@
 set -euo pipefail
 # R2: versioned plugin's skills/ or commands/ changed without a version bump -> block.
 # Constraints (documented): plugin rename may not fire on the renaming push;
-# commands/ dir is forward-compatible (absent today); requires fetched origin/staging.
-# Preflight skips (explicit, not silent): jq absent -> SKIP; origin/staging unreachable -> SKIP.
+# commands/ dir is forward-compatible (absent today); requires fetched origin/main.
+# Preflight skips (explicit, not silent): jq absent -> SKIP; origin/main unreachable -> SKIP.
 command -v jq >/dev/null 2>&1 || { echo "SKIP: check-skill-version requires jq (not found)" >&2; exit 0; }
-git fetch origin staging --quiet 2>/dev/null || true
-if ! git rev-parse --verify --quiet origin/staging >/dev/null; then
-  echo "SKIP: check-skill-version (origin/staging unreachable — cannot compare versions)" >&2
+git fetch origin main --quiet 2>/dev/null || true
+if ! git rev-parse --verify --quiet origin/main >/dev/null; then
+  echo "SKIP: check-skill-version (origin/main unreachable — cannot compare versions)" >&2
   exit 0
 fi
-changed=$(git diff --name-only origin/staging...HEAD -- 'plugins/*/skills/**' 'plugins/*/commands/**')
+changed=$(git diff --name-only origin/main...HEAD -- 'plugins/*/skills/**' 'plugins/*/commands/**')
 mapfile -t plugins < <(printf '%s\n' "$changed" | sed -nE 's#^plugins/([^/]+)/.*#\1#p' | sort -u)
 fail=0
 for p in "${plugins[@]}"; do
@@ -19,7 +19,7 @@ for p in "${plugins[@]}"; do
   [ -f "$pj" ] || continue
   cur=$(jq -r '.version // empty' "$pj" 2>/dev/null || true)
   [ -n "$cur" ] || continue   # SHA-based plugin -> skip
-  base=$(git show "origin/staging:$pj" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)
+  base=$(git show "origin/main:$pj" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)
   if [ "$base" = "$cur" ]; then
     echo "$p: skills/commands changed without version bump (still $cur) — bump $pj"; fail=1
   fi

--- a/scripts/provision-release-gate.sh
+++ b/scripts/provision-release-gate.sh
@@ -40,15 +40,16 @@ RULESET_NAME="release-consistency-gate" # ruleset object name (distinct from PR_
 REUSABLE="Roxabi/roxabi-plugins/.github/workflows/release-consistency.yml"
 COMMIT_BRANCH="main"                    # the gate lives on main: the ruleset targets refs/heads/main
                                         # and pull_request(base=main) reads the workflow from main.
-DEFAULT_REF="staging"                   # reusable-workflow pin; pin to a tag at dogfood via --ref
+DEFAULT_REF="roxabi-plugins/v0.5.0"     # reusable-workflow pin; a tag, not a branch — `staging`
+                                        # no longer exists and a moving branch is not a safe pin
 
 usage() {
   cat >&2 <<'USAGE'
 Usage: provision-release-gate.sh <owner/repo> [--ref <git-ref>] [--remove]
 
   <owner/repo>   target repo (a bare name is prefixed with the Roxabi org)
-  --ref <ref>    reusable-workflow pin in the stub's `uses:` (default: staging;
-                 pin to a tag `roxabi-plugins/vX.Y.Z` at dogfood)
+  --ref <ref>    reusable-workflow pin in the stub's `uses:` (default:
+                 roxabi-plugins/v0.5.0 — always pin to a tag, never a branch)
   --remove       reverse BOTH artifacts: delete the caller stub and the ruleset
 
 Provisions (idempotent):


### PR DESCRIPTION
`staging` is gone (#376). This repoints what still referenced it.

## The one that mattered

`scripts/check-skill-version.sh` fetched `origin/staging`, then hit its own `origin/staging unreachable` guard and **SKIPped to exit 0**. The R2 version gate would have stopped enforcing entirely — with no red, ever. That is the "gate dies silently" failure the migration plan flagged.

Script and its fixtures (`scripts/__tests__/check-gates.test.ts`) move in **one commit**: splitting them fails 3 tests, moving neither leaves the gate inert.

## Also repointed

| surface | change |
|---|---|
| `ci.yml` (×2), `auto-merge.yml`, `context-lint.yml`, `pr-title.yml` | `branches: [main, staging]` → `[main]` |
| `auto-merge.yml` comment | no-squash rationale is now the D3 2-parent guard + `price.sh`'s per-commit walk, not staging promotions |
| `provision-release-gate.sh:43,50` | `DEFAULT_REF="staging"` → `"roxabi-plugins/v0.5.0"`. The script's own comment already recommended a tag; a moving branch was never a safe reusable-workflow pin, and this one no longer exists. |
| `CONTRIBUTING.md`, `CHANGELOG.md` header, `CREATE-PLUGIN-GUIDE.md`, `dev-core/README.md` | describe the trunk flow |

## Deliberately untouched

- **`release-consistency.yml`** — its `staging` references stay correct for staging-train consumers, and are dead code here regardless (no caller stub in this repo; the trunk early-green returns before the scope gate).
- **`CONTRIBUTING.md:113,121,144`** — "promote" there means promoting a wrapped plugin to the curated marketplace. Unrelated sense, no blanket replace.
- **Shared dev-core constants / generators / allowlists** — `PROTECTED_BRANCHES`, `lib.sh:16`, `workflow-generators.ts`, `cleanup/analyze-branches.sh`. Narrowing any of them ships to roxabi-factory and roxabi-live and pushes them off staging prematurely.

## Verification

- Full suite: 47 files, **825** passed / 4 skipped.
- `check-skill-version.sh` against `origin/main`: passes, and now actually compares instead of skipping.
- `check-gates.test.ts`: 8/8.
- Pre-existing and unrelated: `biome check` flags `dead-gate.test.ts` locally — it fails identically on the unmodified tree (stale local `node_modules` at 2.4.16 vs `package.json`'s `^2.5.3`). Not in this diff.

Refs #376