### PR TITLE
fix(dev-core): pin context-lint, catch floating workflow pins, tie byte gate to stack.yml (FU-3, FU-4)

### DIFF
--- a/.github/workflows/context-lint.yml
+++ b/.github/workflows/context-lint.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Lint agent-context files (@imports + placeholders)
         run: |
           set -u

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/shared/__tests__/auto-release-actionlint.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/auto-release-actionlint.test.ts
@@ -73,14 +73,39 @@ describe('generateAutoReleaseYml — actionlint schema validity (#371 S2-T11)', 
   })
 })
 
+/**
+ * release.model + release.component as declared in the repo's own .claude/stack.yml.
+ * The byte gate below derives the expected COMPONENT from HERE — the same source
+ * /checkup N11 (workflow-drift.ts) reads — rather than a hardcoded literal, so a
+ * rename of release.component that is NOT propagated into the committed
+ * auto-release.yml (or a workflow whose baked COMPONENT drifts from stack.yml)
+ * fails in CI, not only at /checkup runtime (#374 FU-4). Minimal regex, no YAML
+ * dep: the release block is 2-space-indented children, one `component:` repo-wide.
+ */
+function stackRelease(): { model: string; component: string } {
+  const src = readFileSync('.claude/stack.yml', 'utf8')
+  const block = src.match(/^release:[^\n]*\n((?:[ \t]+.*\n?)*)/m)?.[1] ?? ''
+  return {
+    model: block.match(/^\s+model:\s*([^\s#]+)/m)?.[1] ?? 'staging-train',
+    component: block.match(/^\s+component:\s*([^\s#]+)/m)?.[1] ?? '',
+  }
+}
+
 describe('committed auto-release.yml is byte-equal to the generator (dogfood fidelity, #371 B5)', () => {
-  it('the checked-in workflow matches generateAutoReleaseYml(roxabi-plugins trunk opts)', () => {
+  it('the checked-in workflow matches the generator for .claude/stack.yml release.component (#374 FU-4)', () => {
     // The CI analogue of /checkup N11 (which only runs at human runtime): a
     // generator edit not mirrored into the committed workflow — or a hand-edit
-    // of the committed workflow — fails HERE, in CI, instead of drifting silently
-    // until the first real release. roxabi-plugins is the trunk dogfood, so its
-    // committed file must equal the generator output for `component: roxabi-plugins`.
+    // of the committed workflow, or a stack.yml component rename that skipped
+    // regeneration — fails HERE, in CI, instead of drifting silently until the
+    // first real release. Expected opts are derived from stack.yml, not hardcoded,
+    // so the baked COMPONENT and the declared release.component can never diverge.
+    const { model, component } = stackRelease()
+    // This repo is the trunk dogfood; if model ever flips, auto-release.yml should
+    // be REMOVED, not left stale — so assert the precondition rather than skip.
+    expect(model).toBe('trunk')
+    expect(component).not.toBe('')
+
     const committed = readFileSync('.github/workflows/auto-release.yml', 'utf8')
-    expect(committed).toBe(generateAutoReleaseYml(trunkOpts))
+    expect(committed).toBe(generateAutoReleaseYml({ ...trunkOpts, release: { model: 'trunk', component } }))
   })
 })

--- a/tools/__tests__/verify-action-pins.test.ts
+++ b/tools/__tests__/verify-action-pins.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   buildGovernedPairs,
   EMITTER_PATHS,
+  findFloatingWorkflowPins,
   findInlinePins,
   findUngovernedPins,
   type InlinePin,
@@ -83,6 +84,42 @@ describe('findInlinePins', () => {
     expect(findInlinePins([fixtureRelPath])).toEqual([
       { file: fixtureRelPath, action: 'actions/checkout', ref: 'df4cb1c069e1874edd31b4311f1884172cec0e10' },
     ])
+  })
+})
+
+// ─── findFloatingWorkflowPins (committed workflows: SHA-or-fail) ──────────────
+
+describe('findFloatingWorkflowPins', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..')
+  const dirRel = 'tools/__tests__/.tmp-floating-fixture'
+  const dirAbs = path.join(repoRoot, dirRel)
+
+  afterEach(() => {
+    if (fs.existsSync(dirAbs)) fs.rmSync(dirAbs, { recursive: true, force: true })
+  })
+
+  it('flags a committed workflow pinned to a floating tag, ignores SHA-pinned ones', () => {
+    fs.mkdirSync(dirAbs, { recursive: true })
+    fs.writeFileSync(
+      path.join(dirAbs, 'pinned.yml'),
+      '      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6\n',
+    )
+    fs.writeFileSync(path.join(dirAbs, 'floating.yml'), '      - uses: actions/checkout@v6\n')
+    // context-lint.yml shipped exactly this floating ref unnoticed (#375 FU-3).
+    expect(findFloatingWorkflowPins(dirRel)).toEqual([
+      { file: `${dirRel}/floating.yml`, action: 'actions/checkout', ref: 'v6' },
+    ])
+  })
+
+  it('accepts a SHA-pinned action that is NOT in ACTION_PINS — governance is not this check', () => {
+    fs.mkdirSync(dirAbs, { recursive: true })
+    // setup-python is never emitted by a generator (ungoverned) but IS SHA-pinned: legitimate
+    // in a committed workflow. This is the exact case findUngovernedPins would wrongly flag.
+    fs.writeFileSync(
+      path.join(dirAbs, 'ok.yml'),
+      '      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1\n',
+    )
+    expect(findFloatingWorkflowPins(dirRel)).toEqual([])
   })
 })
 

--- a/tools/verify-action-pins.ts
+++ b/tools/verify-action-pins.ts
@@ -33,7 +33,7 @@
  * or ungoverned pin.
  */
 
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 const REPO_ROOT = resolve(import.meta.dirname ?? '.', '..')
@@ -147,6 +147,22 @@ export function findUngovernedPins(inlinePins: InlinePin[], governedPairs: Set<s
   return inlinePins.filter((pin) => !governedPairs.has(governedKey(pin.action, pin.ref)))
 }
 
+/** Committed workflow files under `.github/workflows/`. Their invariant is WEAKER than the
+ *  emitter sources' (ACTION_PINS governance): a hand-written workflow, or one using an action
+ *  no generator emits (setup-python, a different checkout minor), legitimately pins a SHA that
+ *  is not in ACTION_PINS — so `findUngovernedPins` is the WRONG check here (it would flag valid
+ *  SHA pins). The invariant that DOES hold: every `uses: owner/repo@<ref>` must be a SHA, never
+ *  a mutable tag/branch. This is the layer the governance scan never covered — `context-lint.yml`
+ *  shipped `actions/checkout@v6` unnoticed because nothing scanned committed YAML (#375 FU-3).
+ *  `parseInlinePins`'s `owner/repo@` shape already skips local (`./…`) and reusable-workflow refs. */
+export function findFloatingWorkflowPins(dir = '.github/workflows'): InlinePin[] {
+  const absDir = resolve(REPO_ROOT, dir)
+  const files = readdirSync(absDir)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .map((f) => `${dir}/${f}`)
+  return findInlinePins(files).filter((pin) => !HEX_SHA_RE.test(pin.ref))
+}
+
 async function gh(path: string): Promise<unknown | null> {
   const proc = Bun.spawnSync(['gh', 'api', path], { stdout: 'pipe', stderr: 'pipe' })
   if (proc.exitCode !== 0) return null
@@ -209,13 +225,26 @@ async function main() {
     console.error('     Add it to workflow-pins.ts and reference it, or this pin is never verified.')
   }
 
-  if (failed > 0 || ungovernedPins.length > 0) {
+  // Committed workflows (hand-written + generator-drifted): SHA-pinned, but NOT
+  // required to be governed by ACTION_PINS. Only floating (non-SHA) refs fail.
+  const floatingWorkflowPins = findFloatingWorkflowPins()
+  for (const pin of floatingWorkflowPins) {
+    console.error(
+      `FAIL ${pin.file}: uses ${pin.action}@${pin.ref} — floating ref in a committed workflow; pin to a SHA.`,
+    )
+  }
+
+  if (failed > 0 || ungovernedPins.length > 0 || floatingWorkflowPins.length > 0) {
     if (failed > 0)
       console.error(`\n${failed}/${pins.length} pins do not resolve — generated CI would fail at "Set up job".`)
     if (ungovernedPins.length > 0) console.error(`${ungovernedPins.length} inline pin(s) bypass ACTION_PINS.`)
+    if (floatingWorkflowPins.length > 0)
+      console.error(`${floatingWorkflowPins.length} committed-workflow pin(s) are floating tags, not SHAs.`)
     process.exit(1)
   }
-  console.log(`\nAll ${pins.length} pins resolve; no inline or rendered pin bypasses ACTION_PINS.`)
+  console.log(
+    `\nAll ${pins.length} pins resolve; no inline or rendered pin bypasses ACTION_PINS; committed workflows are SHA-pinned.`,
+  )
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
Two CI blind spots from the #374/#375 hardening review.

## FU-3 — the repo's only unpinned action, invisible to the pin verifier

Committed `context-lint.yml:29` shipped `actions/checkout@v6` (a **mutable tag**) while its own generator `generateContextLintYml` emits the pinned SHA. Nothing caught it: `verify-action-pins.ts` scans only the generator **sources** (`EMITTER_PATHS`) + rendered generators, never the committed `.github/workflows/*.yml`.

- **Pin** `context-lint.yml:29` → `actions/checkout@df4cb1c…  # v6` (the generator's value). **Only L29** — L12 `branches: [main]` is the deliberate #376 trunk migration and must NOT regenerate back to `[main, staging]`, so the file stays intentionally drifted from the generator on that line and is *not* byte-gated.
- **Extend the verifier** with `findFloatingWorkflowPins()`: scan committed workflows, FAIL any `uses: owner/repo@<ref>` whose ref is not a SHA. This is deliberately a **weaker** invariant than ACTION_PINS governance — a committed workflow legitimately SHA-pins actions no generator emits (`setup-python`, a different `checkout` minor `de0fac2e…`), so `findUngovernedPins` would wrongly flag them. The invariant that holds for committed YAML is **SHA-not-tag**. Verified RED by reverting the pin (`FAIL … floating ref`).

## FU-4 — the byte gate couldn't see a stack.yml component rename

`auto-release.yml` bakes `release.component` at generate time. The CI byte gate hardcoded `component: 'roxabi-plugins'`, so a `.claude/stack.yml` rename that skipped regenerating the workflow **passed CI** — only `/checkup` N11 read stack.yml, and it runs at human time. The gate now derives the expected component from stack.yml (the same source N11 uses), so the baked `COMPONENT` and the declared `release.component` can't diverge silently. Verified RED by renaming the component without regenerating (byte mismatch).

## Tests / falsification

- `findFloatingWorkflowPins`: floating tag flagged; SHA-pinned-but-ungoverned (`setup-python`) accepted — the exact case `findUngovernedPins` would misflag.
- byte gate: derives from `.claude/stack.yml`; RED when component renamed without regen.
- Full suite 839 passed / 4 skipped. Extended verifier passes on the current tree (all committed workflows SHA-pinned).

dev-core `0.9.5 → 0.9.6`. `context-lint.yml`/`verify-action-pins.ts` are not copy-synced; no N11 impact (context-lint is intentionally non-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)