### PR TITLE
fix(dev-core): guard auto-release against dispatch from non-main refs

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -27,6 +27,14 @@ concurrency:
 jobs:
   auto-release:
     name: Tag + release on merge to main
+    # Releases are cut from main ONLY. `workflow_dispatch` above carries no ref
+    # constraint, so a dispatch on any other ref (`gh workflow run … --ref X`, or
+    # the Actions-tab branch picker) would otherwise run this contents:write job
+    # with the App token against X's tip and publish a real tag + GitHub Release
+    # from unreviewed commits. `github.ref` is the dispatched ref, so this skips
+    # every non-main dispatch while still firing on the push-to-main trigger and
+    # on a deliberate manual re-run against main (FU-1).
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/promote/__tests__/auto-release.test.ts
+++ b/plugins/dev-core/skills/promote/__tests__/auto-release.test.ts
@@ -430,3 +430,53 @@ describe('auto-release.sh — annotated tag with no committer identity (#376)', 
     )
   })
 })
+
+// ─── W5 — cut-from-main invariant (FU-1) ───────────────────────────────────────
+//
+// auto-release.yml's `workflow_dispatch` carries no ref constraint, so before the
+// job-level `if: github.ref == refs/heads/main` guard a dispatch on any branch ran
+// this contents:write job with the App token against that branch's tip and could
+// publish a real tag + GitHub Release from unreviewed commits. The `if:` is the CI
+// control; auto-release.sh's ancestry check is the script-level echo for every
+// other caller. It REFUSEs only on a POSITIVE "not reachable from origin/main",
+// and is a deliberate no-op when origin/main is unresolvable (a full-history
+// checkout does not reliably populate remote-tracking refs) so it can never red a
+// legitimate release.
+
+describe('auto-release.sh — cut-from-main invariant (FU-1)', () => {
+  it('a 2-parent merge NOT reachable from origin/main → REFUSE (exit 1, nothing released)', () => {
+    const repo = initRepo()
+    const c0 = commit(repo, 'chore: init')
+    tag(repo, 'comp/v0.7.0')
+    // origin/main is pinned to the tagged init commit — it does NOT contain the
+    // rogue merge built below. update-ref (not push) so the exclusion is exact
+    // regardless of how a given git version mirrors push into remote-tracking refs.
+    git(repo, ['update-ref', 'refs/remotes/origin/main', c0])
+
+    git(repo, ['checkout', '-q', '-b', 'feature'])
+    commit(repo, 'feat: x')
+    git(repo, ['checkout', '-q', '-b', 'rogue', 'main']) // off main, at the init commit
+    const m = mergeNoFf(repo, 'feature', 'Merge feature') // 2-parent merge, lives only on rogue
+
+    // NOT --dry-run: the REFUSE must fire before any tag/push/gh. A regression that
+    // dropped the ancestry check would proceed to derive 0.8.0 and tag it here.
+    const { code, stderr } = autoRelease(repo, ['comp', m])
+    expect(code).toBe(1)
+    expect(stderr).toMatch(/not reachable from origin\/main/)
+    // Proof nothing was cut: the derived tag was never created.
+    expect(git(repo, ['tag', '-l', 'comp/v0.8.0'])).toBe('')
+  })
+
+  it('origin/main unresolvable → ancestry guard is a no-op, never reds a release (dry-run)', () => {
+    const repo = initRepo()
+    commit(repo, 'chore: init') // no tag → first-release path; no origin/main ref set
+    git(repo, ['checkout', '-q', '-b', 'feature'])
+    commit(repo, 'feat: x')
+    git(repo, ['checkout', '-q', 'main'])
+    const m = mergeNoFf(repo, 'feature', 'Merge feature')
+
+    const { code, stderr } = autoRelease(repo, ['--dry-run', 'comp', m])
+    expect(code).toBe(0)
+    expect(stderr).not.toMatch(/not reachable from origin\/main/)
+  })
+})

--- a/plugins/dev-core/skills/promote/auto-release.sh
+++ b/plugins/dev-core/skills/promote/auto-release.sh
@@ -50,6 +50,21 @@ if [ "$PARENT_COUNT" -ne 2 ]; then
   exit 1
 fi
 
+# ── Cut-from-main invariant (FU-1): a release must be reachable from main. ──
+# The generated workflow's job-level `if: github.ref == refs/heads/main` already
+# blocks a dispatch on any other ref in CI; this is the script-level echo of the
+# same invariant for every other caller (a local run, a future workflow that
+# forgets the guard). Only REFUSE on a POSITIVE "not an ancestor": a full-history
+# checkout does not reliably populate refs/remotes/origin/*, so when origin/main
+# is unresolvable we SKIP rather than red a legitimate release — the workflow
+# fetches it (and the `if:` gate stands regardless).
+if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  if ! git merge-base --is-ancestor "$M" origin/main; then
+    echo "REFUSE: $M is not reachable from origin/main — releases are cut from main only (FU-1)." >&2
+    exit 1
+  fi
+fi
+
 # ── Derive DERIVED + BASE — BOTH from price.sh, the sole deriver (D10). ──
 # --base-only reuses the deriver's own floor predicate so the gate and this
 # orchestrator never diverge from a second copy.

--- a/plugins/dev-core/skills/shared/workflows/workflow-generators.ts
+++ b/plugins/dev-core/skills/shared/workflows/workflow-generators.ts
@@ -213,6 +213,14 @@ concurrency:
 jobs:
   auto-release:
     name: Tag + release on merge to main
+    # Releases are cut from main ONLY. \`workflow_dispatch\` above carries no ref
+    # constraint, so a dispatch on any other ref (\`gh workflow run … --ref X\`, or
+    # the Actions-tab branch picker) would otherwise run this contents:write job
+    # with the App token against X's tip and publish a real tag + GitHub Release
+    # from unreviewed commits. \`github.ref\` is the dispatched ref, so this skips
+    # every non-main dispatch while still firing on the push-to-main trigger and
+    # on a deliberate manual re-run against main (FU-1).
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/plugins/dev-init/skills/shared/workflows/workflow-generators.ts
+++ b/plugins/dev-init/skills/shared/workflows/workflow-generators.ts
@@ -215,6 +215,14 @@ concurrency:
 jobs:
   auto-release:
     name: Tag + release on merge to main
+    # Releases are cut from main ONLY. \`workflow_dispatch\` above carries no ref
+    # constraint, so a dispatch on any other ref (\`gh workflow run … --ref X\`, or
+    # the Actions-tab branch picker) would otherwise run this contents:write job
+    # with the App token against X's tip and publish a real tag + GitHub Release
+    # from unreviewed commits. \`github.ref\` is the dispatched ref, so this skips
+    # every non-main dispatch while still firing on the push-to-main trigger and
+    # on a deliberate manual re-run against main (FU-1).
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## What

`auto-release.yml` declares `workflow_dispatch: {}` with **no ref constraint**, runs a `contents: write` job, and mints the roxabi-ci App token. Before this PR, a `gh workflow run auto-release.yml --ref <branch>` — or the Actions-tab branch picker — ran the release job against that branch's tip. `auto-release.sh` only checked the parent count, never reachability, so it would happily derive `<component>/vX.Y.Z`, **tag it, and cut a public GitHub Release from unreviewed commits.**

## Threat framing (not overstated)

This is **not** a privilege escalation: anyone with write access could already push a secrets-reading workflow to a non-fork branch, so forging a tag is strictly *less* than what they can already do. Write access here is 2 people, both admin.

It **is** a genuine foot-gun: one mistaken `--ref` on a manual dispatch publishes a real release from whatever is on that branch. That is worth closing.

## Fix — two defence-in-depth layers

1. **Job-level `if: github.ref == 'refs/heads/main'`** in `generateAutoReleaseYml`. `github.ref` is the *dispatched* ref, so this skips every non-main dispatch while still firing on the `push: main` trigger and on a deliberate manual re-run against `main`. The committed `.github/workflows/auto-release.yml` is regenerated in the same commit (it is byte-gated against the generator by `/checkup` N11 and `auto-release-actionlint.test.ts`).
2. **Belt-and-braces ancestry check** in `auto-release.sh`: REFUSE when `M` is *positively* not reachable from `origin/main`. Deliberate **no-op** when `origin/main` is unresolvable — a full-history checkout does not reliably populate remote-tracking refs — so it can never red a legitimate release. The workflow fetches the ref; the `if:` gate stands regardless.

## Tests (falsification-gated)

`plugins/dev-core/skills/promote/__tests__/auto-release.test.ts` — new `W5` block:
- off-main 2-parent merge → REFUSE (exit 1, tag never created). **Verified RED without the fix**: the old script derived `0.8.0` and would have tagged it.
- `origin/main` unresolvable → guard is a no-op, never reds a release.

Byte gate (`auto-release-actionlint.test.ts`) re-passes on the regenerated workflow. Full suite: 827 passed / 4 skipped.

## Notes

- dev-core bumped `0.9.2 → 0.9.3` (R2 gate — skill files changed).
- Copy-synced generator mirrored into dev-init (`bun run sync:shared`, gate green).
- Origin: deferred FU-1 from the #374/#375 hardening review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)