### PR TITLE
feat(dev-core): /ship meta + cleanup orphan worktree shells

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "dev-core",
-      "description": "Full development workflow — frame, shape, plan, implement, review, ship. Opinionated Roxabi process with 30 skills, 9 agents, and safety hooks.",
+      "description": "Full development workflow — frame, shape, plan, implement, review, ship. Opinionated Roxabi process with 31 skills (incl. /ship), 9 agents, and safety hooks.",
       "source": "./plugins/dev-core",
       "category": "development"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ predate that and were produced by release-please or `/promote`.
 
 ## Unreleased
 
+### Added
+
+* **dev-core/ship:** meta-orchestrator `/ship` — commit → `/pr` → `/code-review` → `/fix` loop → `reviewed` label + `/ci-watch` → optional `/cleanup` (code-already-ready path; review-before-CI order differs from `/dev` Verify)
+* **dev-core/cleanup:** detect orphan Grok/Claude worktree shells (`scan-orphan-worktree-shells.sh` + Step 5b) after `git worktree remove`
+
 ### Changed
 
 * **dev-core:** replace inline mermaid/ASCII shape diagrams with forge-chart sidecars in `clarify`, `analyze`, `spec`, and `plan` — HTML in `artifacts/visuals/`, SSoT at `references/forge-chart-sidecar.md`; supersedes mermaid diagram requirements added in `e455a5b`

--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "roxabi-plugins",
       "devDependencies": {
-        "@biomejs/biome": "^2.4.15",
-        "@commitlint/cli": "^21.0.1",
+        "@biomejs/biome": "^2.5.3",
+        "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.0.1",
         "bun-types": "^1.3.14",
-        "lefthook": "^2.1.8",
+        "lefthook": "^2.1.10",
         "typescript": "^6.0.3",
         "typescript-language-server": "^5.3.0",
-        "vitest": "^4.1.7",
+        "vitest": "^4.1.10",
       },
     },
   },
@@ -21,59 +21,61 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.6", "@biomejs/cli-darwin-x64": "2.5.6", "@biomejs/cli-linux-arm64": "2.5.6", "@biomejs/cli-linux-arm64-musl": "2.5.6", "@biomejs/cli-linux-x64": "2.5.6", "@biomejs/cli-linux-x64-musl": "2.5.6", "@biomejs/cli-win32-arm64": "2.5.6", "@biomejs/cli-win32-x64": "2.5.6" }, "bin": { "biome": "bin/biome" } }, "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
 
-    "@commitlint/cli": ["@commitlint/cli@21.0.2", "", { "dependencies": { "@commitlint/format": "^21.0.1", "@commitlint/lint": "^21.0.2", "@commitlint/load": "^21.0.2", "@commitlint/read": "^21.0.2", "@commitlint/types": "^21.0.1", "tinyexec": "^1.0.0", "yargs": "^18.0.0" }, "bin": { "commitlint": "cli.js" } }, "sha512-YMmfLbqBg+ZRvvmPhc+cilSQFrh/AgzVgCT1U/OifmUZEwPbvCtA8rN//YNaF9d5eoZphxVMGYtmwA2QgQORgg=="],
+    "@commitlint/cli": ["@commitlint/cli@21.2.1", "", { "dependencies": { "@commitlint/config-conventional": "^21.2.0", "@commitlint/format": "^21.2.0", "@commitlint/lint": "^21.2.0", "@commitlint/load": "^21.2.0", "@commitlint/read": "^21.2.1", "@commitlint/types": "^21.2.0", "tinyexec": "^1.0.0", "yargs": "^18.0.0" }, "bin": { "commitlint": "cli.js" } }, "sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg=="],
 
     "@commitlint/config-conventional": ["@commitlint/config-conventional@21.0.2", "", { "dependencies": { "@commitlint/types": "^21.0.1", "conventional-changelog-conventionalcommits": "^9.2.0" } }, "sha512-P/ZRhryQmkj0Z0dY9FOoRwe3xkwJyyAdtXwt01NT2kuZttcG2CNYp1q5Ci3u+nDT2jcbJRw2kt13Czl1qKNPfg=="],
 
-    "@commitlint/config-validator": ["@commitlint/config-validator@21.0.1", "", { "dependencies": { "@commitlint/types": "^21.0.1", "ajv": "^8.11.0" } }, "sha512-Zd2UFdndeMMaW2O96HK0tdfT4gOImUvidMpAd/pws2zZ4m1nrAZ/9b/v2JYuE8fs86GpXv9F7LNaIuCIWhY+pA=="],
+    "@commitlint/config-validator": ["@commitlint/config-validator@21.2.0", "", { "dependencies": { "@commitlint/types": "^21.2.0", "ajv": "^8.11.0" } }, "sha512-t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA=="],
 
-    "@commitlint/ensure": ["@commitlint/ensure@21.0.1", "", { "dependencies": { "@commitlint/types": "^21.0.1", "es-toolkit": "^1.46.0" } }, "sha512-jJ1037967wU7YN/xkv+iRlOBlmaOXPhPO5KQSqya6GyXzBlwuLzELBFao16DVg9dZyqmNrhewzwZ3SAibetHBQ=="],
+    "@commitlint/ensure": ["@commitlint/ensure@21.2.0", "", { "dependencies": { "@commitlint/types": "^21.2.0", "es-toolkit": "^1.46.0" } }, "sha512-76IF9vDNS13lAzEEik9eKwzt8f9hYhWiwVXZ2AnyLCz5/f511FsEQ3pw1X3/zSQpdRLQU7i5qDMVKyXi1GWjSg=="],
 
     "@commitlint/execute-rule": ["@commitlint/execute-rule@21.0.1", "", {}, "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA=="],
 
-    "@commitlint/format": ["@commitlint/format@21.0.1", "", { "dependencies": { "@commitlint/types": "^21.0.1", "picocolors": "^1.1.1" } }, "sha512-ksmG2+cHGtuDPQQbhBbC4unwm444+6TiPw0d1bKf67hntgZqZ8E0g1MuYKUuyT5IH4IMmXZhKq22/Z3jBvtQIw=="],
+    "@commitlint/format": ["@commitlint/format@21.2.0", "", { "dependencies": { "@commitlint/types": "^21.2.0", "picocolors": "^1.1.1" } }, "sha512-c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg=="],
 
-    "@commitlint/is-ignored": ["@commitlint/is-ignored@21.0.2", "", { "dependencies": { "@commitlint/types": "^21.0.1", "semver": "^7.6.0" } }, "sha512-H5z4t8PC9tUsmZ/o+EptM3Nq8sTFtskAShdcqxCoyzklW5eaVT5xbrDAET2uypzir9Vsj4ZZmBtyKjYe2XqgeQ=="],
+    "@commitlint/is-ignored": ["@commitlint/is-ignored@21.2.0", "", { "dependencies": { "@commitlint/types": "^21.2.0", "semver": "^7.6.0" } }, "sha512-4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw=="],
 
-    "@commitlint/lint": ["@commitlint/lint@21.0.2", "", { "dependencies": { "@commitlint/is-ignored": "^21.0.2", "@commitlint/parse": "^21.0.2", "@commitlint/rules": "^21.0.2", "@commitlint/types": "^21.0.1" } }, "sha512-PnUmLYGeGLfW8oVatR9KpNxSHYAnJOEWlMZzfdeFOUq6WUrFx1fGQaWCWJqMoIll/xPM+GdfJV+tKHZVHhl0Fg=="],
+    "@commitlint/lint": ["@commitlint/lint@21.2.0", "", { "dependencies": { "@commitlint/is-ignored": "^21.2.0", "@commitlint/parse": "^21.2.0", "@commitlint/rules": "^21.2.0", "@commitlint/types": "^21.2.0" } }, "sha512-ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw=="],
 
-    "@commitlint/load": ["@commitlint/load@21.0.2", "", { "dependencies": { "@commitlint/config-validator": "^21.0.1", "@commitlint/execute-rule": "^21.0.1", "@commitlint/resolve-extends": "^21.0.1", "@commitlint/types": "^21.0.1", "cosmiconfig": "^9.0.1", "cosmiconfig-typescript-loader": "^6.1.0", "es-toolkit": "^1.46.0", "is-plain-obj": "^4.1.0", "picocolors": "^1.1.1" } }, "sha512-lwUE70hN0/qE/ZRROhbaX65ly/FF12DrqfReLCESo37M0OQCFAf2jRS+2tSCSORq+bm4Kdju7qNDj46uc1QzTA=="],
+    "@commitlint/load": ["@commitlint/load@21.2.0", "", { "dependencies": { "@commitlint/config-validator": "^21.2.0", "@commitlint/execute-rule": "^21.0.1", "@commitlint/resolve-extends": "^21.2.0", "@commitlint/types": "^21.2.0", "cosmiconfig": "^9.0.1", "cosmiconfig-typescript-loader": "^6.1.0", "es-toolkit": "^1.46.0", "is-plain-obj": "^4.1.0", "picocolors": "^1.1.1" } }, "sha512-RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA=="],
 
-    "@commitlint/message": ["@commitlint/message@21.0.2", "", {}, "sha512-5n4aqHGD/FNnom/D5L8i7cYtV+xjuXcBL832C3w9VglEsZzIsoHpJsvxzJ7cgiOsOdc/2jU4t5+7qMHh7GBX3g=="],
+    "@commitlint/message": ["@commitlint/message@21.2.0", "", {}, "sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g=="],
 
-    "@commitlint/parse": ["@commitlint/parse@21.0.2", "", { "dependencies": { "@commitlint/types": "^21.0.1", "conventional-changelog-angular": "^8.2.0", "conventional-commits-parser": "^6.3.0" } }, "sha512-QVZJhGHTm+oiuWyEKOCTQ0ZM3mfJ0eGWFeHuj7WzSKEth+UukcCHac9GD8pgdFlg/qGkFWOtyaNd1T8REgagaw=="],
+    "@commitlint/parse": ["@commitlint/parse@21.2.0", "", { "dependencies": { "@commitlint/types": "^21.2.0", "conventional-changelog-angular": "^9.0.0", "conventional-commits-parser": "^7.0.0" } }, "sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg=="],
 
-    "@commitlint/read": ["@commitlint/read@21.0.2", "", { "dependencies": { "@commitlint/top-level": "^21.0.2", "@commitlint/types": "^21.0.1", "git-raw-commits": "^5.0.0", "tinyexec": "^1.0.0" } }, "sha512-BtsrnLVycSSKf4Q0gMch4giCj5NNlmcbhc8ra5vONgGtP2IjRDo33bEFtr5Pm+2N+5fXGWb2MksWPrspPfdhdw=="],
+    "@commitlint/read": ["@commitlint/read@21.2.1", "", { "dependencies": { "@commitlint/top-level": "^21.2.0", "@commitlint/types": "^21.2.0", "@conventional-changelog/git-client": "^3.0.0", "tinyexec": "^1.0.0" } }, "sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA=="],
 
-    "@commitlint/resolve-extends": ["@commitlint/resolve-extends@21.0.1", "", { "dependencies": { "@commitlint/config-validator": "^21.0.1", "@commitlint/types": "^21.0.1", "es-toolkit": "^1.46.0", "global-directory": "^5.0.0", "resolve-from": "^5.0.0" } }, "sha512-0DhjYWL6uYrY16Efa032fYk3woGJDU4AGWiG1XXltT9AMUNYKyb5cIZU2ivbaMZ3+kKFqUjikD2cjh66Sbh/Sg=="],
+    "@commitlint/resolve-extends": ["@commitlint/resolve-extends@21.2.0", "", { "dependencies": { "@commitlint/config-validator": "^21.2.0", "@commitlint/types": "^21.2.0", "es-toolkit": "^1.46.0", "global-directory": "^5.0.0", "resolve-from": "^5.0.0" } }, "sha512-4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA=="],
 
-    "@commitlint/rules": ["@commitlint/rules@21.0.2", "", { "dependencies": { "@commitlint/ensure": "^21.0.1", "@commitlint/message": "^21.0.2", "@commitlint/to-lines": "^21.0.1", "@commitlint/types": "^21.0.1" } }, "sha512-k6tQ69Td7t2qUSIbik8D3TL1q3ZJpkEbV+yLogDzCRAdOxJm4ndhtBNREsLA1/puRfWvzS9eioF2w43WT+hHgQ=="],
+    "@commitlint/rules": ["@commitlint/rules@21.2.0", "", { "dependencies": { "@commitlint/ensure": "^21.2.0", "@commitlint/message": "^21.2.0", "@commitlint/to-lines": "^21.0.1", "@commitlint/types": "^21.2.0" } }, "sha512-C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg=="],
 
     "@commitlint/to-lines": ["@commitlint/to-lines@21.0.1", "", {}, "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw=="],
 
-    "@commitlint/top-level": ["@commitlint/top-level@21.0.2", "", { "dependencies": { "escalade": "^3.2.0" } }, "sha512-s9KKM+e+mXgFeIh4n7KmOGAVT3mkJ3Fp1bBYHIK5pjeUwlEMzp/tZfb5u0Poa680AsQTXMEMRxZi1vQ9m2X5ug=="],
+    "@commitlint/top-level": ["@commitlint/top-level@21.2.0", "", { "dependencies": { "escalade": "^3.2.0" } }, "sha512-Y5gmQ+KxzqCrBFJfLvFEPvvwD3LDiNZoTT2yeFBm96M8qhmqSzQc5DvX3rheAaAMjyIvMXOCLS/mWfdpONsjyQ=="],
 
-    "@commitlint/types": ["@commitlint/types@21.0.1", "", { "dependencies": { "conventional-commits-parser": "^6.3.0", "picocolors": "^1.1.1" } }, "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg=="],
+    "@commitlint/types": ["@commitlint/types@21.2.0", "", { "dependencies": { "conventional-commits-parser": "^7.0.0", "picocolors": "^1.1.1" } }, "sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw=="],
 
-    "@conventional-changelog/git-client": ["@conventional-changelog/git-client@2.7.0", "", { "dependencies": { "@simple-libs/child-process-utils": "^1.0.0", "@simple-libs/stream-utils": "^1.2.0", "semver": "^7.5.2" }, "peerDependencies": { "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.4.0" }, "optionalPeers": ["conventional-commits-filter", "conventional-commits-parser"] }, "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw=="],
+    "@conventional-changelog/git-client": ["@conventional-changelog/git-client@3.1.0", "", { "dependencies": { "@simple-libs/child-process-utils": "^2.0.0", "@simple-libs/stream-utils": "^2.0.0", "semver": "^7.5.2" }, "peerDependencies": { "conventional-commits-filter": "^6.0.1", "conventional-commits-parser": "^7.0.1" }, "optionalPeers": ["conventional-commits-filter", "conventional-commits-parser"] }, "sha512-Tqa/gHco2WJWa740NRjOrfKVvzIqxkZpecb8bemaQ8sKM5PXb1UK4uTyTb/1wIqNuOVaDOFxyBdhTIQZn6gdjQ=="],
+
+    "@conventional-changelog/template": ["@conventional-changelog/template@1.2.1", "", {}, "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -179,9 +181,9 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
-    "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.2", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0" } }, "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw=="],
+    "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@2.0.0", "", { "dependencies": { "@simple-libs/stream-utils": "^2.0.0" } }, "sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A=="],
 
-    "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
+    "@simple-libs/stream-utils": ["@simple-libs/stream-utils@2.0.0", "", {}, "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -193,19 +195,19 @@
 
     "@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.7", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.7", "@vitest/utils": "4.1.7", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w=="],
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.7", "", { "dependencies": { "@vitest/spy": "4.1.7", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.7", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.7", "", { "dependencies": { "@vitest/utils": "4.1.7", "pathe": "^2.0.3" } }, "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw=="],
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.7", "", { "dependencies": { "@vitest/pretty-format": "4.1.7", "@vitest/utils": "4.1.7", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.7", "", {}, "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q=="],
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.7", "", { "dependencies": { "@vitest/pretty-format": "4.1.7", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw=="],
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -214,6 +216,8 @@
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "argue-cli": ["argue-cli@3.1.0", "", {}, "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw=="],
 
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
 
@@ -229,11 +233,11 @@
 
     "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
 
-    "conventional-changelog-angular": ["conventional-changelog-angular@8.3.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA=="],
+    "conventional-changelog-angular": ["conventional-changelog-angular@9.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.2.1" } }, "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw=="],
 
     "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@9.3.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA=="],
 
-    "conventional-commits-parser": ["conventional-commits-parser@6.3.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "meow": "^13.0.0" }, "bin": { "conventional-commits-parser": "dist/cli/index.js" } }, "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg=="],
+    "conventional-commits-parser": ["conventional-commits-parser@7.1.1", "", { "dependencies": { "@simple-libs/stream-utils": "^2.0.0", "argue-cli": "^3.1.0" }, "bin": { "conventional-commits-parser": "./dist/cli/index.js" } }, "sha512-B0f42jI++V5Vb7qK+DDw68r0dNxz5hk+RdKUkx2NOi39emc9hsHa3u2M3doF7QQhRFzCrAj7uM90teG+RBTaYQ=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -273,8 +277,6 @@
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
-    "git-raw-commits": ["git-raw-commits@5.0.1", "", { "dependencies": { "@conventional-changelog/git-client": "^2.6.0", "meow": "^13.0.0" }, "bin": { "git-raw-commits": "src/cli.js" } }, "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ=="],
-
     "global-directory": ["global-directory@5.0.0", "", { "dependencies": { "ini": "6.0.0" } }, "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -297,27 +299,27 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "lefthook": ["lefthook@2.1.9", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.9", "lefthook-darwin-x64": "2.1.9", "lefthook-freebsd-arm64": "2.1.9", "lefthook-freebsd-x64": "2.1.9", "lefthook-linux-arm64": "2.1.9", "lefthook-linux-x64": "2.1.9", "lefthook-openbsd-arm64": "2.1.9", "lefthook-openbsd-x64": "2.1.9", "lefthook-windows-arm64": "2.1.9", "lefthook-windows-x64": "2.1.9" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ=="],
+    "lefthook": ["lefthook@2.1.10", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.10", "lefthook-darwin-x64": "2.1.10", "lefthook-freebsd-arm64": "2.1.10", "lefthook-freebsd-x64": "2.1.10", "lefthook-linux-arm64": "2.1.10", "lefthook-linux-x64": "2.1.10", "lefthook-openbsd-arm64": "2.1.10", "lefthook-openbsd-x64": "2.1.10", "lefthook-windows-arm64": "2.1.10", "lefthook-windows-x64": "2.1.10" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-K7mM4WoqMwqfXYK11EHy+lSH1uW8XHni3Yn/bSqyerPkUPygGdf3xn18JoV5HyA06xuQL3ofGAOjG01QX9oJ4w=="],
 
-    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg=="],
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nw+X8wRNDoUUV6WSteyKBbcLySq+fsmZt5WV/s50ZJpysmsDKJOUMln6SllNfP+60dzUahAO7REco/2633BsLg=="],
 
-    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ=="],
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-KQ/bHmvpkFdHMn4pZnUdTf+GuSC+aBBgBTxZT4GW+6cSf+qbErKZBhK7cH6BmILsvx43+VzEArvHYY7YOfRFOQ=="],
 
-    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.9", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA=="],
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.10", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-8su6DwydP7+pv7kG0zCtjphqsw4ouOnfexRUErapy5GTxYBoUOhYz3RSHTSWNRsK6W4jva7FPUh2Lp5/PSn30w=="],
 
-    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.9", "", { "os": "freebsd", "cpu": "x64" }, "sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw=="],
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.10", "", { "os": "freebsd", "cpu": "x64" }, "sha512-GeAJEFxko3Lk+AsnS3NleAFrpyMLFUKOlgJvPKuU0xHwVEI/z+ZoCcmuO0BX+4CS0NLbZhC/YQAvBASqDvvVdQ=="],
 
-    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg=="],
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-1sHTCmpTWjVMs+yKPBLRNT1kuuIr1yjietlk7rCB6wFPVOS6Ph3o2zPFH2AvW1UymHlqwyHXzBr9EtDpQ7j1mQ=="],
 
-    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.9", "", { "os": "linux", "cpu": "x64" }, "sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w=="],
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.10", "", { "os": "linux", "cpu": "x64" }, "sha512-z/VlRB3bh6mBvW3r1rwnJ5vP8z+Krx5gJzkZ4veDXh+6FlRTx8wtd3g3fllOv/yZMxkgmL3fQoFXv05Esa7vBQ=="],
 
-    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.9", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw=="],
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.10", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-430zL8sSIKw5P0YXGG6PB+eAhHa06n0PXuaERaAQE4Ss3odfqwnl5Mq9hQmkEnOS1EGiQEKkd0UHv/i4PtMNIQ=="],
 
-    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.9", "", { "os": "openbsd", "cpu": "x64" }, "sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA=="],
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.10", "", { "os": "openbsd", "cpu": "x64" }, "sha512-bgkO8PphGZVDhQgCJ524aYYPI5491pVmCiLPGjBIo1AvOSlIyw4N1Y+1C3QfqwEmechzw+Aq16SNc8pqv6UuXg=="],
 
-    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA=="],
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-5Q6etF0Fla2DDA4ilDySrdNgiR5+W7cJZwnZ69Je3kvWCaWm4wnkuc8FEdjp3kiL2x3ZXipdI00f5vpO8aWmog=="],
 
-    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.9", "", { "os": "win32", "cpu": "x64" }, "sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA=="],
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.10", "", { "os": "win32", "cpu": "x64" }, "sha512-c/XH8YZtylG4XaxzqFfXluvq2LXq2W/p54Bnzn3+Z7E5X2Fk3JlFJAibulMbIt2+w8T7UI/r97ok5GqE4kGaeA=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
@@ -377,7 +379,7 @@
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
-    "vitest": ["vitest@4.1.7", "", { "dependencies": { "@vitest/expect": "4.1.7", "@vitest/mocker": "4.1.7", "@vitest/pretty-format": "4.1.7", "@vitest/runner": "4.1.7", "@vitest/snapshot": "4.1.7", "@vitest/spy": "4.1.7", "@vitest/utils": "4.1.7", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.7", "@vitest/browser-preview": "4.1.7", "@vitest/browser-webdriverio": "4.1.7", "@vitest/coverage-istanbul": "4.1.7", "@vitest/coverage-v8": "4.1.7", "@vitest/ui": "4.1.7", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA=="],
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
@@ -389,6 +391,16 @@
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
+    "@commitlint/cli/@commitlint/config-conventional": ["@commitlint/config-conventional@21.2.0", "", { "dependencies": { "@commitlint/types": "^21.2.0", "conventional-changelog-conventionalcommits": "^10.0.0" } }, "sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ=="],
+
+    "@commitlint/config-conventional/@commitlint/types": ["@commitlint/types@21.0.1", "", { "dependencies": { "conventional-commits-parser": "^6.3.0", "picocolors": "^1.1.1" } }, "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg=="],
+
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "@commitlint/cli/@commitlint/config-conventional/conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@10.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.2.1" } }, "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ=="],
+
+    "@commitlint/config-conventional/@commitlint/types/conventional-commits-parser": ["conventional-commits-parser@6.3.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "meow": "^13.0.0" }, "bin": { "conventional-commits-parser": "dist/cli/index.js" } }, "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg=="],
+
+    "@commitlint/config-conventional/@commitlint/types/conventional-commits-parser/@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
   }
 }

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-core",
-  "version": "0.9.7",
-  "description": "Full development workflow — frame, shape, plan, implement, review, ship. 30 skills, 9 agents, safety hooks.",
+  "version": "0.9.8",
+  "description": "Full development workflow — frame, shape, plan, implement, review, ship. 31 skills (incl. /ship meta), 9 agents, safety hooks.",
   "author": {
     "name": "Roxabi"
   }

--- a/plugins/dev-core/README.md
+++ b/plugins/dev-core/README.md
@@ -1,6 +1,6 @@
 # dev-core
 
-Full development lifecycle orchestrator for Roxabi projects. Covers framing, analysis, specification, planning, implementation, review, and shipping. Opinionated workflow with 30 skills, 9 specialized agents, and safety hooks.
+Full development lifecycle orchestrator for Roxabi projects. Covers framing, analysis, specification, planning, implementation, review, and shipping. Opinionated workflow with 31 skills, 9 specialized agents, and safety hooks.
 
 ## Prerequisites
 
@@ -59,17 +59,20 @@ Auto-discovers your runtime, framework, test tooling, and linter from the codeba
 
 ## Usage
 
-The main entry point is:
+Main entry points:
 
 ```
-/dev #N
+/dev #N     Full lifecycle from issue (frame → … → merge)
+/ship       Land ready code on the current feature branch (commit → PR → review → merge gate)
 ```
 
-Where `#N` is a GitHub issue number. The orchestrator scans existing artifacts, determines the issue tier (S / F-lite / F-full), shows current progress, and delegates to the right phase skill. It drives the full lifecycle from issue to merged PR.
+`/dev #N` — `#N` is a GitHub issue number. Scans artifacts, determines tier (S / F-lite / F-full), shows progress, drives Frame→Ship.
+
+`/ship` — use when the code is already on a feature branch and you only want commit → PR → agent review → fix loop → `reviewed` label + CI/auto-merge watch.
 
 ## Skills
 
-30 skills organized by workflow phase:
+31 skills organized by workflow phase:
 
 | Skill | Phase | Description |
 |-------|-------|-------------|
@@ -80,7 +83,8 @@ Where `#N` is a GitHub issue number. The orchestrator scans existing artifacts, 
 | `doctor` | Setup | Project-type-aware health check — verifies prerequisites, GitHub config, labels, CI/CD workflows (checks both local files and remote via REST API), required secrets (PAT for auto-merge.yml), branch protection, stack.yml, workspace.json registration, and LSP plugin install (typescript-lsp / pyright-lsp with auto-fix). Distinguishes ❌ blocking errors from ⚠️ optional warnings; exits 0 when warnings-only |
 | `seed-docs` | Setup | Populates scaffolded architecture/standards docs with real content — reads CLAUDE.md for conventions, optionally scans codebase (entry points, import graph, naming patterns), fills TODO stubs, writes AI Quick Reference sections. Idempotent: skips already-populated files |
 | `seed-community` | Setup | Bootstraps OSS community health files — CONTRIBUTING.md, LICENSE, SECURITY.md, CODE_OF_CONDUCT.md, README sections (Getting Started, Badges), `.github/PULL_REQUEST_TEMPLATE.md`, issue templates. Reads project metadata + CLAUDE.md; generates missing files idempotently |
-| `dev` | Orchestrator | Routes issues through the full workflow |
+| `dev` | Orchestrator | Routes issues through the full workflow (Frame→Ship) |
+| `ship` | Orchestrator | Lands ready code: commit → PR → code-review → fix loop → `reviewed` + ci-watch → cleanup |
 | `recheck` | Frame | Drift-check an issue (git-drift, symbol-missing, dep-resolved) before /dev work begins. Runs before /frame for every tier — no skip path. Signal-clean returns silently; signal-fire blocks with user choice (Proceed/Update/Close/Abort) |
 | `frame` | Frame | Creates initial feature frame from issue |
 | `analyze` | Shape | Deep analysis with expert consultation |

--- a/plugins/dev-core/skills/ci-watch/SKILL.md
+++ b/plugins/dev-core/skills/ci-watch/SKILL.md
@@ -72,8 +72,8 @@ Timeout: the loop self-bounds at `MERGE_WAIT_TIMEOUT` (script, 15 min) → grace
 ## Chain Position
 
 - **Phase:** Verify
-- **Predecessor:** `/pr` (PR exists)
-- **Successor:** `/validate`
+- **Predecessor:** `/pr` (via `/dev`) · or `reviewed` label step (via `/ship`)
+- **Successor:** `/validate` (via `/dev`) · or `/cleanup` (via `/ship` after merge)
 - **Class:** adv (continuous flow, no gate)
 
 ## Task Integration

--- a/plugins/dev-core/skills/cleanup/README.md
+++ b/plugins/dev-core/skills/cleanup/README.md
@@ -19,11 +19,12 @@ Triggers: `"cleanup"` | `"clean branches"` | `"cleanup worktrees"` | `"remove st
 
 ## How it works
 
-1. **Gather state** — `gather-state.sh` lists local branches (tracking info), worktrees, open PRs, closed PR labels, and queued CI runs.
+1. **Gather state** — `gather-state.sh` lists local branches (tracking info), worktrees, **orphan worktree shells** (`scan-orphan-worktree-shells.sh`: empty Grok parents, unregistered dirs, stale `~/.grok/worktrees.db` rows), open PRs, closed PR labels, and queued CI runs.
 2. **Analyze branches** — `analyze-branches.sh` batch-audits local + remote branches (regular merge, squash PR state, issue# grep, open PRs, worktrees). Outputs `---safe-local---` / `---safe-remote---` plus a summary table. Use `--json` for machine-readable output.
 3. **Present summary table** — 🗑 Safe to delete | ⚠️ Active work | 🔒 Protected
 4. **Confirm** — presents safe branches as default selections; unmerged branches listed separately with explicit warning; never auto-selects unmerged.
 5. **Execute** — removes worktrees first (before deleting their branch), uses `git branch -d` for merged, `git branch -D` only on explicit confirmation.
+5b. **Orphan shells** — removes leftover `~/.grok/worktrees/<slug>/` / `.claude/worktrees/` paths and stale Grok DB rows that `git worktree list` no longer sees (confirm first; repo-scoped only).
 6. **Remote cleanup** — uses `---safe-remote---` from step 2; asks for explicit confirmation per branch.
 7. **Sweep** — strips stuck pipeline labels from closed PRs; cancels long-queued CI runs.
 

--- a/plugins/dev-core/skills/cleanup/SKILL.md
+++ b/plugins/dev-core/skills/cleanup/SKILL.md
@@ -2,15 +2,15 @@
 name: cleanup
 argument-hint: [--all | --report-only | --yes | --scope <#N>]
 description: Clean git branches/worktrees/remotes after merge-status verification; sweep stuck pipeline labels and orphan CI runs. Triggers: "cleanup" | "clean branches" | "cleanup worktrees" | "remove stale branches".
-version: 0.6.1
+version: 0.6.2
 allowed-tools: Bash, Read, EnterWorktree, ExitWorktree, ToolSearch
 ---
 
 # Git Cleanup
 
-Let: β := branch | ω := worktree | π := open PR | Π := protected branch (main/master/staging) | safe(β) ⟺ fully_merged(β) ∧ ¬π(β) | merged(β) := regular_merge(β) ∨ squash_merge(β) | N := scope issue number (∅ if unscoped)
+Let: β := branch | ω := worktree | π := open PR | Π := protected branch (main/master/staging) | safe(β) ⟺ fully_merged(β) ∧ ¬π(β) | merged(β) := regular_merge(β) ∨ squash_merge(β) | N := scope issue number (∅ if unscoped) | orphan_shell := leftover path under `~/.grok/worktrees/<slug>/` or `.claude/worktrees/` that is **not** in `git worktree list` (empty parent, unregistered content, or `worktrees.db` row with missing path)
 
-Safely clean local β, ω, and remote branches with **mandatory merge-status verification** before any deletion. End-of-session sweep also strips stuck pipeline labels from closed PRs and cancels long-queued CI runs.
+Safely clean local β, ω, and remote branches with **mandatory merge-status verification** before any deletion. End-of-session sweep also strips stuck pipeline labels from closed PRs, cancels long-queued CI runs, and surfaces **orphan worktree shells** that git no longer tracks.
 
 ## Entry: parse $ARGUMENTS
 
@@ -49,7 +49,7 @@ If both set: `REPORT_ONLY` wins — no mutations.
 bash ${CLAUDE_SKILL_DIR}/gather-state.sh
 ```
 
-Emits: `current`, branch list with tracking info, worktree list, open PRs, closed PRs with pipeline labels, and queued/stuck CI runs. Unscoped — always full-repo; Steps 7–8 (label/CI sweeps) consume it as-is regardless of `--scope` (see Options).
+Emits: `current`, branch list with tracking info, worktree list, **orphan worktree shells** (`---orphan-worktree-shells---` via `scan-orphan-worktree-shells.sh`), open PRs, closed PRs with pipeline labels, and queued/stuck CI runs. Unscoped — always full-repo; Steps 7–8 (label/CI sweeps) and the orphan-shell scan consume gather-state as-is regardless of `--scope` (see Options).
 
 ### 2. Analyze Branches
 
@@ -126,6 +126,44 @@ git branch -D <branch>        # unmerged — only if explicitly confirmed
 
 git worktree prune
 ```
+
+### 5b. Orphan worktree shells (Grok / Claude leftovers)
+
+`git worktree list` only knows registered worktrees. After `git worktree remove`, agents often leave:
+
+| kind | Example | Safe cleanup |
+|------|---------|--------------|
+| `empty_parent` | `~/.grok/worktrees/gosilex-spark/` empty | `rmdir` (or `rm -rf` if confirmed empty) |
+| `unregistered` | partial dir (e.g. only `node_modules`) under Grok slug or `.claude/worktrees/` **not** in `git worktree list` | `rm -rf <path>` after confirm — **never** if path is still a live registered ω |
+| `db_stale` | row in `~/.grok/worktrees.db` with `status=alive` but path missing | delete the DB row (path already gone) |
+
+Source: `gather-state.sh` → `---orphan-worktree-shells---` (`path|kind|detail`). Scope is **this repo only** (Grok slug = owner alnum-stripped + `-` + repo name, e.g. `go-silex/spark` → `gosilex-spark`). Do **not** touch other repos' Grok worktree trees (e.g. metalyde while cleaning spark).
+
+#### 5b-present
+
+```
+Orphan worktree shells
+══════════════════════
+
+  Path                                              │ Kind          │ Detail
+  ~/.grok/worktrees/gosilex-spark                   │ empty_parent  │ empty Grok parent
+  ~/.grok/worktrees/gosilex-spark/2026-…-c4624b74   │ db_stale      │ worktrees.db alive, path missing
+  (none found)
+```
+
+If `REPORT_ONLY=true` → print table and skip deletion. Else → multi-select (default: all listed); always offer "Skip".
+
+#### 5b-execute (confirmed only)
+
+```bash
+# empty_parent / unregistered on disk:
+rmdir <path> 2>/dev/null || rm -rf <path>   # rmdir first; rm -rf only if user confirmed content orphans
+
+# db_stale (path already missing — metadata only):
+sqlite3 ~/.grok/worktrees.db "DELETE FROM worktrees WHERE path = '<path>';"
+```
+
+**Safety:** never `rm -rf` a path that still appears in `git worktree list`. Never wipe `~/.grok/worktrees/` wholesale — only this repo's slug children / matching `source_repo` DB rows.
 
 ### 6. Clean Remote Branches
 
@@ -266,6 +304,11 @@ Cleanup Complete
     ⏭ Skipped: feat/33-i18n (active PR)
     ⏭ Skipped: experiment/test (unmerged, user chose to keep)
 
+  Orphan shells:
+    ✅ Removed empty parent: ~/.grok/worktrees/gosilex-spark
+    ✅ Deleted worktrees.db row: …/2026-07-28-c4624b74
+    ⏭ Skipped: (none)
+
   Remote:
     ✅ Deleted remote: origin/feat/19-auth
     ✅ Deleted remote: origin/docs/28-coding-standards
@@ -315,6 +358,7 @@ If `REPORT_ONLY=true`, prefix the header with `[report-only — no mutations per
 - **Remote tracking branches**: Step 6 scans **all** remote β independently — always require explicit confirmation.
 - **Stale worktrees**: ω path ∉ disk → `git worktree prune`.
 - **EnterWorktree worktrees**: worktrees in `.claude/worktrees/` are session-managed — `git worktree list` shows them alongside legacy worktrees; clean with `git worktree remove` or `ExitWorktree` if in active session.
+- **Orphan shells after remove**: `git worktree remove` does not delete empty parent dirs under `~/.grok/worktrees/<slug>/`, nor Grok `worktrees.db` rows. Step 5b + `scan-orphan-worktree-shells.sh` cover these.
 
 ## Chain Position
 

--- a/plugins/dev-core/skills/cleanup/gather-state.sh
+++ b/plugins/dev-core/skills/cleanup/gather-state.sh
@@ -13,6 +13,17 @@ git branch -vv 2>/dev/null || echo "branches=none"
 echo "---worktrees---"
 git worktree list 2>/dev/null || echo "worktrees=none"
 
+echo "---orphan-worktree-shells---"
+# Leftovers that `git worktree list` misses (empty Grok parents, unregistered
+# dirs under ~/.grok/worktrees/<slug>/ or .claude/worktrees/, stale worktrees.db).
+# Analyze-only — lines: path|kind|detail. See scan-orphan-worktree-shells.sh.
+_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -x "$_script_dir/scan-orphan-worktree-shells.sh" ]; then
+  bash "$_script_dir/scan-orphan-worktree-shells.sh" || echo "orphan_shells=error"
+else
+  echo "orphan_shells=none"
+fi
+
 echo "---open-prs---"
 gh pr list --state open 2>/dev/null || echo "open_prs=none"
 

--- a/plugins/dev-core/skills/cleanup/scan-orphan-worktree-shells.sh
+++ b/plugins/dev-core/skills/cleanup/scan-orphan-worktree-shells.sh
@@ -9,7 +9,7 @@
 #   - Grok worktrees.db rows for this source_repo whose path no longer exists
 #
 # Emits lines: path|kind|detail
-# kind ∈ empty_parent | unregistered | missing_path | db_stale
+# kind ∈ empty_parent | unregistered | db_stale
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
@@ -57,6 +57,16 @@ is_registered() {
   [ -n "${REGISTERED[$p]+x}" ]
 }
 
+# True if directory has at least one entry (incl. hidden). Avoids
+# `find | head` under `set -o pipefail` (SIGPIPE → exit 141).
+dir_has_entries() {
+  local d="$1" e
+  shopt -s nullglob dotglob
+  e=("$d"/*)
+  shopt -u nullglob dotglob
+  [ "${#e[@]}" -gt 0 ]
+}
+
 # --- 1) ~/.grok/worktrees/<slug>/ ---
 slug="$(grok_repo_slug || true)"
 GROK_WT_ROOT="${GROK_WORKTREES_ROOT:-$HOME/.grok/worktrees}"
@@ -78,7 +88,7 @@ if [ -n "$slug" ]; then
         if [ -e "$child/.git" ]; then
           # Has a gitdir but not registered → stale / half-removed worktree
           emit "$child" "unregistered" "has .git but not in git worktree list"
-        elif [ -z "$(find "$child" -mindepth 1 -maxdepth 1 2>/dev/null | head -1)" ]; then
+        elif ! dir_has_entries "$child"; then
           emit "$child" "empty_parent" "empty leftover after worktree remove"
         else
           emit "$child" "unregistered" "content without git registration (orphan shell)"
@@ -95,7 +105,7 @@ if [ -n "$slug" ]; then
       is_registered "$candidate" && continue
       if [ -e "$candidate/.git" ]; then
         emit "$candidate" "unregistered" "under ~/.grok/worktrees/projects, not registered"
-      elif [ -z "$(find "$candidate" -mindepth 1 -maxdepth 1 2>/dev/null | head -1)" ]; then
+      elif ! dir_has_entries "$candidate"; then
         emit "$candidate" "empty_parent" "empty under ~/.grok/worktrees/projects"
       else
         # partial leftover (e.g. only node_modules)
@@ -114,7 +124,7 @@ if [ -d "$claude_wt" ]; then
     is_registered "$child" && continue
     if [ -e "$child/.git" ]; then
       emit "$child" "unregistered" ".claude/worktrees entry not in git worktree list"
-    elif [ -z "$(find "$child" -mindepth 1 -maxdepth 1 2>/dev/null | head -1)" ]; then
+    elif ! dir_has_entries "$child"; then
       emit "$child" "empty_parent" "empty .claude/worktrees shell"
     else
       emit "$child" "unregistered" "orphan .claude/worktrees content"
@@ -122,10 +132,7 @@ if [ -d "$claude_wt" ]; then
   done
   shopt -u nullglob
   # empty parent .claude/worktrees with no children
-  shopt -s nullglob
-  claude_children=("$claude_wt"/*)
-  shopt -u nullglob
-  if [ "${#claude_children[@]}" -eq 0 ]; then
+  if ! dir_has_entries "$claude_wt"; then
     emit "$claude_wt" "empty_parent" "empty .claude/worktrees directory"
   fi
 fi

--- a/plugins/dev-core/skills/cleanup/scan-orphan-worktree-shells.sh
+++ b/plugins/dev-core/skills/cleanup/scan-orphan-worktree-shells.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Usage: scan-orphan-worktree-shells.sh
+# Analyze-only — never deletes.
+#
+# Finds leftover worktree *shells* that `git worktree list` misses after
+# `git worktree remove`:
+#   - empty or unregistered dirs under ~/.grok/worktrees/<repo-slug>/
+#   - orphan paths under .claude/worktrees/ (not in git worktree list)
+#   - Grok worktrees.db rows for this source_repo whose path no longer exists
+#
+# Emits lines: path|kind|detail
+# kind ∈ empty_parent | unregistered | missing_path | db_stale
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$repo_root" ]; then
+  echo "orphan_shells=none"
+  exit 0
+fi
+
+# Registered worktree paths (absolute).
+declare -A REGISTERED=()
+while IFS= read -r line; do
+  case "$line" in
+    worktree\ *)
+      p="${line#worktree }"
+      REGISTERED["$p"]=1
+      ;;
+  esac
+done < <(git worktree list --porcelain 2>/dev/null || true)
+
+# Grok slug: owner with non-alphanumerics stripped + "-" + repo
+# (matches ~/.grok/worktrees/gosilex-spark for go-silex/spark).
+grok_repo_slug() {
+  local url owner repo
+  url="$(git remote get-url origin 2>/dev/null || true)"
+  [ -z "$url" ] && return 1
+  # git@host:owner/repo.git | https://host/owner/repo.git | ssh://…/owner/repo.git
+  if [[ "$url" =~ [:/]([^/:]+)/([^/]+?)(\.git)?$ ]]; then
+    owner="${BASH_REMATCH[1]}"
+    repo="${BASH_REMATCH[2]}"
+    repo="${repo%.git}"
+    owner="$(printf '%s' "$owner" | tr -cd '[:alnum:]')"
+    printf '%s-%s' "$owner" "$repo"
+    return 0
+  fi
+  return 1
+}
+
+emit() {
+  # path|kind|detail
+  printf '%s|%s|%s\n' "$1" "$2" "$3"
+}
+
+is_registered() {
+  local p="$1"
+  [ -n "${REGISTERED[$p]+x}" ]
+}
+
+# --- 1) ~/.grok/worktrees/<slug>/ ---
+slug="$(grok_repo_slug || true)"
+GROK_WT_ROOT="${GROK_WORKTREES_ROOT:-$HOME/.grok/worktrees}"
+if [ -n "$slug" ]; then
+  slug_dir="$GROK_WT_ROOT/$slug"
+  if [ -d "$slug_dir" ]; then
+    # children (depth 1)
+    shopt -s nullglob
+    children=("$slug_dir"/*)
+    shopt -u nullglob
+    if [ "${#children[@]}" -eq 0 ]; then
+      emit "$slug_dir" "empty_parent" "empty Grok worktree parent for this repo"
+    else
+      for child in "${children[@]}"; do
+        [ -e "$child" ] || continue
+        if is_registered "$child"; then
+          continue
+        fi
+        if [ -e "$child/.git" ]; then
+          # Has a gitdir but not registered → stale / half-removed worktree
+          emit "$child" "unregistered" "has .git but not in git worktree list"
+        elif [ -z "$(find "$child" -mindepth 1 -maxdepth 1 2>/dev/null | head -1)" ]; then
+          emit "$child" "empty_parent" "empty leftover after worktree remove"
+        else
+          emit "$child" "unregistered" "content without git registration (orphan shell)"
+        fi
+      done
+    fi
+  fi
+
+  # Legacy accidental layout: ~/.grok/worktrees/projects/<…>/<repo>
+  # Only flag if path is under this repo's name and not registered.
+  projects_root="$GROK_WT_ROOT/projects"
+  if [ -d "$projects_root" ]; then
+    while IFS= read -r -d '' candidate; do
+      is_registered "$candidate" && continue
+      if [ -e "$candidate/.git" ]; then
+        emit "$candidate" "unregistered" "under ~/.grok/worktrees/projects, not registered"
+      elif [ -z "$(find "$candidate" -mindepth 1 -maxdepth 1 2>/dev/null | head -1)" ]; then
+        emit "$candidate" "empty_parent" "empty under ~/.grok/worktrees/projects"
+      else
+        # partial leftover (e.g. only node_modules)
+        emit "$candidate" "unregistered" "orphan content under ~/.grok/worktrees/projects"
+      fi
+    done < <(find "$projects_root" -mindepth 2 -maxdepth 4 -type d \( -name "$(basename "$repo_root")" -o -path "*/$(basename "$repo_root")" \) -print0 2>/dev/null || true)
+  fi
+fi
+
+# --- 2) .claude/worktrees/* under main repo ---
+claude_wt="$repo_root/.claude/worktrees"
+if [ -d "$claude_wt" ]; then
+  shopt -s nullglob
+  for child in "$claude_wt"/*; do
+    [ -e "$child" ] || continue
+    is_registered "$child" && continue
+    if [ -e "$child/.git" ]; then
+      emit "$child" "unregistered" ".claude/worktrees entry not in git worktree list"
+    elif [ -z "$(find "$child" -mindepth 1 -maxdepth 1 2>/dev/null | head -1)" ]; then
+      emit "$child" "empty_parent" "empty .claude/worktrees shell"
+    else
+      emit "$child" "unregistered" "orphan .claude/worktrees content"
+    fi
+  done
+  shopt -u nullglob
+  # empty parent .claude/worktrees with no children
+  shopt -s nullglob
+  claude_children=("$claude_wt"/*)
+  shopt -u nullglob
+  if [ "${#claude_children[@]}" -eq 0 ]; then
+    emit "$claude_wt" "empty_parent" "empty .claude/worktrees directory"
+  fi
+fi
+
+# --- 3) Grok worktrees.db stale rows for this source_repo ---
+db="${GROK_WORKTREES_DB:-$HOME/.grok/worktrees.db}"
+if [ -f "$db" ] && command -v sqlite3 >/dev/null 2>&1; then
+  # Match rows for this checkout path, or under this repo's Grok slug.
+  # Escape single quotes for SQL string literals.
+  _sql_escape() { printf "%s" "$1" | sed "s/'/''/g"; }
+  _repo_sql="$(_sql_escape "$repo_root")"
+  _slug_sql=""
+  [ -n "${slug:-}" ] && _slug_sql="$(_sql_escape "$GROK_WT_ROOT/$slug")"
+  _sql="SELECT path, status FROM worktrees WHERE source_repo = '${_repo_sql}'"
+  if [ -n "$_slug_sql" ]; then
+    _sql="${_sql} OR path LIKE '${_slug_sql}/%' OR path = '${_slug_sql}'"
+  fi
+  while IFS='|' read -r path status; do
+    [ -n "$path" ] || continue
+    if [ ! -e "$path" ]; then
+      emit "$path" "db_stale" "worktrees.db status=${status:-?} path missing on disk"
+    elif ! is_registered "$path"; then
+      # Path exists but git does not know it — still report as unregistered
+      emit "$path" "unregistered" "worktrees.db status=${status:-?} not in git worktree list"
+    fi
+  done < <(sqlite3 -separator '|' "$db" "$_sql" 2>/dev/null || true)
+fi
+
+# Always end with a marker if nothing printed (caller can treat empty as none)
+# — caller checks for any lines after the section header.

--- a/plugins/dev-core/skills/dev/README.md
+++ b/plugins/dev-core/skills/dev/README.md
@@ -51,3 +51,5 @@ Tier affects which steps run:
 ## Chain position
 
 Entry point of the full dev pipeline. Preceded by the external `roxabi-issues:issue-triage` step (not dev-core). Delegates to: `/recheck` → `/frame` → `/analyze` → `/spec` → `/plan` → `/implement` → `/pr` → `/ci-watch` → `/validate` → `/code-review` → `/fix` → `/cleanup`.
+
+**Code already ready?** Use `/ship` instead — commit → PR → review → fix loop → `reviewed` + ci-watch (review-before-CI order).

--- a/plugins/dev-core/skills/pr/SKILL.md
+++ b/plugins/dev-core/skills/pr/SKILL.md
@@ -187,8 +187,8 @@ Lifecycle notes: S-tier → Intent + Implementation + Verification only. ¬issue
 ## Chain Position
 
 - **Phase:** Build
-- **Predecessor:** `/implement` (worktree with commits)
-- **Successor:** `/ci-watch`
+- **Predecessor:** `/implement` (worktree with commits) · or `/ship` commit step
+- **Successor:** `/ci-watch` (via `/dev`) · or `/code-review` (via `/ship`)
 - **Class:** adv (continuous flow, no gate)
 
 ## Task Integration

--- a/plugins/dev-core/skills/shared/references/chain-contract.md
+++ b/plugins/dev-core/skills/shared/references/chain-contract.md
@@ -17,6 +17,23 @@ issue-triage (external, roxabi-issues) → recheck → frame → analyze → spe
 
 > `plan ⏸→ implement`: for τ ∈ {F-lite, F-full}, `/dev` inserts a **compact pause** between plan and implement (Step 8b) — recommend `/compact` before building. τ=S skips plan entirely. See the gate-class Exit `/plan` exception.
 
+### Parallel meta: `/ship` (code already ready)
+
+```
+commit → pr → code-review → {fix ↺ review}×≤2 → label reviewed → ci-watch → cleanup?
+```
+
+`/ship` is a **second orchestrator** (not a step inside `/dev`). Use when the feature branch already has the work and you only want the gate path. Differences vs `/dev` Verify:
+
+| | `/dev` Verify | `/ship` |
+|---|---|---|
+| Order | pr → **ci-watch** → validate → **review** → fix | commit → pr → **review** → fix → **reviewed + ci-watch** |
+| validate | yes | no |
+| commit | via implement | first-class step |
+| `reviewed` label | via code-review Phase 8 / fix Phase 7 | owned by ship after final APPROVED (strips premature label after `/fix` before re-review) |
+
+¬add `/ship` steps to `/dev` STEPS list — they remain separate entry points.
+
 ## Ownership model
 
 | Concern | Owner |
@@ -160,6 +177,13 @@ When adding a new skill to the dev-core pipeline:
 4. Add it to `/dev` Tier Skip Matrix (S|F-lite|F-full columns)
 5. Add the three canonical body sections to the skill's own SKILL.md: **Chain Position**, **Task Integration**, **Exit** (using the class-appropriate Exit pattern)
 6. Update this reference file if the new skill introduces a new class
+
+When adding a **meta-orchestrator** (like `/ship`):
+
+1. New skill directory under `skills/<name>/` with SKILL.md + README.md
+2. Document relation to `/dev` (when to use which) — do **not** force-insert into `/dev` STEPS unless the full lifecycle should change
+3. Update this contract + plugin README skills table
+4. Child skills keep their Exit “via `/dev`” paths; add “via `/ship`” only if behavior must differ (e.g. strip `reviewed` after fix)
 
 ## Cache synchronization
 

--- a/plugins/dev-core/skills/ship/README.md
+++ b/plugins/dev-core/skills/ship/README.md
@@ -1,0 +1,43 @@
+# ship
+
+Meta-orchestrator to land **ready** code on a feature branch:
+
+```
+commit → /pr → /code-review → [/fix ↺ /code-review] → reviewed label → /ci-watch → [/cleanup]
+```
+
+## When to use
+
+```
+/ship                    Full gate path on current feature branch
+/ship --draft            Open a draft PR first
+/ship --from review      PR already open — start at agent review
+/ship --max-fix-iters 1  Single fix pass only
+/ship --skip-cleanup     Leave branches/worktrees after merge
+```
+
+**Triggers:** `"ship"` | `"ship this"` | `"land this"` | `"land the PR"` | `"ship PR"` | `"submit for merge"` | `"get this merged"` | `"ship my branch"`
+
+Use when implementation is already done (or mostly done) and you want review + merge-on-green without running `/dev` Frame/Shape/Build.
+
+## vs `/dev`
+
+| | `/dev` | `/ship` |
+|---|--------|---------|
+| Starts from | GitHub issue + artifacts | Current feature branch |
+| Pipeline | recheck→…→implement→pr→**ci-watch**→validate→**review**→fix→cleanup | **commit**→pr→**review**→fix loop→**reviewed+ci-watch**→cleanup |
+| validate | yes | no |
+| Ideal for | Greenfield issue work | Hotfix, agent-coded branch, “just land it” |
+
+## How it works
+
+1. **commit** — if the tree is dirty, conventional-commit + push (skipped when clean).
+2. **pr** — delegates to `/pr` (create or update).
+3. **code-review** — delegates to `/code-review`.
+4. **fix loop** — on CHANGES_REQUESTED, `/fix` then re-review (max 2). Strips a premature `reviewed` label after fix so merge-on-green cannot fire mid-loop.
+5. **reviewed + ci-watch** — adds `reviewed`, enables auto-merge when possible, watches CI/merge via `/ci-watch`.
+6. **cleanup** — optional post-merge `/cleanup`.
+
+## Chain position
+
+**Predecessor:** finished coding on a feature branch · **Successor:** `/promote` (if base is staging) · **Class:** meta-orchestrator

--- a/plugins/dev-core/skills/ship/SKILL.md
+++ b/plugins/dev-core/skills/ship/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: ship
+argument-hint: '[#PR | --draft | --base <branch> | --from <step> | --max-fix-iters N | --no-commit | --skip-cleanup]'
+description: Meta-orchestrator to land ready code — commit → PR → code-review → fix loop → reviewed label + ci-watch. Triggers: "ship" | "ship this" | "land this" | "land the PR" | "ship PR" | "submit for merge" | "get this merged" | "ship my branch".
+version: 0.1.0
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
+---
+
+# Ship
+
+## Success
+
+I := commits on feature branch ∧ PR ∃ ∧ agent review APPROVED (or clean after ≤K fix↔review iters) ∧ label `reviewed` ∧ CI green ∧ (auto-merge attempted ∨ merge path reported)
+V := `gh pr view` state MERGED ∨ (CI green ∧ `reviewed` ∈ labels ∧ autoMergeRequest ≠ null) ∨ explicit Abort/Stop
+
+Let:
+  Β    := current branch (must ∉ {main, master, staging})
+  β    := `staging` (∃ origin/staging) ∨ `main`
+  P    := open PR for Β (number)
+  K    := max fix↔review iterations (default **2**, override `--max-fix-iters N`)
+  Σ_s  := session step map (in-memory only)
+  ψ_r  := PR comments ∃ body starting with `## Code Review`
+  ψ_f  := PR comments ∃ body starting with `## Review Fixes Applied`
+  dirty := `git status --porcelain` non-empty
+  ahead := `git rev-list --count origin/${β}..HEAD` > 0 (or unpushed commits on Β)
+  bar  := same quality bar as `/dev` — hand-authored feel; QG = floor
+
+**Not** a substitute for `/dev`. Use when **implementation is already done** (or nearly) and you want the gate path only:
+
+```
+commit → /pr → /code-review → [/fix ↺ /code-review]×≤K → label reviewed → /ci-watch → [/cleanup]
+```
+
+Compared to `/dev` Verify (`pr → ci-watch → validate → review → fix`):
+- **Review before merge-gate** — agent review + fix loop first; `reviewed` + CI watch last
+- **No** frame/spec/plan/implement/validate (optional: jump via `/dev --from …` if you need those)
+- **Commit step** included (dirty tree → conventional commit + push)
+
+¬rewrite child skill logic. ¬auto-merge mid-CI. Label `reviewed` is the merge gate (merge-on-green / `gh pr merge --auto --merge`).
+
+## Entry
+
+```
+/ship                    → full pipeline from current branch
+/ship #42                → bind to PR #42 (must match current branch head)
+/ship --draft            → pass --draft to /pr
+/ship --base staging     → pass --base to /pr
+/ship --from review      → skip commit+pr if PR already exists
+/ship --max-fix-iters 1  → cap fix↔review loops
+/ship --no-commit        → refuse to create commits; dirty tree → halt
+/ship --skip-cleanup     → after merge, do not run /cleanup
+```
+
+## Steps
+
+```
+commit → pr → review → fix ↺ review → label-reviewed → ci-watch → cleanup
+```
+
+| Step | Class | Skill / action | On success → |
+|------|-------|----------------|--------------|
+| commit | adv (inline) | conventional commit + push if dirty | pr |
+| pr | adv | `skill: "pr"` (+ `--draft` / `--base` if set) | review |
+| review | verdict | `skill: "code-review"` | APPROVED → label-reviewed · CHANGES_REQUESTED → fix · Stop → halt |
+| fix | loop | `skill: "fix", args: "#{P}"` | strip premature `reviewed` if present → review (iter++) |
+| label-reviewed | adv (inline) | ensure auto-merge + `reviewed` label | ci-watch |
+| ci-watch | adv | `skill: "ci-watch", args: "--pr {P}"` | cleanup (if merged ∨ green path) |
+| cleanup | adv | `skill: "cleanup"` (scoped if issue# known) | done |
+
+## Step 0 — Parse + Guard Rails
+
+```
+DRAFT=false; BASE=""; FROM=""; K=2; NO_COMMIT=false; SKIP_CLEANUP=false; PR_ARG=""
+for arg in $ARGUMENTS; do
+  case "$arg" in
+    --draft) DRAFT=true ;;
+    --base)  next is BASE ;;
+    --base=*) BASE="${arg#--base=}" ;;
+    --from)  next is FROM ;;
+    --from=*) FROM="${arg#--from=}" ;;
+    --max-fix-iters=*) K="${arg#--max-fix-iters=}" ;;
+    --no-commit) NO_COMMIT=true ;;
+    --skip-cleanup) SKIP_CLEANUP=true ;;
+    \#[0-9]*|[0-9]*) PR_ARG="${arg#\#}" ;;
+  esac
+done
+```
+
+1. `git fetch origin ${β} --quiet` (best-effort)
+2. Β ∈ {main, master, staging} → **REFUSE**: "Create/switch to a feature branch first."
+3. Resolve P:
+   - `PR_ARG` set → `gh pr view $PR_ARG --json number,headRefName,state,url`
+   - else → `gh pr list --head "$Β" --state open --json number,url -q '.[0]'`
+4. If `FROM` set ∈ {review, fix, label-reviewed, ci-watch, cleanup}: mark prior steps done in Σ_s; require P ∃ for any step after pr.
+
+## Step 1 — Scan State
+
+```
+Σ_s defaults false. Detect:
+
+  commit:  ¬dirty  (nothing to commit)  — still may have ahead commits
+  pr:      P ∃ ∧ open
+  review:  P ∃ ∧ (ψ_r ∨ reviewDecision ∈ {APPROVED, CHANGES_REQUESTED})
+  fix:     P ∃ ∧ ψ_f  (last cycle; re-review may still be needed)
+  label:   P ∃ ∧ label reviewed ∈ PR
+  ci:      null (session)
+  cleanup: null (session)
+  iter:    0   # fix↔review iterations completed
+```
+
+Present short banner (no full /dev phase bars):
+
+```
+## Ship — {Β}  [PR #{P}|no PR]
+
+  commit          {✓|→|skip}
+  pr              {✓|→|pending}
+  code-review     {✓|→|pending}  (iter {iter}/{K})
+  fix             {cond}
+  reviewed+CI     {✓|→|pending}
+  cleanup         {✓|skip|pending}
+
+→ Next: {S*}
+```
+
+## Step 2 — commit (inline)
+
+**Skip if:** `--no-commit` ∧ ¬dirty · or ¬dirty (nothing to stage).
+
+**If dirty ∧ `--no-commit`:** halt — "Working tree dirty; commit manually or drop `--no-commit`."
+
+**If dirty:**
+1. `git status -sb` + `git diff` / `git diff --staged` + `git log -5 --oneline`
+2. Stage intentional paths only — ¬`git add -A` if secrets risk (same rule as `/fix`). Prefer explicit paths from status.
+3. Message: Conventional Commits, focus on *why*. HEREDOC commit.
+4. `git push -u origin HEAD` (or `git push` if upstream set).
+5. Fail → Retry | Abort.
+
+**If ¬dirty ∧ ¬ahead ∧ ¬P:** **REFUSE** — "Nothing to ship (clean tree, no commits ahead of base, no PR)."
+
+**If ¬dirty ∧ ahead:** mark commit done; continue (already committed).
+
+## Step 3 — pr
+
+**Skip if:** P ∃ open for Β (unless user forced update — then invoke `/pr` which offers Update).
+
+**Invoke:** `skill: "pr"` with args:
+- `--draft` if DRAFT
+- `--base {BASE}` if BASE set
+
+On success: re-resolve P from `gh pr list --head "$Β"`. ¬P → halt.
+
+**Silent via /ship:** no "Next: /ci-watch" from child — ship owns chaining.
+
+## Step 4 — code-review
+
+**Invoke:** `skill: "code-review"` (PR auto-detected from branch).
+
+Interpret Phase 8 outcome (user decision inside code-review when standalone; when driven by ship, prefer):
+
+| Outcome | Ship action |
+|---------|-------------|
+| Clean / APPROVED / user picks **Merge as-is** | → **do not** let code-review label+merge alone if ship will own gate — if code-review already labeled, continue to ci-watch; else → label-reviewed |
+| User picks **Fix now** / CHANGES_REQUESTED | → fix (if iter < K) |
+| Stop / Abort | halt ship |
+| F = ∅ clean approve | → label-reviewed |
+
+**Important:** `/code-review` Phase 8 may offer Merge as-is (label + auto-merge). Under `/ship`, that path is **allowed** and equivalent to label-reviewed + handoff; then ship still runs **ci-watch** to observe green + merge. If user already labeled inside code-review, skip duplicate label step.
+
+## Step 5 — fix (loop)
+
+**Enter only if:** review requested changes ∧ iter < K.
+
+**Invoke:** `skill: "fix", args: "#{P}"`.
+
+On success:
+1. `iter := iter + 1`
+2. **Strip premature merge gate** (fix Phase 7 may add `reviewed` before re-review):
+   ```bash
+   gh pr edit "$P" --remove-label reviewed 2>/dev/null || true
+   ```
+3. Goto Step 4 (code-review) for re-verify.
+
+**iter ≥ K on entry to fix:** refuse another fix cycle — present **Merge as-is** (→ label-reviewed) | **Stop**.
+
+## Step 6 — label-reviewed (inline)
+
+**Skip if:** `reviewed` already on PR.
+
+1. Rebase check (best-effort, same spirit as code-review Phase 8):
+   ```bash
+   git fetch origin ${β}
+   # if behind: rebase + force-with-lease on feature branch only; conflict → halt
+   ```
+2. Enable auto-merge if supported:
+   ```bash
+   gh pr merge "$P" --auto --merge 2>/dev/null || true
+   ```
+   (¬plain merge while checks in progress)
+3. Add label:
+   ```bash
+   gh api "repos/{owner}/{repo}/issues/${P}/labels" -f "labels[]=reviewed"
+   ```
+4. Confirm: `gh pr view $P --json labels,autoMergeRequest`
+
+## Step 7 — ci-watch
+
+**Invoke:** `skill: "ci-watch", args: "--pr ${P}"`  
+Bash timeout ≥ 20 min when auto-merge expected (see ci-watch skill).
+
+| Exit | Ship action |
+|------|-------------|
+| 0 merged / green+AM | → cleanup |
+| 1 CI failed | present **Retry CI** (`gh run rerun`) \| **fix locally** \| **Abort** |
+| 2 cancelled | report; Retry \| Abort |
+| 4 green unmerged | report blocker (conflicts / AM off / timeout); **rebase** \| **re-label** \| **Abort** — ¬blind Retry-CI |
+
+## Step 8 — cleanup
+
+**Skip if:** `--skip-cleanup` ∨ PR not merged yet (still open) ∨ user declines.
+
+**If PR merged:**
+```
+skill: "cleanup"
+```
+If issue number known from branch (`feat/42-…` → 42) or PR closing issues: prefer `skill: "cleanup", args: "--scope #N"`.
+
+## Continuous-flow rules (same as /dev)
+
+- **¬ask** "Ready to proceed to /X?"
+- **¬summarize** "Just finished X, moving to Y"
+- Child skills return → re-scan Σ_s → invoke next step same turn
+- Exception: verdict/loop gates inside code-review and fix (human decisions stay)
+- Exception: CI failure / merge blocker → present choice
+
+## Task list (optional)
+
+If TaskCreate available, seed `kind: "ship-pipeline"` tasks for active steps only (same pattern as `/dev` 2b, lighter). Metadata: `{ kind: "ship-pipeline", pr: P, step, iteration }`. ¬required for correctness.
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| (none) | Full pipeline on current branch |
+| `#N` / `N` | Bind to PR number N |
+| `--draft` | Create draft PR |
+| `--base <branch>` | PR base override |
+| `--from <step>` | `commit`\|`pr`\|`review`\|`fix`\|`label-reviewed`\|`ci-watch`\|`cleanup` |
+| `--max-fix-iters N` | Default 2 |
+| `--no-commit` | Never create commits |
+| `--skip-cleanup` | Skip post-merge cleanup |
+
+## Safety Rules
+
+1. **NEVER** ship from `main` / `master` / `staging`
+2. **NEVER** `git push --force` — only `--force-with-lease` on feature branch rebase
+3. **NEVER** plain `gh pr merge` while checks IN_PROGRESS/QUEUED
+4. **NEVER** leave `reviewed` on a PR that still needs re-review after `/fix` (strip before re-review)
+5. **ALWAYS** cap fix↔review at K (default 2)
+6. **ALWAYS** stage intentional files only on commit step
+7. **NEVER** rewrite `/pr`, `/code-review`, `/fix`, `/ci-watch`, `/cleanup` logic — delegate
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Dirty tree + secrets patterns | Halt; ask user to unstage |
+| PR exists, local behind origin/Β | `git pull --ff-only` or halt on divergence |
+| `/pr` REFUSE (no commits) | Halt with message |
+| Review clean first try | Skip fix; label + ci-watch |
+| Fix applies label early | Strip before re-review |
+| AM not available on repo | Label still applied; ci-watch reports green; note manual merge path |
+| Multiple open PRs for branch | Impossible normally; if API returns many, pick latest open |
+| `--from review` without PR | REFUSE |
+
+## Chain Position
+
+- **Phase:** Ship (feature → base)
+- **Predecessor:** ad-hoc implementation, or `/implement`, or end of `/dev` Build without Verify
+- **Successor:** `/promote` (staging→main) when base was staging
+- **Class:** meta-orchestrator (like `/dev`, narrower)
+
+## Relation to `/dev`
+
+| | `/dev` | `/ship` |
+|---|--------|---------|
+| Scope | issue lifecycle Frame→Ship | branch already has code |
+| Order | pr → **ci-watch** → validate → **review** → fix | commit → pr → **review** → fix → **reviewed+ci-watch** |
+| validate | yes | no |
+| commit | via implement | explicit first step |
+| Entry | `/dev #N` | `/ship` on feature branch |
+
+Prefer `/ship` for hotfix / already-pushed work / agent sessions that coded first. Prefer `/dev` when artifacts (frame/spec/plan) matter.
+
+## Exit
+
+- **Merged:** print PR URL + base branch; if staging, hint `/promote` when ready. Stop.
+- **CI green, AM pending:** print status; Stop (or keep watching if user asks).
+- **Failure:** error + Retry \| Abort. Stop.
+- **User Stop:** "Stopped at {S*}. Resume: `/ship --from {S*}`."
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary
- Add **`/ship`** meta-orchestrator: commit → `/pr` → `/code-review` → `/fix` loop → `reviewed` + `/ci-watch` → optional `/cleanup` (code-already-ready path; review-before-CI order differs from `/dev` Verify).
- Extend **`/cleanup`** to detect orphan Grok/Claude worktree shells (`scan-orphan-worktree-shells.sh` + Step 5b) after `git worktree remove` (empty parents, unregistered dirs, stale `worktrees.db` rows).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | Land ready code + hygiene | Complete |
| Implementation | commits on `fix/cleanup-orphan-worktree-shells` | Complete |
| Verification | vitest local (839 pass) · pre-push gates | Passed |

## Test Plan
- [ ] `/ship` skill present under `plugins/dev-core/skills/ship/`
- [ ] `gather-state.sh` emits `---orphan-worktree-shells---`
- [ ] Empty `~/.grok/worktrees/<slug>/` reported as `empty_parent`
- [ ] Stale `worktrees.db` rows with missing path reported as `db_stale`
- [ ] Chain contract documents `/ship` vs `/dev` Verify order

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| SC: analyze-branches still green | `cleanup/__tests__/analyze-branches.test.ts` | ✅ local |
| SC: suite green | `bun run test` (839) | ✅ local |

---
Generated via `/ship`