### PR TITLE
fix(dev-core): refuse a trunk auto-release.yml when auto-release.sh is unresolvable (#375)

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/ci-setup/cookbooks/workflows.md
+++ b/plugins/dev-core/skills/ci-setup/cookbooks/workflows.md
@@ -61,6 +61,7 @@ Standard set: `ci.yml`, `secret-scan.yml`, `dependabot-automerge.yml`, `pr-title
        --test-command "<commands.test from σ, if set>"
      ```
      > **Top-up par défaut** : les fichiers déjà présents sur le repo sont **skippés** — les repos font évoluer leur `ci.yml` bien au-delà du template (multi-job, e2e, etc.). Ajouter `--force` UNIQUEMENT pour régénérer volontairement, après diff explicite des fichiers qui seraient écrasés.
+     > **Trunk mode (`release.model: trunk`, #375)** : le `auto-release.yml` généré invoque `plugins/dev-core/skills/promote/auto-release.sh` (+ sa closure `price.sh`/`lib/finalize.ts`) depuis la racine du repo. Ce chemin ne résout que si dev-core est **vendored sous `plugins/`** (comme dans roxabi-plugins) ; un repo qui consomme dev-core depuis `~/.claude/plugins/cache/…` ne l'a pas → le workflow mourrait `exit 127` à sa première release. Le writer (`writeWorkflows`/`pushWorkflows`) **REFUSE loud à la provision** si le script n'est pas résolvable (localement via `fs.existsSync`, à distance via l'API contents) plutôt que d'expédier un workflow cassé. Vendorer le script, ou ne pas activer trunk. Aujourd'hui seul roxabi-plugins est trunk et `init.ts workflows` n'expose pas encore de flag `--release-model` (productisation consommateur différée → #375 FU-5).
    - **App token provisioning** (always — PAT mode retired):
      - `gh variable set ROXABI_CI_APP_ID --org <org> --body <app-id>` (org-level)
        OR (private repo / free-plan org): `gh variable set ROXABI_CI_APP_ID --repo <owner>/<repo> --body <app-id>`

--- a/plugins/dev-core/skills/shared/__tests__/workflow-push.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/workflow-push.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The trunk resolvability guard (#375) on the REST writer. `pushWorkflows` refuses
+// to push a trunk auto-release.yml unless the baked `run:` target
+// (plugins/dev-core/skills/promote/auto-release.sh) is present on the target ref —
+// otherwise the workflow dies exit 127 at its first release. The guard reuses the
+// contents API the pusher already speaks, so it is exercised here with a mocked
+// `run` (token source) and a stubbed global fetch.
+
+vi.mock('../adapters/github-adapter', () => ({
+  run: vi.fn(async () => 'fake-token'),
+}))
+
+import { pushWorkflows } from '../workflows/workflow-push'
+
+const SCRIPT = 'plugins/dev-core/skills/promote/auto-release.sh'
+const trunk = {
+  stack: 'bun',
+  test: 'vitest',
+  deploy: 'none',
+  release: { model: 'trunk', component: 'roxabi-plugins' },
+} as const
+
+const origFetch = globalThis.fetch
+afterEach(() => {
+  ;(globalThis as unknown as { fetch: unknown }).fetch = origFetch
+  vi.restoreAllMocks()
+})
+
+describe('pushWorkflows — trunk resolvability guard (#375)', () => {
+  it('REFUSES before pushing anything when auto-release.sh is absent on the target ref', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: { method?: string }) => ({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    }))
+    ;(globalThis as unknown as { fetch: unknown }).fetch = fetchMock
+
+    await expect(pushWorkflows('acme', 'consumer', trunk, 'main')).rejects.toThrow(/not resolvable/)
+
+    // The refusal precedes the write loop: exactly one call — the guard's contents
+    // GET for the script — and never a PUT of any workflow file. Without the guard,
+    // pushWorkflows would GET+PUT every file in the set.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain(`/contents/${SCRIPT}`)
+    expect(String(url)).toContain('ref=main')
+    expect((init as { method?: string } | undefined)?.method ?? 'GET').toBe('GET')
+  })
+
+  it('proceeds past the guard when auto-release.sh is present (200)', async () => {
+    // Guard GET → 200; then each file: GET (checkRes, 404 → treat as new) → PUT (201).
+    const fetchMock = vi.fn(async (url: string, init?: { method?: string }) => {
+      if (String(url).includes(`/contents/${SCRIPT}`)) return { ok: true, status: 200, json: async () => ({}) }
+      if (init?.method === 'PUT') return { ok: true, status: 201, json: async () => ({}) }
+      return { ok: false, status: 404, json: async () => ({}) } // checkRes: file absent → create
+    })
+    ;(globalThis as unknown as { fetch: unknown }).fetch = fetchMock
+
+    const results = await pushWorkflows('acme', 'consumer', trunk, 'main')
+
+    expect(results.some((r) => r.file === 'auto-release.yml' && r.status === 'created')).toBe(true)
+    // The guard GET happened, and PUTs followed (so the guard did not short-circuit a valid push).
+    expect(fetchMock.mock.calls.some(([u]) => String(u).includes(`/contents/${SCRIPT}`))).toBe(true)
+    expect(fetchMock.mock.calls.some(([, i]) => (i as { method?: string } | undefined)?.method === 'PUT')).toBe(true)
+  })
+
+  it('staging-train never triggers the guard (no script GET)', async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: { method?: string }) => {
+      if (init?.method === 'PUT') return { ok: true, status: 201, json: async () => ({}) }
+      return { ok: false, status: 404, json: async () => ({}) }
+    })
+    ;(globalThis as unknown as { fetch: unknown }).fetch = fetchMock
+
+    await pushWorkflows('acme', 'consumer', { stack: 'bun', test: 'vitest', deploy: 'none' }, 'main')
+
+    // No auto-release.yml in the set, and the guard is skipped, so the script path
+    // is never requested.
+    expect(fetchMock.mock.calls.some(([u]) => String(u).includes(`/contents/${SCRIPT}`))).toBe(false)
+  })
+})

--- a/plugins/dev-core/skills/shared/__tests__/workflows.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/workflows.test.ts
@@ -401,12 +401,31 @@ describe('writeWorkflows', () => {
     expect(results).toContainEqual({ file: 'deploy-cloudflare.yml', status: 'created' })
   })
 
+  // A trunk auto-release.yml `run:`s plugins/dev-core/skills/promote/auto-release.sh
+  // from the repo root; the resolvability guard (#375) requires that path to exist
+  // before it will write the workflow, so seed the closure in the throwaway repo.
+  function seedTrunkReleaseScript(): void {
+    fs.mkdirSync('plugins/dev-core/skills/promote', { recursive: true })
+    fs.writeFileSync('plugins/dev-core/skills/promote/auto-release.sh', '#!/usr/bin/env bash\n')
+  }
+
   it('emits auto-release.yml when release.model is trunk (N18)', async () => {
+    seedTrunkReleaseScript()
     const results = await writeWorkflows({ ...opts, release: { model: 'trunk', component: 'roxabi-plugins' } })
 
     expect(results).toContainEqual({ file: 'auto-release.yml', status: 'created' })
     expect(fs.existsSync('.github/workflows/auto-release.yml')).toBe(true)
     expect(fs.readFileSync('.github/workflows/auto-release.yml', 'utf8')).toContain('name: Auto Release')
+  })
+
+  it('REFUSES to write a trunk auto-release.yml when auto-release.sh is not vendored (#375)', async () => {
+    // Empty repo — the baked `run:` path does not resolve here, so the workflow
+    // would die exit 127 at its first release. Fail loud at provision time.
+    await expect(writeWorkflows({ ...opts, release: { model: 'trunk', component: 'roxabi-plugins' } })).rejects.toThrow(
+      /auto-release\.sh.*not resolvable|not resolvable.*auto-release\.sh/s,
+    )
+    // Nothing was written — the refusal precedes mkdir/write, so no partial .github/.
+    expect(fs.existsSync('.github/workflows/auto-release.yml')).toBe(false)
   })
 
   it('does NOT emit auto-release.yml under staging-train (default)', async () => {

--- a/plugins/dev-core/skills/shared/workflows/workflow-generators.ts
+++ b/plugins/dev-core/skills/shared/workflows/workflow-generators.ts
@@ -11,6 +11,15 @@ import { generateE2eJob } from './workflows-fleet'
 export type { WorkflowOpts } from './workflow-types'
 export { normalizeWorkflowOpts }
 
+// The repo-relative path the trunk auto-release workflow's `run:` step invokes.
+// It resolves ONLY where dev-core is vendored under `plugins/` (roxabi-plugins
+// itself). A consumer repo that enables trunk mode but consumes dev-core from
+// `~/.claude/plugins/cache/…` does not have this path in its checkout, so the
+// step would die `exit 127` at its first release (#375). The generator bakes it
+// and the write-boundary resolvability guard (workflow-push.ts) checks for it —
+// both reference THIS const so the emitted path and the checked path never drift.
+export const TRUNK_AUTO_RELEASE_SCRIPT = 'plugins/dev-core/skills/promote/auto-release.sh'
+
 // --- Content generators ---
 
 /** Generic auto-merge workflow: enables merge queue on 'reviewed' label,
@@ -242,7 +251,7 @@ ${APP_MINT_STEP}
         env:
           GH_TOKEN: \${{ steps.app.outputs.token }}
           COMPONENT: ${component}
-        run: bash plugins/dev-core/skills/promote/auto-release.sh "$COMPONENT" "\${{ github.sha }}"
+        run: bash ${TRUNK_AUTO_RELEASE_SCRIPT} "$COMPONENT" "\${{ github.sha }}"
 `
 }
 

--- a/plugins/dev-core/skills/shared/workflows/workflow-push.ts
+++ b/plugins/dev-core/skills/shared/workflows/workflow-push.ts
@@ -12,6 +12,7 @@ import {
   generateContextLintYml,
   generateDeployYml,
   generatePrTitleYml,
+  TRUNK_AUTO_RELEASE_SCRIPT,
 } from './workflow-generators'
 import { normalizeWorkflowOpts, type WorkflowOpts } from './workflow-types'
 import {
@@ -24,6 +25,54 @@ import {
 
 async function getToken(): Promise<string> {
   return (await run(['gh', 'auth', 'token'])).trim()
+}
+
+// ── Trunk resolvability guard (#375) ────────────────────────────────────────
+// A trunk `auto-release.yml`'s `run:` step invokes TRUNK_AUTO_RELEASE_SCRIPT
+// from the repo root. That path resolves ONLY where dev-core is vendored under
+// `plugins/` (roxabi-plugins itself); a consumer that enables trunk mode while
+// consuming dev-core from `~/.claude/plugins/cache/…` does not have it in the
+// checkout, so the workflow would die `exit 127` at its first release. Both
+// writers below fail LOUD here — at provision time, where the operator can
+// vendor the script or drop trunk — instead of silently shipping a workflow
+// that only breaks on the first real release. Staging-train never invokes the
+// script, so the guard is a no-op unless model === 'trunk'.
+const trunkScriptRefusal = (where: string): string =>
+  `Refusing to write a trunk auto-release.yml (${where}): it invokes \`${TRUNK_AUTO_RELEASE_SCRIPT}\`, ` +
+  `which is not resolvable there. A trunk release requires dev-core vendored under plugins/ (as in ` +
+  `roxabi-plugins) so the script — and its price.sh + lib/finalize.ts closure — ships with the repo. ` +
+  `Vendor it, or do not set release.model: trunk. (#375)`
+
+/** Local (`writeWorkflows`) guard: the script must exist under the cwd. */
+function assertTrunkScriptLocal(o: Required<WorkflowOpts>): void {
+  if (o.release.model !== 'trunk') return
+  const fs = require('node:fs')
+  if (!fs.existsSync(TRUNK_AUTO_RELEASE_SCRIPT)) {
+    throw new Error(trunkScriptRefusal('local write'))
+  }
+}
+
+/** Remote (`pushWorkflows`) guard: the script must exist on the target ref.
+ *  Reuses the contents API the pusher already speaks — no local checkout needed. */
+async function assertTrunkScriptRemote(
+  owner: string,
+  repo: string,
+  branch: string,
+  o: Required<WorkflowOpts>,
+): Promise<void> {
+  if (o.release.model !== 'trunk') return
+  const token = await getToken()
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${TRUNK_AUTO_RELEASE_SCRIPT}?ref=${encodeURIComponent(branch)}`
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!res.ok) {
+    throw new Error(`${trunkScriptRefusal(`${owner}/${repo}@${branch}`)} (contents API: HTTP ${res.status})`)
+  }
 }
 
 /** Push a single file to a repo via the GH contents API (create-or-update).
@@ -150,6 +199,7 @@ export async function pushWorkflows(
   force = false,
 ): Promise<PushResult[]> {
   const o = normalizeWorkflowOpts(opts)
+  await assertTrunkScriptRemote(owner, repo, branch, o)
   const results: PushResult[] = []
   for (const { name, path, content, message } of workflowFileSet(o)) {
     const status = await pushWorkflowFile(owner, repo, path, content, {
@@ -191,8 +241,9 @@ export async function pushGenericWorkflows(
  *  Every file in the set is reported, including `.github/dependabot.yml`. */
 export async function writeWorkflows(opts: WorkflowOpts, force = false): Promise<PushResult[]> {
   const fs = require('node:fs')
-  fs.mkdirSync('.github/workflows', { recursive: true })
   const o = normalizeWorkflowOpts(opts)
+  assertTrunkScriptLocal(o)
+  fs.mkdirSync('.github/workflows', { recursive: true })
 
   const results: PushResult[] = []
   for (const { name, path, content } of workflowFileSet(o)) {

--- a/plugins/dev-init/skills/shared/workflows/workflow-generators.ts
+++ b/plugins/dev-init/skills/shared/workflows/workflow-generators.ts
@@ -13,6 +13,15 @@ import { generateE2eJob } from './workflows-fleet'
 export type { WorkflowOpts } from './workflow-types'
 export { normalizeWorkflowOpts }
 
+// The repo-relative path the trunk auto-release workflow's `run:` step invokes.
+// It resolves ONLY where dev-core is vendored under `plugins/` (roxabi-plugins
+// itself). A consumer repo that enables trunk mode but consumes dev-core from
+// `~/.claude/plugins/cache/…` does not have this path in its checkout, so the
+// step would die `exit 127` at its first release (#375). The generator bakes it
+// and the write-boundary resolvability guard (workflow-push.ts) checks for it —
+// both reference THIS const so the emitted path and the checked path never drift.
+export const TRUNK_AUTO_RELEASE_SCRIPT = 'plugins/dev-core/skills/promote/auto-release.sh'
+
 // --- Content generators ---
 
 /** Generic auto-merge workflow: enables merge queue on 'reviewed' label,
@@ -244,7 +253,7 @@ ${APP_MINT_STEP}
         env:
           GH_TOKEN: \${{ steps.app.outputs.token }}
           COMPONENT: ${component}
-        run: bash plugins/dev-core/skills/promote/auto-release.sh "$COMPONENT" "\${{ github.sha }}"
+        run: bash ${TRUNK_AUTO_RELEASE_SCRIPT} "$COMPONENT" "\${{ github.sha }}"
 `
 }
 

--- a/plugins/dev-init/skills/shared/workflows/workflow-push.ts
+++ b/plugins/dev-init/skills/shared/workflows/workflow-push.ts
@@ -14,6 +14,7 @@ import {
   generateContextLintYml,
   generateDeployYml,
   generatePrTitleYml,
+  TRUNK_AUTO_RELEASE_SCRIPT,
 } from './workflow-generators'
 import { normalizeWorkflowOpts, type WorkflowOpts } from './workflow-types'
 import {
@@ -26,6 +27,54 @@ import {
 
 async function getToken(): Promise<string> {
   return (await run(['gh', 'auth', 'token'])).trim()
+}
+
+// ── Trunk resolvability guard (#375) ────────────────────────────────────────
+// A trunk `auto-release.yml`'s `run:` step invokes TRUNK_AUTO_RELEASE_SCRIPT
+// from the repo root. That path resolves ONLY where dev-core is vendored under
+// `plugins/` (roxabi-plugins itself); a consumer that enables trunk mode while
+// consuming dev-core from `~/.claude/plugins/cache/…` does not have it in the
+// checkout, so the workflow would die `exit 127` at its first release. Both
+// writers below fail LOUD here — at provision time, where the operator can
+// vendor the script or drop trunk — instead of silently shipping a workflow
+// that only breaks on the first real release. Staging-train never invokes the
+// script, so the guard is a no-op unless model === 'trunk'.
+const trunkScriptRefusal = (where: string): string =>
+  `Refusing to write a trunk auto-release.yml (${where}): it invokes \`${TRUNK_AUTO_RELEASE_SCRIPT}\`, ` +
+  `which is not resolvable there. A trunk release requires dev-core vendored under plugins/ (as in ` +
+  `roxabi-plugins) so the script — and its price.sh + lib/finalize.ts closure — ships with the repo. ` +
+  `Vendor it, or do not set release.model: trunk. (#375)`
+
+/** Local (`writeWorkflows`) guard: the script must exist under the cwd. */
+function assertTrunkScriptLocal(o: Required<WorkflowOpts>): void {
+  if (o.release.model !== 'trunk') return
+  const fs = require('node:fs')
+  if (!fs.existsSync(TRUNK_AUTO_RELEASE_SCRIPT)) {
+    throw new Error(trunkScriptRefusal('local write'))
+  }
+}
+
+/** Remote (`pushWorkflows`) guard: the script must exist on the target ref.
+ *  Reuses the contents API the pusher already speaks — no local checkout needed. */
+async function assertTrunkScriptRemote(
+  owner: string,
+  repo: string,
+  branch: string,
+  o: Required<WorkflowOpts>,
+): Promise<void> {
+  if (o.release.model !== 'trunk') return
+  const token = await getToken()
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${TRUNK_AUTO_RELEASE_SCRIPT}?ref=${encodeURIComponent(branch)}`
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!res.ok) {
+    throw new Error(`${trunkScriptRefusal(`${owner}/${repo}@${branch}`)} (contents API: HTTP ${res.status})`)
+  }
 }
 
 /** Push a single file to a repo via the GH contents API (create-or-update).
@@ -152,6 +201,7 @@ export async function pushWorkflows(
   force = false,
 ): Promise<PushResult[]> {
   const o = normalizeWorkflowOpts(opts)
+  await assertTrunkScriptRemote(owner, repo, branch, o)
   const results: PushResult[] = []
   for (const { name, path, content, message } of workflowFileSet(o)) {
     const status = await pushWorkflowFile(owner, repo, path, content, {
@@ -193,8 +243,9 @@ export async function pushGenericWorkflows(
  *  Every file in the set is reported, including `.github/dependabot.yml`. */
 export async function writeWorkflows(opts: WorkflowOpts, force = false): Promise<PushResult[]> {
   const fs = require('node:fs')
-  fs.mkdirSync('.github/workflows', { recursive: true })
   const o = normalizeWorkflowOpts(opts)
+  assertTrunkScriptLocal(o)
+  fs.mkdirSync('.github/workflows', { recursive: true })
 
   const results: PushResult[] = []
   for (const { name, path, content } of workflowFileSet(o)) {


### PR DESCRIPTION
Closes #375.

## What

`generateAutoReleaseYml` bakes `bash plugins/dev-core/skills/promote/auto-release.sh` into the trunk workflow's `run:` step. That path resolves **only** where dev-core is vendored under `plugins/` — roxabi-plugins itself. A consumer repo that enabled `release.model: trunk` while consuming dev-core from `~/.claude/plugins/cache/…` would get a workflow that dies `exit 127` at its first release, and the N18 writer emitted it with **no resolvability check** (violates Design Principle #1, project-agnostic).

## Latency (why this is a guard, not a live fix)

Doubly latent today: there is no consumer trunk repo, and `init.ts workflows` does not parse a `--release-model` flag, so the CLI cannot even reach the trunk branch. This closes the hole for when a trunk provisioner *is* wired up — converting a silent 127-at-first-release into a **loud REFUSE at provision time**.

## Fix

- **`TRUNK_AUTO_RELEASE_SCRIPT`** const in `workflow-generators.ts` — the `run:` line and the guard now reference one string (no drift). Extracting it is **byte-identical** output: `auto-release.yml` unchanged, N11 + actionlint byte gates re-pass.
- **Guard both write boundaries** in `workflow-push.ts`:
  - `writeWorkflows` (local `/init --local`) → `fs.existsSync`.
  - `pushWorkflows` (REST) → reuses the contents API the pusher already speaks — no local checkout needed.
  - Both no-op unless `release.model === 'trunk'`, so staging-train (factory/live) is untouched.
- Doc note in `ci-setup/cookbooks/workflows.md`.

## Scope decision

This is the **resolvability guard** the issue's primary Action asks for — **not** the `script_path` config contract. Productising consumer trunk (a `--release-model` flag + vendoring helper) is speculative generality with zero consumers, and is deferred to **FU-5**, matching the hardening review's own recommendation. Two premises in the issue text are also retracted, both verified against the code: the REST path *can* do the existence check (`workflow-push.ts` already GETs), and the shipped `stack.yml.example` already has a `release:` block.

## Tests (falsification-gated)

`workflows.test.ts`:
- trunk + `auto-release.sh` absent → REFUSE, nothing written. **Verified RED without the guard**: it wrote a broken `auto-release.yml`.
- trunk + script seeded → writes (existing N18 test, now seeds the closure).

New `workflow-push.test.ts` (mocked token + fetch):
- trunk + 404 on the script → REFUSE **before any PUT**. **RED without the guard**: it proceeded to GET+PUT every file.
- trunk + 200 → proceeds; staging-train → guard never fires.

Full suite: 831 passed / 4 skipped. Byte gates (N11 workflow-drift + actionlint) green.

## Notes

- dev-core `0.9.3 → 0.9.4`. Copy-synced to dev-init (`bun run sync:shared`, gate green).
- Stacked on FU-1 (#382, merged) — branched off the updated `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)