### PR TITLE
feat(dev-core): adversarial agent + dual-harness task list and hooks

### DIFF
--- a/plugins/1b1/README.md
+++ b/plugins/1b1/README.md
@@ -1,6 +1,6 @@
 # 1b1 — One by One
 
-A Claude Code plugin that walks through a list of items one at a time, briefing you on each one and asking what to do before moving to the next.
+An agent-harness plugin that walks through a list of items one at a time, briefing you on each one and asking what to do before moving to the next.
 
 ## What it does
 

--- a/plugins/cv/README.md
+++ b/plugins/cv/README.md
@@ -1,6 +1,6 @@
 # CV
 
-A Claude Code plugin that generates, adapts, and updates professional CVs from structured data. Your CV content lives in a single JSON file, and the plugin handles formatting, tailoring for job postings, and output in Markdown or HTML.
+An agent-harness plugin that generates, adapts, and updates professional CVs from structured data. Your CV content lives in a single JSON file, and the plugin handles formatting, tailoring for job postings, and output in Markdown or HTML.
 
 ## What it does
 

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-core",
-  "version": "0.9.8",
-  "description": "Full development workflow — frame, shape, plan, implement, review, ship. 31 skills (incl. /ship meta), 9 agents, safety hooks.",
+  "version": "0.10.0",
+  "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. adversarial), dual-harness task list, safety hooks (Claude + Grok).",
   "author": {
     "name": "Roxabi"
   }

--- a/plugins/dev-core/README.md
+++ b/plugins/dev-core/README.md
@@ -41,7 +41,7 @@ After installing **dev-core** and **dev-init**, run the full project harness:
 /dev-init
 ```
 
-> **Not** bare `/init` — that is Claude Code's built-in (scaffolds a `CLAUDE.md` only). The Roxabi harness is namespaced: `/dev-init`.
+> **Not** bare `/init` — that is the host built-in (scaffolds a `CLAUDE.md` only). The Roxabi harness is namespaced: `/dev-init`.
 
 Auto-detects your GitHub repo. Writes `.claude/dev-core.yml` (primary config) and `.env` (legacy fallback), registers the project in `~/.roxabi-vault/workspace.json`, generates a self-healing `roxabi` shim, and creates the `artifacts/` directory. Works for any project type. Re-run with `/dev-init --force` to reconfigure.
 
@@ -110,7 +110,7 @@ Main entry points:
 
 ## Agents
 
-9 specialized agents organized in three tiers. Each agent has a built-in **config guard** (fails fast if `stack.yml` is missing), a domain-specific **escalation path** (knows who to message for out-of-scope issues), and a **confidence threshold** (stops and escalates instead of guessing when certainty is below 70–80%).
+Specialized agents organized in three tiers (plus review specialists: `adversarial`, `axial-adr-review`, `recall`). Each agent has a built-in **config guard** (fails fast if `stack.yml` is missing), a domain-specific **escalation path** (knows who to message for out-of-scope issues), and a **confidence threshold** (stops and escalates instead of guessing when certainty is below 70–80%).
 
 Each agent frontmatter includes a `# capabilities:` comment (`write_knowledge`, `write_code`, `review_code`, `run_tests`) for human-readable permission reference, and a `# based-on:` traceability comment. All agents inline a base communication + research-order protocol in their body. `backend-dev`, `frontend-dev`, `fixer`, and `tester` additionally inline quality-gate rules. The shared reference files live in `skills/shared/references/` (`base.md`, `engineer.md`).
 
@@ -129,6 +129,7 @@ Each agent frontmatter includes a `# capabilities:` comment (`write_knowledge`, 
 | `tester` | Writes and runs tests, manages RED-GATE |
 | `fixer` | Applies accepted review findings |
 | `security-auditor` | OWASP Top 10 audit with exploit scenarios, confidence scoring (C ≥ 60), and false-positive filtering |
+| `adversarial` | Red-team for `/spec` + `/code-review`: bypass, fleet-regression, vacuous guards, assumption-kill (read-only) |
 
 ### Strategy
 
@@ -142,13 +143,13 @@ Each agent frontmatter includes a `# capabilities:` comment (`write_knowledge`, 
 
 `stack.yml` handles most project adaptation (paths, commands, standards docs). For behavioral changes — project-specific constraints, tighter escalation rules, extra checklist phases — override any agent or skill at the project level.
 
-Claude Code resolves `.claude/agents/<name>.md` over the plugin cache automatically. Drop a file there and it replaces the plugin agent for that project only. Skills work the same way via `.claude/skills/<name>/SKILL.md`.
+The host resolves project agents (`.claude/agents/<name>.md` or `.grok/agents/`) over the plugin cache automatically. Drop a file there and it replaces the plugin agent for that project only. Skills work the same way under the host skills path.
 
 See [`references/project-overrides.md`](references/project-overrides.md) for full anatomy, examples, and what to keep vs change.
 
 ## Hooks
 
-Three Claude Code hooks for safety and consistency:
+Three plugin hooks for safety and consistency (Claude + Grok compatible):
 
 | Hook | Trigger | What it does |
 |------|---------|--------------|

--- a/plugins/dev-core/agents/adversarial.md
+++ b/plugins/dev-core/agents/adversarial.md
@@ -1,0 +1,173 @@
+---
+name: adversarial
+description: |
+  Red-team / devil's advocate for specs and diffs. Attacks assumptions, control
+  effectiveness, vacuous guards, fleet impact, and partial-failure paths — not a
+  domain specialist and not an OWASP checklist (→ security-auditor).
+
+  Invoked by `/spec` (Step 4 — Expert Review, always) and `/code-review`
+  (Phase 3 — Multi-Domain Review, always). Read-only: findings only, never fixes.
+
+  <example>
+  Context: Spec for a release gate about to ship
+  user: "/spec --issue 374"
+  assistant: "Including adversarial among expert reviewers — will try to bypass the gate and kill vacuous claims."
+  </example>
+
+  <example>
+  Context: PR hardens a CI control
+  user: "/code-review #382"
+  assistant: "Dispatching adversarial — attack control bypass, fleet-regression, and operational failure modes."
+  </example>
+maxTurns: 30
+# capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false
+# based-on: shared/base
+---
+
+# Adversarial
+
+Let:
+  C := confidence (0–100)
+  φ := finding | Φ := finding set
+  L := lens ∈ {bypass, fleet-regression, operational, assumption-kill, vacuous-guard, scope-attack}
+  σ := severity ∈ {fatal, major, minor}
+
+Read-only red-team. Goal: **kill the design/diff** with concrete attack paths or
+disproofs — not restate what security/architect/product already cover.
+
+**Communication:** Report status, blockers, and handoffs in the final summary to the parent orchestrator. ¬block on uncertainty — note the blocker and continue on unblocked work.
+**Research order:** codebase (Glob/Grep/Read) → WebSearch only for external attack patterns; never for internal project questions.
+
+## Role Boundaries (critical)
+
+| This agent | Sibling (do ¬duplicate) |
+|------------|-------------------------|
+| Control circumvention, partial-failure, ordering, fleet impact | `security-auditor` — OWASP / injection / auth / secrets |
+| "Does the guard measure the priced quantity?" | `tester` — coverage / AAA / missing tests |
+| "What assumption makes this false?" | `architect` — patterns / layering / circular deps |
+| Spec: untestable AC, missing adversarial flow, scope that passes on wrong design | `product-lead` — product fit / story quality |
+
+If a φ is pure OWASP → drop (security-auditor owns it). If pure missing-test without
+vacuous-guard angle → drop (tester owns it). Prefer φ that would **survive domain review
+and still ship a broken control**.
+
+## Lenses
+
+Run every applicable lens. A φ without a named lens is invalid (C := 0).
+
+### 1. bypass (fatal-leaning)
+How does a motivated actor (PR author, dispatch caller, ambiguous-ref collision, head-supplied script) make the control green while the bad state remains?
+
+Signals: head content deciding AUTHORITY; `workflow_dispatch` w/o ref constraint; tag/ref shadowing; gate stub rewritable by PR; early-green before the real check; PATH/exec of unpinned tooling.
+
+### 2. fleet-regression
+Does this change deadlock *other* repos / consumers / paths that should stay green?
+
+Signals: new step before every early-green → job-level red everywhere; reading `origin/main` while callers live on `staging`; hard fail on parse error of base config; undeclared runtime dep that only fails in CI.
+
+### 3. operational
+Race, ordering, ambiguous refs, vacuous assertions, type/fixture churn that makes the suite lie.
+
+Signals: `indexOf` matching a comment not the step; `set -euo pipefail` abort on malformed input becoming hard-red; assert on coerced value crying wolf; test fixture that passes for the wrong reason.
+
+### 4. assumption-kill
+List the unstated assumptions. For each: what observation falsifies it? If the assumption is load-bearing and unstated → φ.
+
+### 5. vacuous-guard
+Does the test/assert/check measure the **priced quantity** or a cheap proxy?
+
+Signals: SHA-identity assert when the claim is a commit *set*; string presence in a file that also has the string in prose; negative path never exercised; guard deleted → test still green (point tester at it; own the design-level vacuity).
+
+### 6. scope-attack (spec-primary)
+Spec/diff can ship while the problem remains unsolved.
+
+Signals: AC that pass on the wrong design; no adversarial/failure flow; criteria non-binary in practice; "success" defined as "tool ran" not "invariant held"; out-of-scope that hides the real risk.
+
+## Severity
+
+| σ | Definition | C threshold to report |
+|---|-----------|:---------------------:|
+| **fatal** | Control fully bypassable ∨ fleet deadlock ∨ ships known-open critical hole as "fixed" | ≥ 85 |
+| **major** | Partial bypass ∨ silent green on bad path ∨ vacuous guard on priced quantity | ≥ 75 |
+| **minor** | Defense-in-depth gap, unclear assumption, weak AC — not alone blocking | ≥ 65 |
+
+C < 65 → ¬report. Ambiguous σ → default higher, note uncertainty.
+
+## Exclusions — ¬report
+
+- Pure OWASP / injection / secrets (→ security-auditor)
+- Pure missing unit test without vacuous-guard angle (→ tester)
+- Style, naming, formatting
+- Speculative "what if product changes mind" without concrete path
+- φ only in `.md`/docs unless the doc *is* the control (workflow YAML, gate scripts, SKILL contracts)
+- Duplicate of a lens already fully covered by another φ in this report — merge, don't spam
+
+## Finding Format
+
+∀ φ: ALL fields required. Missing field → C := 0.
+
+```
+<severity>: <title>
+  <file>:<line>   # or spec path:section for /spec
+  -- adversarial
+  Lens: <bypass|fleet-regression|operational|assumption-kill|vacuous-guard|scope-attack>
+  Attack / disproof: <concrete steps — how to break it, or what observation kills the claim>
+  Root cause: <why the design allows this, not just what is wrong>
+  Class: [<canonical-class>, ...] [candidate/<slug>?]   # omit if none apply
+  Raw callsites: [{file: <path>, line: <n>}, ...]       # required when Class is set
+  Solutions:
+    1. <primary fix or redesign> (recommended)
+    2. <alternative / mitigation if primary deferred>
+  Confidence: <0–100>%
+```
+
+`/code-review` usage → wrap in Conventional Comments labels:
+
+```
+issue(blocking): <title>          # fatal, or major that blocks ship
+suggestion(blocking): <title>     # major that needs decision before merge
+thought: <title>                  # minor / assumption surface
+  ...
+  -- adversarial
+```
+
+`/spec` usage → same structure; file:line may be `artifacts/specs/...md:## Section`.
+
+## Workflow
+
+O_attack {
+  1. Scope: identify the **priced claim** (what the change asserts is now true).
+  2. Inventory controls: gates, asserts, AC, early-exits, authz, ordering.
+  3. ∀ control: run lenses 1–5 (and 6 if subject is a spec).
+  4. Prefer findings that domain agents would miss — control effectiveness over code style.
+  5. Filter: drop ∈ exclusions; drop C < 65; merge same root-cause.
+  6. Report: fatal → major → minor. Fatal φ → flag for team lead in summary immediately.
+} → Φ
+
+## Disposition discipline
+
+When the orchestrator or human has already accepted a known-open hole:
+- Still report it once as `thought:` / minor if the PR claims the hole is closed
+- Do ¬re-litigate deferred follow-ups that the change explicitly documents as out of scope
+- Do attack **false closure**: claiming fixed while the bypass remains
+
+## Boundaries
+
+Read-only for source. Bash: `git` read-only (`show`, `diff`, `log`, `rev-parse`), version checks — never write, never push, never mutate. ¬fix code. ¬rewrite specs.
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Subject is pure docs / rename | Light pass; only scope-attack / assumption-kill if claims change |
+| Control intentionally partial + documented | Report only if documentation overclaims ("fully hardened") |
+| Needs runtime proof | "suspected — needs runtime verification", C ≤ 74 |
+| Same bypass multiple files | One φ, multi Raw callsites |
+| Disagrees with security-auditor on OWASP | Yield to security-auditor; keep only non-OWASP residual |
+
+## Escalation
+
+- C < 75% on fatal claim → present attack path + uncertainty, ¬silent drop
+- fatal φ → flag team lead in summary immediately
+- Needs runtime → note suspected, message devops
+- Fleet impact across repos → message devops + architect

--- a/plugins/dev-core/agents/architect.md
+++ b/plugins/dev-core/agents/architect.md
@@ -1,6 +1,5 @@
 ---
 name: architect
-model: opus
 description: |
   Use this agent for system design decisions, cross-cutting architecture,
   and technical planning across the monorepo.
@@ -10,7 +9,6 @@ description: |
   user: "Design the caching strategy for the API"
   assistant: "I'll use the architect agent to design the architecture."
   </example>
-permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=true, write_code=false, review_code=true, run_tests=false
 # based-on: shared/base

--- a/plugins/dev-core/agents/axial-adr-create.md
+++ b/plugins/dev-core/agents/axial-adr-create.md
@@ -1,6 +1,5 @@
 ---
 name: axial-adr-create
-model: sonnet
 description: |
   Interview agent for the foundational "Axis of Decomposition" ADR — captures the primary axis of system variation to prevent N×M drift (cross-cutting concerns duplicated across non-primary axis siblings).
 
@@ -19,7 +18,6 @@ description: |
   user: "Re-elicit the axial decomposition"
   assistant: "Running axial-adr-create. Will offer Keep / Supersede / Review if an ADR already exists."
   </example>
-permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false
 # based-on: shared/base

--- a/plugins/dev-core/agents/axial-adr-review.md
+++ b/plugins/dev-core/agents/axial-adr-review.md
@@ -1,6 +1,5 @@
 ---
 name: axial-adr-review
-model: opus
 description: |
   Read-only review agent for axial-decomposition drift. Parses the project's axial ADR (`axial: true` frontmatter) and reviews a diff or spec for drift along the non-primary axis (N×M trap). Emits Conventional Comments findings tagged with the canonical `target-axis-trap` class.
 
@@ -19,7 +18,6 @@ description: |
   user: "/spec --issue 88"
   assistant: "Including axial-adr-review among spec reviewers to flag drift along non-primary axis."
   </example>
-permissionMode: bypassPermissions
 maxTurns: 20
 # capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false
 # based-on: shared/base

--- a/plugins/dev-core/agents/backend-dev.md
+++ b/plugins/dev-core/agents/backend-dev.md
@@ -9,8 +9,6 @@ description: |
   user: "Create an endpoint to fetch user preferences"
   assistant: "I'll use the backend-dev agent to implement the API."
   </example>
-model: sonnet
-permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true
 # based-on: shared/engineer

--- a/plugins/dev-core/agents/devops.md
+++ b/plugins/dev-core/agents/devops.md
@@ -9,8 +9,6 @@ description: |
   user: "GitHub Actions is failing on the typecheck step"
   assistant: "I'll use the devops agent to debug the CI pipeline."
   </example>
-model: sonnet
-permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=false, run_tests=true
 # based-on: shared/base

--- a/plugins/dev-core/agents/doc-writer.md
+++ b/plugins/dev-core/agents/doc-writer.md
@@ -9,8 +9,6 @@ description: |
   user: "Document the new auth module"
   assistant: "I'll use the doc-writer agent to create the documentation."
   </example>
-model: haiku
-permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false
 # based-on: shared/base

--- a/plugins/dev-core/agents/fixer.md
+++ b/plugins/dev-core/agents/fixer.md
@@ -9,8 +9,6 @@ description: |
   user: "Fix these accepted review comments: [list of findings]"
   assistant: "I'll use the fixer agent to apply the fixes across the stack."
   </example>
-model: sonnet
-permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true
 # based-on: shared/base

--- a/plugins/dev-core/agents/frontend-dev.md
+++ b/plugins/dev-core/agents/frontend-dev.md
@@ -9,8 +9,6 @@ description: |
   user: "Implement the user profile page"
   assistant: "I'll use the frontend-dev agent to implement the UI."
   </example>
-model: sonnet
-permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true
 # based-on: shared/engineer

--- a/plugins/dev-core/agents/product-lead.md
+++ b/plugins/dev-core/agents/product-lead.md
@@ -1,6 +1,5 @@
 ---
 name: product-lead
-model: sonnet
 description: |
   Use this agent for product leadership: requirements gathering, issue triage,
   prioritization, writing analyses and specs, driving the dev pipeline,
@@ -11,7 +10,6 @@ description: |
   user: "Gather requirements for the notification system"
   assistant: "I'll use the product-lead agent to define requirements."
   </example>
-permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=true, write_code=false, review_code=false, run_tests=false
 # based-on: shared/base

--- a/plugins/dev-core/agents/recall.md
+++ b/plugins/dev-core/agents/recall.md
@@ -1,6 +1,5 @@
 ---
 name: recall
-model: haiku
 description: |
   Targeted recall agent for cross-chunk class join in /code-review.
   Receives only callsites + context window, never the full diff.
@@ -11,7 +10,6 @@ description: |
   orchestrator: "Spawn recall agent for parallel-path-drift"
   assistant: "I'll use the recall agent to confirm scope and find un-cited callsites."
   </example>
-permissionMode: bypassPermissions
 maxTurns: 20
 # capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false
 # based-on: shared/base

--- a/plugins/dev-core/agents/security-auditor.md
+++ b/plugins/dev-core/agents/security-auditor.md
@@ -1,6 +1,5 @@
 ---
 name: security-auditor
-model: opus
 description: |
   Audit code for security vulnerabilities, review auth flows,
   and verify compliance with OWASP top 10.
@@ -10,7 +9,6 @@ description: |
   user: "Audit the authentication module for vulnerabilities"
   assistant: "I'll use the security-auditor agent to perform a security audit."
   </example>
-permissionMode: bypassPermissions
 maxTurns: 30
 # capabilities: write_knowledge=false, write_code=false, review_code=true, run_tests=false
 # based-on: shared/base

--- a/plugins/dev-core/agents/tester.md
+++ b/plugins/dev-core/agents/tester.md
@@ -9,8 +9,6 @@ description: |
   user: "Write tests for the auth service"
   assistant: "I'll use the tester agent to generate test coverage."
   </example>
-model: sonnet
-permissionMode: bypassPermissions
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=false, run_tests=true
 # based-on: shared/base

--- a/plugins/dev-core/hooks/README.md
+++ b/plugins/dev-core/hooks/README.md
@@ -1,18 +1,20 @@
 # dev-core Hooks
 
-Claude Code hooks that run automatically on file writes and shell commands.
+Plugin hooks that run automatically on file writes and shell commands (Claude Code + Grok; dual-read stdin/env).
 
 ## What These Hooks Do
 
 | Hook | Trigger | Action |
 |------|---------|--------|
-| `format.js` (PostToolUse) | After Edit or Write | Auto-formats files using `build.formatter_fix_cmd` from `stack.yml` |
-| `security-check.js` (PreToolUse) | Before Edit or Write | Blocks hardcoded secrets, SQL/command injection patterns |
-| `bun test` blocker (PreToolUse) | Before Bash | Blocks `bun test` (wrong runner), enforces `bun run test` |
+| `format.cjs` (PostToolUse) | After Edit / Write / `search_replace` / `write` | Auto-formats files using `build.formatter_fix_cmd` from `stack.yml` |
+| `security-check.cjs` (PreToolUse) | Before Edit / Write / `search_replace` / `write` | Blocks hardcoded secrets, SQL/command injection patterns |
+| `bun-test-guard.cjs` (PreToolUse) | Before Bash / `run_terminal_command` | Blocks `bun test` (wrong runner), enforces `bun run test` |
 
-## How `format.js` Works
+**Dual harness input** (`lib/hook-input.cjs`): Claude env (`CLAUDE_TOOL_INPUT`, `CLAUDE_FILE_PATHS`) **or** Grok stdin JSON envelope (`toolInput`). Plugin root: `${CLAUDE_PLUGIN_ROOT:-$GROK_PLUGIN_ROOT}`.
 
-`format.js` reads `build.formatter_fix_cmd` from `.claude/stack.yml` at runtime:
+## How `format.cjs` Works
+
+`format.cjs` reads `build.formatter_fix_cmd` from `.claude/stack.yml` at runtime:
 
 - **Empty / key absent** → exits silently, no formatting applied
 - **Set** → runs the command with the modified file paths appended as arguments
@@ -21,7 +23,7 @@ Claude Code hooks that run automatically on file writes and shell commands.
 stack.yml: formatter_fix_cmd: "bunx biome check --write"
 
 Edit foo.ts, bar.ts
-  → format.js
+  → format.cjs
   → execFileSync('bunx', ['biome', 'check', '--write', 'foo.ts', 'bar.ts'])
 ```
 
@@ -94,4 +96,4 @@ Run `/checkup` to verify that your active hooks match your `stack.yml` formatter
 
 ## Security Note
 
-`format.js` reads `CLAUDE_FILE_PATHS`, splits it safely, and passes paths as discrete `execFileSync` arguments. The formatter command from `stack.yml` is split on whitespace into argv — no shell expansion, no injection surface.
+`format.cjs` resolves paths via dual-read (`CLAUDE_FILE_PATHS` or stdin `toolInput.file_path`), splits safely, and passes them as discrete `execFileSync` arguments. The formatter command from `stack.yml` is split on whitespace into argv — no shell expansion, no injection surface.

--- a/plugins/dev-core/hooks/bun-test-guard.cjs
+++ b/plugins/dev-core/hooks/bun-test-guard.cjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+/**
+ * Block bare `bun test` (Bun runner) — require `bun run test` (Vitest).
+ * Dual harness: stdin toolInput.command (Grok) ∪ CLAUDE_TOOL_INPUT (Claude).
+ */
+
+const { loadHookInput, extractShellCommand } = require('./lib/hook-input.cjs')
+
+function main() {
+  const { toolInput } = loadHookInput()
+  const cmd = extractShellCommand(toolInput)
+  if (!cmd) process.exit(0)
+
+  const hasBunTest = /(^|\s|&&|;|\|)bun test(\s|$)/.test(cmd)
+  const hasBunRunTest = /bun run test/.test(cmd)
+
+  if (hasBunTest && !hasBunRunTest) {
+    const reason = 'Use bun run test (Vitest), not bun test (Bun runner)'
+    // Grok: decision deny; exit 2 also blocks on both hosts
+    process.stdout.write(
+      JSON.stringify({ decision: 'deny', reason, message: reason }) + '\n',
+    )
+    process.stderr.write(reason + '\n')
+    process.exit(2)
+  }
+
+  process.exit(0)
+}
+
+main()

--- a/plugins/dev-core/hooks/format.cjs
+++ b/plugins/dev-core/hooks/format.cjs
@@ -4,6 +4,7 @@ const { execFileSync } = require('node:child_process')
 const fs = require('node:fs')
 const path = require('node:path')
 const { parseStackYml } = require('./lib/parse-stack-yml.cjs')
+const { loadHookInput } = require('./lib/hook-input.cjs')
 
 // All extensions common formatters can handle.
 // The formatter itself decides which it actually processes — this list just
@@ -58,11 +59,11 @@ function main() {
     process.exit(0)
   }
 
-  const rawPaths = process.env.CLAUDE_FILE_PATHS
-  if (!rawPaths) process.exit(0)
+  // Dual harness: CLAUDE_FILE_PATHS (Claude) ∪ stdin toolInput.file_path (Grok)
+  const { filePaths } = loadHookInput()
+  if (filePaths.length === 0) process.exit(0)
 
-  const allFiles = rawPaths
-    .split('\n')
+  const allFiles = filePaths
     .map((p) => p.trim())
     .filter((p) => p.length > 0)
     .filter((p) => FORMATTABLE_EXTENSIONS.has(path.extname(p)))

--- a/plugins/dev-core/hooks/hooks.json
+++ b/plugins/dev-core/hooks/hooks.json
@@ -2,31 +2,31 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|write|MultiEdit|search_replace",
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/security-check.js"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT:-$GROK_PLUGIN_ROOT}/hooks/security-check.cjs\""
           }
         ]
       },
       {
-        "matcher": "Bash",
+        "matcher": "Bash|run_terminal_command",
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '(^|\\s|&&|;|\\|)bun test(\\s|$)' && ! echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'bun run test'; then echo 'Use bun run test (Vitest), not bun test (Bun runner)' >&2; exit 2; fi"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT:-$GROK_PLUGIN_ROOT}/hooks/bun-test-guard.cjs\""
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|write|MultiEdit|search_replace",
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/format.js"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT:-$GROK_PLUGIN_ROOT}/hooks/format.cjs\""
           }
         ]
       }

--- a/plugins/dev-core/hooks/lib/hook-input.cjs
+++ b/plugins/dev-core/hooks/lib/hook-input.cjs
@@ -1,0 +1,121 @@
+'use strict'
+
+/**
+ * Dual-harness hook input (Claude Code + Grok).
+ *
+ * Claude often injects CLAUDE_TOOL_INPUT / CLAUDE_FILE_PATHS env vars.
+ * Grok posts a JSON envelope on stdin (toolName, toolInput, …) and sets
+ * GROK_* / CLAUDE_PLUGIN_ROOT aliases for plugin hooks.
+ *
+ * Prefer: env (Claude) ∪ stdin envelope (Grok) ∪ both when present.
+ */
+
+const fs = require('node:fs')
+
+/**
+ * Prefer env (Claude) so we never block on an open empty stdin.
+ * Only read stdin when Claude env is absent (Grok envelope path).
+ * @returns {object|null}
+ */
+function readStdinJsonSync() {
+  try {
+    if (process.stdin.isTTY) return null
+    const raw = fs.readFileSync(0, 'utf8')
+    if (!raw || !raw.trim()) return null
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * @returns {{ toolName: string|null, toolInput: object, filePaths: string[], envelope: object|null }}
+ */
+function loadHookInput() {
+  let toolInput = {}
+  let toolName = null
+  let envelope = null
+
+  // Claude path: env present → do not touch stdin (avoids hang if pipe left open)
+  const hasClaudeEnv = !!(
+    process.env.CLAUDE_TOOL_INPUT ||
+    process.env.CLAUDE_FILE_PATHS
+  )
+
+  if (process.env.CLAUDE_TOOL_INPUT) {
+    try {
+      const fromEnv = JSON.parse(process.env.CLAUDE_TOOL_INPUT)
+      if (fromEnv && typeof fromEnv === 'object') toolInput = fromEnv
+    } catch {
+      // ignore malformed env
+    }
+  }
+
+  if (!hasClaudeEnv) {
+    envelope = readStdinJsonSync()
+    if (envelope && typeof envelope === 'object') {
+      toolName = envelope.toolName || envelope.tool_name || null
+      const ti = envelope.toolInput || envelope.tool_input
+      if (ti && typeof ti === 'object') toolInput = ti
+    }
+  }
+
+  const filePaths = []
+
+  if (process.env.CLAUDE_FILE_PATHS) {
+    for (const p of process.env.CLAUDE_FILE_PATHS.split('\n')) {
+      const t = p.trim()
+      if (t) filePaths.push(t)
+    }
+  }
+
+  // Single path fields (Claude Edit/Write + Grok search_replace/write)
+  for (const key of ['file_path', 'filePath', 'path']) {
+    const v = toolInput[key]
+    if (typeof v === 'string' && v.trim()) filePaths.push(v.trim())
+  }
+
+  const seen = new Set()
+  const uniq = []
+  for (const p of filePaths) {
+    if (!seen.has(p)) {
+      seen.add(p)
+      uniq.push(p)
+    }
+  }
+
+  return { toolName, toolInput, filePaths: uniq, envelope }
+}
+
+/**
+ * Content being written (security scan target).
+ * @param {object} toolInput
+ * @returns {string}
+ */
+function extractWriteContent(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return ''
+  return (
+    toolInput.content ||
+    toolInput.new_string ||
+    toolInput.newString ||
+    toolInput.new_str ||
+    ''
+  )
+}
+
+/**
+ * Shell command string when tool is Bash / run_terminal_command.
+ * @param {object} toolInput
+ * @returns {string}
+ */
+function extractShellCommand(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return ''
+  return toolInput.command || toolInput.cmd || ''
+}
+
+module.exports = {
+  loadHookInput,
+  extractWriteContent,
+  extractShellCommand,
+  readStdinJsonSync,
+}

--- a/plugins/dev-core/hooks/lib/parse-stack-yml.cjs
+++ b/plugins/dev-core/hooks/lib/parse-stack-yml.cjs
@@ -4,7 +4,7 @@
  * Shared CommonJS parser for .claude/stack.yml.
  *
  * Consumed by:
- *   - plugins/dev-core/hooks/format.js  (CJS require)
+ *   - plugins/dev-core/hooks/format.cjs  (CJS require)
  *   - plugins/dev-core/skills/checkup/doctor.ts  (Bun TS import)
  *
  * Dependency-free: pure regex/string ops — no external YAML library.

--- a/plugins/dev-core/hooks/security-check.cjs
+++ b/plugins/dev-core/hooks/security-check.cjs
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs')
 const path = require('node:path')
+const { loadHookInput, extractWriteContent } = require('./lib/hook-input.cjs')
 
 const SECURITY_PATTERNS = [
   {
@@ -82,23 +83,36 @@ function checkContent(content, filePath, state) {
   return blocked
 }
 
+/**
+ * Dual deny payload:
+ * - Grok PreToolUse: decision "deny" + reason
+ * - Claude Code: decision "block" + message (legacy) + exit 2
+ */
+function emitDeny(reason) {
+  const payload = {
+    decision: 'deny',
+    reason,
+    // Claude-compatible aliases
+    message: reason,
+  }
+  // Some Claude builds still key off decision:block
+  process.stdout.write(JSON.stringify({ ...payload, decision: 'deny' }) + '\n')
+  process.stderr.write(reason + '\n')
+  process.exit(2)
+}
+
 function main() {
   pruneOldStateFiles()
 
-  const input = process.env.CLAUDE_TOOL_INPUT
-  if (!input) {
+  const { toolInput, filePaths } = loadHookInput()
+  const content = extractWriteContent(toolInput)
+  if (!content) {
     process.exit(0)
   }
 
+  const filePath = filePaths[0] || toolInput.file_path || toolInput.filePath || 'unknown'
+
   try {
-    const toolInput = JSON.parse(input)
-    const content = toolInput.content || toolInput.new_string || ''
-    const filePath = toolInput.file_path || 'unknown'
-
-    if (!content) {
-      process.exit(0)
-    }
-
     const state = loadState()
     const warningsBefore = Object.keys(state.warnings).length
     const blocked = checkContent(content, filePath, state)
@@ -109,12 +123,7 @@ function main() {
     }
 
     if (blocked.length > 0) {
-      console.log(
-        JSON.stringify({
-          decision: 'block',
-          message: `Security check:\n${blocked.map((w) => `- ${w}`).join('\n')}`,
-        }),
-      )
+      emitDeny(`Security check:\n${blocked.map((w) => `- ${w}`).join('\n')}`)
     }
   } catch (e) {
     process.stderr.write(`security-check: ${e?.message ? e.message : String(e)}\n`)

--- a/plugins/dev-core/references/project-overrides.md
+++ b/plugins/dev-core/references/project-overrides.md
@@ -15,7 +15,7 @@ Use Ω when changing **α behavior itself**, ¬config values:
 
 ## How it works
 
-Claude Code resolves α definitions:
+Host resolves α definitions (Claude / Grok paths):
 
 ```
 .claude/agents/<name>.md          ← project-level (highest priority)
@@ -33,9 +33,9 @@ Start from plugin α as base. Keep what works, add project-specific:
 ---
 name: backend-dev
 # based-on: dev-core/backend-dev     # traceability — shows which plugin version this overrides
-model: sonnet
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "Task", "TaskCreate", "TaskGet", "TaskUpdate", "TaskList"]
-permissionMode: bypassPermissions   # ⚠ removes all confirmation dialogs — review before use
+# model: omitted — harness inherits parent / host default (¬name provider-specific models)
+# permissionMode: omitted — host-controlled; plugin agents cannot force bypass on Grok
+tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "WebFetch", "WebSearch", "Task"]
 maxTurns: 50
 # capabilities: write_knowledge=false, write_code=true, review_code=true, run_tests=true
 ---

--- a/plugins/dev-core/references/team-coordination.md
+++ b/plugins/dev-core/references/team-coordination.md
@@ -13,14 +13,14 @@ Main Claude = orchestrator. Assesses issues, spawns α, runs skills, coordinates
 | Tier | α | Role |
 |------|---|------|
 | **Domain** | frontend-dev, backend-dev, devops | Write code in their packages |
-| **Quality** | fixer, tester, security-auditor | Fix findings, write tests, audit |
+| **Quality** | fixer, tester, security-auditor, adversarial | Fix findings, write tests, OWASP audit, red-team review |
 | **Strategy** | architect, product-lead, doc-writer | Plan, analyze, document |
 
 ## 4-Phase Workflow
 
 1. **Assessment:** Fetch issue → check analysis/spec → spawn product-lead (+architect) → human approves
 2. **Implementation:** Domain α + tester. RED → GREEN → REFACTOR → tests pass → PR
-3. **Review:** Fresh α (security, architect, product, tester + domain). Conventional Comments → `/1b1`
+3. **Review:** Fresh α (security, adversarial, architect, product, tester + domain). Conventional Comments → `/1b1`
 4. **Fix & Merge:** Fixer(s) apply accepted comments → CI → human merges. ≥6 findings spanning distinct modules → multiple fixers.
 
 ## Task Lifecycle
@@ -63,6 +63,7 @@ Omit empty fields. Lead forwards relevant sections to next α spawn prompt.
 | fixer | All packages (accepted findings only) | New features |
 | tester | Test files in all packages | Source files |
 | security-auditor | Read-only + Bash | Source files |
+| adversarial | Read-only + Bash (git read-only) | Source files |
 | architect | `docs/architecture/`, ADRs | App code |
 | product-lead | `artifacts/analyses/`, `artifacts/specs/`, `gh` CLI | App code |
 | doc-writer | `docs/`, `CLAUDE.md` | App code |
@@ -110,9 +111,9 @@ When `/plan` generates μ, α receive structured work units via TaskCreate.
 
 ## Agent Configuration
 
-α behavior via YAML frontmatter in `.claude/agents/*.md`:
-- `permissionMode` (bypassPermissions | plan)
+α behavior via YAML frontmatter in host agent paths (`.claude/agents/*.md` / `.grok/agents/`):
 - `maxTurns` (30–50)
-- `memory: project` (.claude/agent-memory/)
+- `memory: project` (host agent-memory dir)
+- ¬`permissionMode` in plugin agents (Grok ignores bypass; host session controls permissions)
 
 Tool access uses harness defaults unless a project override sets `tools` or `disallowedTools` explicitly.

--- a/plugins/dev-core/skills/checkup/cookbooks/stack-checks.md
+++ b/plugins/dev-core/skills/checkup/cookbooks/stack-checks.md
@@ -40,7 +40,7 @@ Read `docs.path` from σ. ¬set → D⏭("docs.path not set"), skip doc checks.
 
 **Artifacts:** ∀ path ∈ `artifacts.*` → chk(∃, ✅, ⚠️ "dir not found: {path}").
 
-**Hooks formatter:** `build.formatter_fix_cmd` contains `biome` → confirm `hooks.json` PostToolUse runs `format.js` → ✅ | ⚠️ "formatter mismatch".
+**Hooks formatter:** `build.formatter_fix_cmd` contains `biome` → confirm `hooks.json` PostToolUse runs `format.cjs` → ✅ | ⚠️ "formatter mismatch".
 
 **Pre-commit hooks:**
 Read `hooks.tool` from σ. Resolve: `none` → ⏭ | `auto`/absent → python→`pre-commit`, else→`lefthook` | explicit → use.

--- a/plugins/dev-core/skills/code-review/README.md
+++ b/plugins/dev-core/skills/code-review/README.md
@@ -4,7 +4,7 @@ Multi-domain code review via fresh domain agents → Conventional Comments findi
 
 ## Why
 
-A single reviewer (even a good one) misses domain-specific issues. `/code-review` spawns fresh, unbiased agents per domain (security, architecture, tests, frontend, backend, devops, product) simultaneously, merges their findings using Conventional Comments labels, deduplicates overlaps, and produces a structured verdict: Approve, Approve with comments, or Request changes.
+A single reviewer (even a good one) misses domain-specific issues. `/code-review` spawns fresh, unbiased agents per domain (security, adversarial red-team, architecture, tests, frontend, backend, devops, product) simultaneously, merges their findings using Conventional Comments labels, deduplicates overlaps, and produces a structured verdict: Approve, Approve with comments, or Request changes.
 
 ## Usage
 
@@ -25,6 +25,7 @@ Triggers: `"code review"` | `"review changes"` | `"review PR #42"` | `"check my 
    | Agent | Condition | Focus |
    |-------|-----------|-------|
    | security-auditor | always | OWASP, injection, secrets, auth |
+   | adversarial | always | red-team: bypass, fleet-regression, vacuous guards |
    | architect | |Δ| > 5 or arch changes | patterns, circular deps |
    | product-lead | spec exists | spec compliance, product fit |
    | tester | test files changed | coverage, AAA, edge cases |

--- a/plugins/dev-core/skills/code-review/SKILL.md
+++ b/plugins/dev-core/skills/code-review/SKILL.md
@@ -110,6 +110,7 @@ digests = emit_all_digests(chunks)            # list[BoundaryDigest]
 | Agent | Condition | Focus |
 |-------|-----------|-------|
 | **security-auditor** | always | OWASP, secrets, injection, auth |
+| **adversarial** | always | red-team: bypass, fleet-regression, vacuous guards, assumption-kill (¬OWASP — security-auditor owns that) |
 | **architect** | \|Δ\| > 5 ∨ src ⊇ {arch, pattern, structure, service, module} | patterns, structure, circular deps |
 | **product-lead** | spec ∃ | spec compliance, product fit |
 | **tester** | Δ ∩ {`src/`, `test/`, `*.test.*`, `*.spec.*`} ≠ ∅ | coverage, AAA, edge cases |
@@ -158,7 +159,7 @@ Task(
 )
 ```
 
-Agent name map: `security-auditor` → `dev-core:security-auditor` | `architect` → `dev-core:architect` | `product-lead` → `dev-core:product-lead` | `tester` → `dev-core:tester` | `frontend-dev` → `dev-core:frontend-dev` | `backend-dev` → `dev-core:backend-dev` | `devops` → `dev-core:devops` | `recall` → `dev-core:recall` | `axial-adr-review` → `dev-core:axial-adr-review`
+Agent name map: `security-auditor` → `dev-core:security-auditor` | `adversarial` → `dev-core:adversarial` | `architect` → `dev-core:architect` | `product-lead` → `dev-core:product-lead` | `tester` → `dev-core:tester` | `frontend-dev` → `dev-core:frontend-dev` | `backend-dev` → `dev-core:backend-dev` | `devops` → `dev-core:devops` | `recall` → `dev-core:recall` | `axial-adr-review` → `dev-core:axial-adr-review`
 
 ### Agent payload
 

--- a/plugins/dev-core/skills/code-review/review-classes.yml
+++ b/plugins/dev-core/skills/code-review/review-classes.yml
@@ -187,10 +187,11 @@ classes:
 #   derivation: `grep -h '^name:' plugins/dev-core/agents/*.md | awk '{print $2}'`
 #   SSoT: agents/*.md (no other location is authoritative)
 #
-# Authoritative listing as of 30c092b (derived from agents/; do NOT update by hand
+# Authoritative listing (derived from agents/; do NOT update by hand
 # — re-run the derivation above):
-#   architect | backend-dev | devops | doc-writer | fixer
-#   frontend-dev | product-lead | security-auditor | tester
+#   adversarial | architect | axial-adr-create | axial-adr-review | backend-dev
+#   devops | doc-writer | fixer | frontend-dev | product-lead | recall
+#   security-auditor | tester
 #
 # Filter implementation (Slice 5 cron): MUST scan plugins/dev-core/agents/*.md at
 # runtime and extract name: fields — the inline listing above is documentation-only.

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -108,7 +108,7 @@ bash ${CLAUDE_SKILL_DIR}/scan-state.sh {N} {slug}
 
 ## Step 2b — Seed Pipeline Tasks
 
-Claude Code task list drives in-session progress for the dev pipeline. Treat it as authoritative for within-session state — artifacts remain authoritative across sessions.
+Host task list (Claude `Task*` or Grok `todo_write` — see `skills/shared/references/harness-task-list.md`) drives in-session progress for the dev pipeline. Treat it as authoritative for within-session state — artifacts remain authoritative across sessions.
 
 **2b.1 Check existing:** `TaskList` → filter where `metadata.issue == N` ∧ `metadata.kind == 'dev-pipeline'`. ∃ matches → skip seeding (tasks already exist from a prior `/dev` invocation in this session). Cache {step → task.id} map from the matches. Goto 2b.4.
 

--- a/plugins/dev-core/skills/implement/README.md
+++ b/plugins/dev-core/skills/implement/README.md
@@ -18,7 +18,7 @@ Triggers: `"implement"` | `"build this"` | `"execute plan"` | `"start coding"` |
 
 ## How it works
 
-1. **Locate plan** — reads the plan artifact and attaches to existing Claude Code tasks (or re-seeds if session restarted).
+1. **Locate plan** — reads the plan artifact; probes host task tools (Claude `Task*` / Grok `todo_write` / artifact-only) and attaches or re-seeds accordingly.
 2. **Setup** — creates a worktree at `.claude/worktrees/{N}-{slug}`, checks out a feature branch from base (staging or main), runs `install`.
 3. **Context injection** (F-tier) — injects relevant standards docs into each agent's prompt.
 4. **Implement**:

--- a/plugins/dev-core/skills/implement/SKILL.md
+++ b/plugins/dev-core/skills/implement/SKILL.md
@@ -2,7 +2,7 @@
 name: implement
 argument-hint: '[--issue <N> | --plan <path> | --audit]'
 description: Execute plan — setup worktree, spawn agents, write code + tests. Triggers: "implement" | "build this" | "execute plan" | "start coding" | "write the code" | "code this up" | "let's build it" | "build it out" | "ship it".
-version: 0.3.0
+version: 0.3.1
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---
 
@@ -42,9 +42,10 @@ Does NOT create a PR — that is `/pr` (next step).
 
 ## Task Integration
 
-- `/dev` owns the dev-pipeline task lifecycle externally (TaskUpdate in_progress before invoke, completed after return)
+- `/dev` owns the dev-pipeline task lifecycle externally (mark in_progress before invoke, completed after return — host-mapped)
 - This skill does NOT update its own dev-pipeline task
-- Sub-tasks managed: reads plan-tasks created by `/plan` (Step 6a), flips their lifecycle as agents execute them (Step 1b + Step 4)
+- Sub-tasks: attach/re-seed plan-tasks from `/plan` (Step 6a), flip lifecycle as agents execute (Step 1b + Step 4)
+- **Host mapping SSoT:** [harness-task-list.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-task-list.md) — probe once, use H for all task ops
 
 ## Exit
 
@@ -80,15 +81,48 @@ Steps: locate-plan → setup → context-inject → implement → quality-gate �
 
 Extract from frontmatter: `issue`, `tier`, `spec` path. From body: agent list, task list, slice structure.
 
-### Step 1b — Attach to Plan Tasks
+### Step 1b — Attach to Plan Tasks (dual harness)
 
-Parse π's `## Task IDs` section → {T1: id, T2: id, ...} map. ¬section → `/plan` pre-dates task-tool integration → fall through to 1b.3 (re-seed).
+**Probe H** (once per `/implement` run) per [harness-task-list.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-task-list.md):
 
-**1b.1 Verify ids:** ∀ id → `TaskGet(id)`. All succeed → cache map, goto Step 2.
-**1b.2 Partial miss:** ¬some id (session restart invalidated state) → re-seed only the missing ones using the canonical schema from [plan-task-schema.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/plan-task-schema.md) on the corresponding micro-tasks, then rewrite `## Task IDs` section in π with refreshed ids.
-**1b.3 Total miss (legacy plan):** section absent → re-seed all micro-tasks using [plan-task-schema.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/plan-task-schema.md), append `## Task IDs` section to π, commit the update (`git add` π + commit `chore(plan): attach task ids`).
+```
+tools ∋ TaskCreate ∧ TaskUpdate ∧ TaskList  → H := claude-tasks
+else tools ∋ todo_write                     → H := grok-todos
+else                                        → H := artifact-only
+```
 
-τ=S without π → `TaskCreate` 3–6 coarse tasks directly from spec acceptance criteria: `{ kind: "plan-task", issue: N, tier: "S" }`. No artifact update.
+Fields / seed shape: [plan-task-schema.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/plan-task-schema.md).  
+Blueprint source: π `## Task Seeding Blueprint` (or micro-task table). Cache map M := `{T# → host_id}` (claude) or `{T# → T#}` (grok stable ids).
+
+#### H = claude-tasks
+
+Parse π's `## Task IDs` section → M. ¬section → fall through to 1b.3.
+
+| Step | Action |
+|------|--------|
+| **1b.1 Verify** | ∀ id ∈ M → `TaskGet(id)`. All succeed → cache M, goto Step 2 |
+| **1b.2 Partial miss** | Session restart wiped some ids → re-seed **missing** rows only via `TaskCreate` (schema), rewrite `## Task IDs` in π |
+| **1b.3 Total miss** | Section absent / all dead → re-seed **all** micro-tasks via `TaskCreate` + `blockedBy` wiring, append `## Task IDs`, commit `chore(plan): attach task ids` |
+
+τ=S without π → `TaskCreate` 3–6 coarse tasks from spec AC: `{ kind: "plan-task", issue: N, tier: "S" }`. No artifact update.
+
+#### H = grok-todos
+
+Host has no durable id graph and no `TaskGet`. Stable ids = blueprint `T{n}`.
+
+| Step | Action |
+|------|--------|
+| **1b.1 Verify** | If session already has todos with ids `T1…Tn` matching blueprint → reuse (merge=true only for status updates). Goto Step 2 |
+| **1b.2 Partial miss** | Some `T#` missing from current todos → `todo_write` merge=true with those ids only (`status: pending`, content from schema portable encoding) |
+| **1b.3 Total miss** | No matching todos → seed **all** from blueprint: `todo_write` merge=false, id=`T{n}`, content=`[{phase}] {agent_instance} — {subject} \| Verify: {cmd} \| {spec_trace}`. **¬** write `## Task IDs` host-sha section (nothing durable). Optional: note `host: grok-todos` in π frontmatter if useful |
+
+Deps: **¬** invent `blockedBy` on host. Ready-set = rows whose blueprint `blockedBy` are all `completed` (track status in todo list).
+
+τ=S without π → `todo_write` 3–6 coarse todos from AC (`id: S1…`, content = criterion text).
+
+#### H = artifact-only
+
+No host task list. Skip attach/re-seed. Work from π micro-task table only; progress in the reply / Step 6 summary.
 
 ## Step 2 — Setup
 
@@ -151,47 +185,55 @@ Ref file paths from `/plan` Step 3.
 
 ## Step 4 — Implement
 
-**Task lifecycle (all tiers):**
-- Before starting a micro-task → `TaskUpdate(id, status: "in_progress", owner: "{agent-name or 'lead'}")`.
-- Success (verify ✓) → `TaskUpdate(id, status: "completed")`.
-- Retry (≤3) → leave `in_progress`, add comment via `TaskUpdate(id, metadata: { last_error: "..." })`.
-- 3× fail → leave `in_progress`, escalation decision (see Step 5).
+Use **H from Step 1b** for every lifecycle op (mapping below). Generic ops: claim → inject context → spawn → mark done.
+
+### Task lifecycle (all tiers) — by H
+
+| Generic | H = claude-tasks | H = grok-todos | H = artifact-only |
+|---------|------------------|----------------|-------------------|
+| Claim / start | `TaskUpdate(id, status: in_progress, owner: …)` | `todo_write` merge=true, id=`T#`, status=`in_progress` | Note start in reply |
+| Load context | `TaskGet(id)` → description + metadata | Blueprint row + todo `content` for `T#` | π micro-task row only |
+| Mark done | `TaskUpdate(id, status: completed)` | `todo_write` merge=true, id=`T#`, status=`completed` | Check off in summary |
+| Retry note | `TaskUpdate` metadata `last_error` | Append error to todo `content` or leave `in_progress` | Note in reply |
+| 3× fail | leave in_progress → escalate (Step 5) | same | same |
+| List ready | `TaskList` → empty `blockedBy` + phase | Blueprint: deps all `completed` + matching phase | Same from π table |
+| List all done? | `TaskList` + metadata.issue == N | All seeded `T#` status=`completed` | All π rows done |
 
 ### Tier S — Direct
 
-Read spec + ref patterns → create + implement → tests → QG → loop until ✓. Single session, ¬agent spawning. Flip each task `in_progress` → `completed` as you progress through the list.
+Read spec + ref patterns → create + implement → tests → QG → loop until ✓. Single session, ¬agent spawning. Flip each task start → completed via H mapping as you progress.
 
 ### Tier F — Agent-Driven (test-first)
 
-Spawn via `Task` tool (subagent/domain). Sequential ∨ parallel (2–3 max).
+Spawn via host subagent tool (`Task` / `spawn_subagent`). Sequential ∨ parallel (2–3 max).
 
-**Worktree isolation:** Main context is already inside ω (Step 2). Subagents spawned via `Task` inherit this CWD. All file operations must stay within `.claude/worktrees/{N}-{slug}`. Do not `cd` to repo root or other paths outside ω.
+**Worktree isolation:** Main context is already inside ω (Step 2). Subagents inherit this CWD. All file ops stay within `.claude/worktrees/{N}-{slug}`. Do not `cd` to repo root or other paths outside ω.
 
 **Per agent spawn:**
-1. `TaskUpdate(task_id, status: "in_progress", owner: "{agent}")`.
-2. `TaskGet(task_id)` → inject `description` + `metadata` verbatim into the subagent's prompt. The agent reads its own task context from the task list.
+1. Claim task (H table).
+2. Load context (H table) → inject into subagent prompt.
 3. Spawn:
    ```
-   Task(
+   Task(   # or spawn_subagent on Grok
      subagent_type: "dev-core:{agent}",
      description: "{agent}: {phase} — #{N} {slug}",
-     prompt: "Issue #{N}. Task: {TaskGet.description}. Target: {file_path}. Skeleton: {code_snippet}. Verify: {verify_command}. Ref pattern: {pattern_file}. Worktree: `.claude/worktrees/{N}-{slug}` — you are already inside it; do not leave this directory. ¬TaskCreate — task lifecycle managed by lead."
+     prompt: "Issue #{N}. Task: {task_description}. Target: {file_path}. Skeleton: {code_snippet}. Verify: {verify_command}. Ref pattern: {pattern_file}. Worktree: `.claude/worktrees/{N}-{slug}` — you are already inside it; do not leave this directory. ¬seed host tasks — task lifecycle managed by lead."
    )
    ```
    Agent name map: `tester` → `dev-core:tester` | `frontend-dev` → `dev-core:frontend-dev` | `backend-dev` → `dev-core:backend-dev` | `devops` → `dev-core:devops` | `doc-writer` → `dev-core:doc-writer` | `architect` → `dev-core:architect` | `security-auditor` → `dev-core:security-auditor`
-4. Subagent returns → verify → ✓ → `TaskUpdate(task_id, status: "completed")`. ✗ → retry (≤3).
+4. Subagent returns → verify → ✓ → mark done (H). ✗ → retry (≤3).
 
 **RED → GREEN → REFACTOR:**
-1. **RED** — tester: write failing tests from spec. Structural verify only (grep test structure). Tests expected to fail pre-impl. Create RED-GATE sentinel per slice. RED tasks flip `completed` as each test file lands.
-2. **GREEN** — domain agents ∥: implement to pass. `ready` verify → run now; `deferred` → wait RED-GATE. Blocked-by wiring from Step 6a/6b of `/plan` means task list already reflects these dependencies — advance in `blockedBy`-clear order.
+1. **RED** — tester: write failing tests from spec. Structural verify only (grep test structure). Tests expected to fail pre-impl. Create RED-GATE sentinel per slice. RED tasks flip completed as each test file lands.
+2. **GREEN** — domain agents ∥: implement to pass. `ready` verify → run now; `deferred` → wait RED-GATE. Advance only when blueprint deps are satisfied (claude: `blockedBy` clear; grok/artifact: deps completed in checklist).
 3. **REFACTOR** — domain agents: refactor, keep tests ✓.
 4. **Verify** — tester: coverage + edge cases.
 
-**Parallel spawn:** `TaskList` → pick N tasks with empty `blockedBy` and matching phase → spawn N agents simultaneously, each with its own `TaskGet`-injected prompt.
+**Parallel spawn:** list ready tasks (H table) for current phase → spawn ≤N agents, each with its own context-injected prompt.
 
 **Per-task:** verify → ✓ | ✗ fix (max 3) | 3✗ → escalate to lead. Track first-try pass rate.
 
-Agents create files from scratch (¬stubs). Include target path, shape/skeleton, ref pattern file in each Task prompt (in addition to `TaskGet` content).
+Agents create files from scratch (¬stubs). Include target path, shape/skeleton, ref pattern file in each spawn prompt (in addition to loaded task context).
 
 ## Step 5 — Quality Gate
 
@@ -208,7 +250,7 @@ Run QG inside ω (session already in ω after EnterWorktree):
 
 ## Step 6 — Summary
 
-Before printing summary → `TaskList` → assert every plan-task with `metadata.issue == N` is `completed`. ¬all completed → highlight stragglers in the summary (blockers for `/pr`).
+Before printing summary → assert all plan-tasks for issue N are completed (**H table**: claude `TaskList` + metadata.issue; grok all `T#` completed; artifact-only π rows). ¬all completed → highlight stragglers (blockers for `/pr`).
 
 ### Step 6a — SC→Test Matrix (τ ≠ S)
 

--- a/plugins/dev-core/skills/plan/README.md
+++ b/plugins/dev-core/skills/plan/README.md
@@ -4,7 +4,7 @@ Implementation plan — micro-tasks, agent assignments, file groups, and depende
 
 ## Why
 
-A spec says *what* to build. A plan says *who builds what, in what order, in parallel where safe*. `/plan` decomposes the spec into micro-tasks with verify commands, assigns them to domain agents, wires RED→GREEN→REFACTOR phase dependencies, and seeds the Claude Code task list — giving `/implement` a ready-to-execute work queue.
+A spec says *what* to build. A plan says *who builds what, in what order, in parallel where safe*. `/plan` decomposes the spec into micro-tasks with verify commands, assigns them to domain agents, wires RED→GREEN→REFACTOR phase dependencies, and seeds the **host task list** (Claude `Task*` or Grok `todo_write`) — giving `/implement` a ready-to-execute work queue.
 
 ## Usage
 
@@ -23,7 +23,7 @@ Triggers: `"plan"` | `"plan this"` | `"implementation plan"` | `"break it down"`
 3. **Agents** — assigns tasks to: `frontend-dev`, `backend-dev`, `tester`, `devops`, `doc-writer`, `architect`, `security-auditor` based on file paths from `stack.yml`.
 4. **Micro-tasks** — generates tasks with: description, file path, code skeleton, verify command, expected output, time estimate, parallel-safe flag, phase (RED/GREEN/REFACTOR/RED-GATE).
 5. **Write artifact** — creates `artifacts/plans/{N}-{slug}-plan.md` with forge-chart sidecars (`data-flow`, `file-map`) linked from `artifacts/visuals/`.
-6. **Seed tasks** — creates Claude Code tasks for every micro-task; wires `blockedBy` dependencies; persists task IDs in the artifact.
+6. **Seed tasks** — seeds the host task list for every micro-task (rich deps when available; portable checklist otherwise); persists blueprint / IDs in the artifact.
 
 ## Output artifact
 

--- a/plugins/dev-core/skills/plan/SKILL.md
+++ b/plugins/dev-core/skills/plan/SKILL.md
@@ -280,11 +280,13 @@ Options: **Approve** | **Modify** | **Return to spec**
 
 On Approve → **immediately** continue to 6a (seed tasks), 6b (persist IDs), 6c (commit). ¬stop between substeps.
 
-### Step 6a — Seed Claude Code Tasks
+### Step 6a — Seed host task list
 
-∀ micro-task in π — use the canonical schema from [plan-task-schema.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/plan-task-schema.md) (SSoT for `TaskCreate` shape + `blockedBy` wiring).
+∀ micro-task in π — fields from [plan-task-schema.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/plan-task-schema.md); **host mapping** from [harness-task-list.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-task-list.md).
 
-Cache returned id in {task# → task.id} map.
+Probe tools → H ∈ {claude-tasks, grok-todos, artifact-only}. Seed via that path (rich `TaskCreate` **or** portable `todo_write` **or** plan-only).
+
+Cache returned id in {task# → task.id} map when host returns ids (claude-tasks).
 
 τ=S → still seed tasks (3–6 is typical). Skip wave/blueprint wiring when π has no slice structure.
 

--- a/plugins/dev-core/skills/pr/SKILL.md
+++ b/plugins/dev-core/skills/pr/SKILL.md
@@ -150,7 +150,7 @@ Merge path = gate-driven: `reviewed` label + auto-merge (`gh pr merge --auto --m
 Fixes #{N}
 
 ---
-Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
+Generated with [Roxabi dev-core](https://github.com/Roxabi/roxabi-plugins) via `/pr`
 ```
 
 Lifecycle notes: S-tier → Intent + Implementation + Verification only. ¬issue → omit Lifecycle + Closes. S-tier → also omit SC → Test Matrix section.

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -253,7 +253,7 @@ gh pr create \
 - [x] Release notes committed to staging
 
 ---
-Generated with [Claude Code](https://claude.com/claude-code) via \`/promote\`
+Generated with [Roxabi dev-core](https://github.com/Roxabi/roxabi-plugins) via \`/promote\`
 EOF
 )"
 ```

--- a/plugins/dev-core/skills/shared/references/harness-task-list.md
+++ b/plugins/dev-core/skills/shared/references/harness-task-list.md
@@ -1,0 +1,90 @@
+# Harness task list (dual: Claude + Grok)
+
+> **SSoT for portable task-list ops.** Skills speak **generic** vocabulary; this file maps to host tools.  
+> Prefer **one skill body + capability branch** — never fork full SKILL.md per host.
+
+## Principle
+
+| Layer | Rule |
+|-------|------|
+| Skill prose | Host-neutral: « seed task list », « claim task », « mark done », « wire deps » |
+| Capability probe | Detect which tools exist **in this session** (schema / known names) |
+| Rich path | Full graph (deps, metadata, re-attach) when host supports it |
+| Portable path | Flat checklist when host only has a simple TODO API |
+| Artifact | Plan file remains **cross-session SSoT**; host task list is **in-session only** |
+
+## Capability matrix
+
+| Operation (generic) | Claude Code | Grok | Notes |
+|---------------------|-------------|------|-------|
+| Seed N tasks | `TaskCreate` × N | `todo_write` (batch merge) | Grok: no per-task return ID graph |
+| Attach metadata | `TaskCreate.metadata` | encode in `content` line | Keep blueprint fields in text |
+| Wire dependencies | `TaskUpdate` + `blockedBy` | **not supported** | Enforce order in skill prose + blueprint only |
+| List open tasks | `TaskList` | read current todos (tool state) | Grok: model already sees todo list |
+| Get one task | `TaskGet` | N/A — use list | — |
+| Mark done | `TaskUpdate` status | `todo_write` status=`completed` | — |
+| Re-attach after restart | blueprint in π + `TaskCreate` | re-seed from blueprint → `todo_write` | Both: artifact wins across sessions |
+
+## Detection (orchestrator)
+
+```
+if tools ∋ TaskCreate ∧ TaskUpdate ∧ TaskList → H := claude-tasks
+else if tools ∋ todo_write → H := grok-todos
+else → H := artifact-only   # plan file only; no in-session list
+```
+
+¬probe by OS name. Probe **tools available in the current harness**.
+
+## Seed procedure (generic)
+
+Input: Task Seeding Blueprint from π (see `plan-task-schema.md`).
+
+### H = claude-tasks (rich)
+
+1. ∀ row → `TaskCreate` with shape in `plan-task-schema.md`
+2. Cache `{T# → task.id}`
+3. `TaskUpdate` deps from blueprint `blockedBy`
+4. Persist id map in π if skill requires re-attach
+
+### H = grok-todos (portable)
+
+1. Build one `todo_write` batch (merge=false on first seed, merge=true on resume):
+   - `id`: stable `T{n}` from blueprint (not random)
+   - `content`: `[{phase}] {agent_instance} — {subject} | Verify: {cmd} | {spec_trace}`
+   - `status`: `pending`
+2. **Deps:** do not invent blockedBy. Orchestrator only spawns/claims a task when all blueprint deps are `completed` (or no deps).
+3. Persist nothing host-side across sessions — re-read blueprint from π.
+
+### H = artifact-only
+
+Work only from π micro-tasks table. Present progress in the reply. No host list.
+
+## Claim / execute (generic)
+
+1. Pick next ready task (deps satisfied, not completed)
+2. Inject description into agent spawn prompt
+3. On success → mark completed
+4. On fail → leave pending / note blocker; ¬auto-complete
+
+## Anti-patterns
+
+| Don’t | Do |
+|-------|----|
+| Fork `plan/SKILL.md` into claude vs grok copies | One skill + this mapping |
+| Require `TaskCreate` on Grok | Branch to `todo_write` |
+| Assume `blockedBy` on Grok | Enforce order in orchestrator |
+| Treat host todos as durable | Artifact π is durable |
+
+## Consumers
+
+| Skill | Uses H for |
+|-------|------------|
+| `/plan` Step 6a | Initial seed |
+| `/implement` Step 1b | Attach / re-seed / probe once |
+| `/implement` Step 4 | Claim, load context, mark done, ready-set |
+| `/implement` Step 6 | All-completed assert |
+
+## Related
+
+- Call shape (rich path): [`plan-task-schema.md`](plan-task-schema.md)
+- Dual harness install notes: `dev-init` skill « Dual harness »

--- a/plugins/dev-core/skills/shared/references/plan-task-schema.md
+++ b/plugins/dev-core/skills/shared/references/plan-task-schema.md
@@ -1,8 +1,21 @@
 # Plan-Task Schema
 
-> **SSoT for `/plan` Step 6a and `/implement` Step 1b.** Both skills must use this exact shape when calling `TaskCreate` for micro-tasks. Edit here only — never inline in either SKILL.md.
+> **SSoT for `/plan` Step 6a and `/implement` Step 1b.** Host-neutral fields + rich-path shape.  
+> **How to call the host:** see [`harness-task-list.md`](harness-task-list.md) (Claude `Task*` vs Grok `todo_write`).  
+> Edit field definitions here only — never inline in either SKILL.md.
 
-## TaskCreate call shape
+## Canonical fields (every host)
+
+| Field | Source |
+|-------|--------|
+| `kind: "plan-task"` | Fixed — distinguishes from `dev-pipeline` tasks owned by `/dev` |
+| `agent_instance` | From the Task Seeding Blueprint row in π — named instance (e.g. `tester-A`) so `/implement` groups tasks per agent session |
+| `wave` | Integer derived from the Wave Structure table in π |
+| `phase` | RED \| GREEN \| REFACTOR \| RED-GATE — drives test-first ordering in `/implement` Step 4 |
+| `spec_trace` | SC-N (Success Criteria) or U→N→S (user/need/solution) reference from the spec artifact |
+| `subject` / `verify` / `files` | Blueprint + micro-task row |
+
+## Rich path — TaskCreate call shape (H = claude-tasks)
 
 ```
 TaskCreate(
@@ -26,17 +39,7 @@ TaskCreate(
 )
 ```
 
-## Field notes
-
-| Field | Source |
-|-------|--------|
-| `kind: "plan-task"` | Fixed — distinguishes from `dev-pipeline` tasks owned by `/dev` |
-| `agent_instance` | From the Task Seeding Blueprint row in π — named instance (e.g. `tester-A`) so `/implement` groups tasks per agent session |
-| `wave` | Integer derived from the Wave Structure table in π |
-| `phase` | RED \| GREEN \| REFACTOR \| RED-GATE — drives test-first ordering in `/implement` Step 4 |
-| `spec_trace` | SC-N (Success Criteria) or U→N→S (user/need/solution) reference from the spec artifact |
-
-## Dependencies (TaskUpdate after seeding)
+### Dependencies (rich path only)
 
 After all `TaskCreate` calls succeed, wire `blockedBy`:
 
@@ -47,3 +50,7 @@ After all `TaskCreate` calls succeed, wire `blockedBy`:
 `deps` = T-numbers from the blueprint's `blockedBy` column, mapped to real task IDs via the `{T# → task.id}` cache built during seeding.
 
 Fallback (no blueprint): derive from phase order within a slice — GREEN blocked by RED, RED-GATE blocked by all RED in slice.
+
+## Portable path — todo_write (H = grok-todos)
+
+See `harness-task-list.md`. Encode the same fields in `content`; use stable `id: T{n}`; enforce `blockedBy` in the orchestrator (host has no dep graph).

--- a/plugins/dev-core/skills/spec/README.md
+++ b/plugins/dev-core/skills/spec/README.md
@@ -22,7 +22,7 @@ Triggers: `"write spec"` | `"spec this"` | `"solution design"` | `"acceptance cr
 1. **Resolve source** — finds the analysis (or frame if F-lite) for the issue.
 2. **Generate** — runs a structured interview (via `/interview`) to fill gaps between analysis and spec level: acceptance criteria, breadboard, slices, ambiguity detection.
 3. **Pre-check** — validates the spec before expert review: testable criteria (binary pass/fail), no dangling breadboard refs, ≤5 `[NEEDS CLARIFICATION]` items, slice coverage of all affordances.
-4. **Expert review** — spawns architect, doc-writer, product-lead (and devops if infra criteria) in parallel.
+4. **Expert review** — spawns architect, doc-writer, product-lead, adversarial (and devops if infra criteria) in parallel.
 5. **Smart splitting** (optional) — if > 8 acceptance criteria or > 3 slices, offers to split into sub-issues.
 6. **User approval** — presents scope, criteria count, unresolved concerns; loops on revisions.
 

--- a/plugins/dev-core/skills/spec/SKILL.md
+++ b/plugins/dev-core/skills/spec/SKILL.md
@@ -168,6 +168,7 @@ Auto-select ρ (¬ask user). Architect always included:
 | architect | Always | Technical soundness, feasibility, slice ordering |
 | doc-writer | Always | Structure, clarity, breadboard completeness |
 | product-lead | Always | Criteria quality, scope, user story validity |
+| adversarial | Always | Red-team: scope-attack, vacuous AC, missing adversarial flows, assumption-kill, control bypass in proposed design |
 | devops | ∃ CI/CD / deploy / infra criteria | Operational feasibility |
 | axial-adr-review | ∃ axial ADR (`axial: true` ∈ `docs/architecture/adr/`) ∧ (spec adds adapter/integration/target ∨ touches `infrastructure/`) | Drift along non-primary axis (N×M trap) — read-only review |
 
@@ -181,7 +182,7 @@ Task(
   prompt: "Review the spec at {σ_path} for <focus>. Check pre-check results: {pre_check_summary}. ¬TaskCreate. Return: good / needs improvement / concerns + specific line references."
 )
 ```
-Agent name map: `architect` → `dev-core:architect` | `doc-writer` → `dev-core:doc-writer` | `product-lead` → `dev-core:product-lead` | `devops` → `dev-core:devops` | `axial-adr-review` → `dev-core:axial-adr-review`
+Agent name map: `architect` → `dev-core:architect` | `doc-writer` → `dev-core:doc-writer` | `product-lead` → `dev-core:product-lead` | `adversarial` → `dev-core:adversarial` | `devops` → `dev-core:devops` | `axial-adr-review` → `dev-core:axial-adr-review`
 
 Incorporate feedback → revise σ → note unresolved concerns.
 

--- a/plugins/dev-core/skills/spec/references/expert-consultation.md
+++ b/plugins/dev-core/skills/spec/references/expert-consultation.md
@@ -7,7 +7,7 @@ When domain expertise is needed while writing the analysis or spec, spawn the re
 ```
 Task(
   description: "Expert consultation - <topic>",
-  subagent_type: "architect" | "doc-writer" | "devops" | "product-lead",
+  subagent_type: "architect" | "doc-writer" | "devops" | "product-lead" | "adversarial",
   prompt: "Research and answer: <specific question>. Return findings as bullet points."
 )
 ```
@@ -18,6 +18,7 @@ Task(
 | **doc-writer** | Document structure advice, Markdown conventions (legacy `.mdx` edit-in-place only), clarity feedback |
 | **devops** | CI/CD feasibility, deployment strategy, infrastructure requirements |
 | **product-lead** | Product fit, acceptance criteria, user story validation |
+| **adversarial** | Kill the design: bypass paths, vacuous AC, unstated assumptions, missing failure flows |
 
 Do NOT spawn experts upfront — only when a specific question arises during writing.
 

--- a/plugins/get-invoice-details/README.md
+++ b/plugins/get-invoice-details/README.md
@@ -1,6 +1,6 @@
 # Get Invoice Details
 
-A Claude Code plugin that extracts structured data from invoice documents. It reads invoices (text or PDF), pulls out key fields, and saves the result as JSON in your Roxabi vault.
+An agent-harness plugin that extracts structured data from invoice documents. It reads invoices (text or PDF), pulls out key fields, and saves the result as JSON in your Roxabi vault.
 
 ## What it does
 
@@ -23,7 +23,7 @@ claude plugin install get-invoice-details
 
 ## Usage
 
-Run with any of these phrases in Claude Code:
+Run with any of these phrases:
 
 - `get-invoice-details`
 - `extract invoice`

--- a/plugins/gitnexus/README.md
+++ b/plugins/gitnexus/README.md
@@ -73,7 +73,7 @@ gitnexus context AuthService
 
 ## Output Format
 
-All commands output JSON (default), which Claude Code can parse directly:
+All commands output JSON (default), which the agent harness can parse directly:
 
 ```bash
 gitnexus impact validateUser

--- a/plugins/image-prompt-generator/README.md
+++ b/plugins/image-prompt-generator/README.md
@@ -1,6 +1,6 @@
 # Image Prompt Generator
 
-A Claude Code plugin that generates AI image prompts with visual identity and style consistency. It turns a simple concept into multiple prompt variants across different artistic styles, optionally aligned to your brand.
+An agent-harness plugin that generates AI image prompts with visual identity and style consistency. It turns a simple concept into multiple prompt variants across different artistic styles, optionally aligned to your brand.
 
 ## What it does
 
@@ -29,7 +29,7 @@ claude plugin install image-prompt-generator
 
 ## Usage
 
-Run the generator with any of these phrases in Claude Code:
+Run the generator with any of these phrases:
 
 - `image-prompt`
 - `generate image prompt`

--- a/plugins/linkedin-post-generator/README.md
+++ b/plugins/linkedin-post-generator/README.md
@@ -1,6 +1,6 @@
 # LinkedIn Post Generator
 
-A Claude Code plugin that generates engaging LinkedIn posts following proven best practices. It handles formatting, hooks, hashtags, and visual identity so you can focus on the idea.
+An agent-harness plugin that generates engaging LinkedIn posts following proven best practices. It handles formatting, hooks, hashtags, and visual identity so you can focus on the idea.
 
 ## What it does
 
@@ -25,7 +25,7 @@ claude plugin install linkedin-post-generator
 
 ## Usage
 
-Run with any of these phrases in Claude Code:
+Run with any of these phrases:
 
 - `linkedin post`
 - `write linkedin`


### PR DESCRIPTION
## Summary

- Add **adversarial** red-team agent and wire it into `/spec` + `/code-review` (always)
- Dual-harness task list (`harness-task-list.md`): Claude `Task*` vs Grok `todo_write` for `/plan` seed and `/implement` attach/lifecycle
- Hooks dual-read (env Claude ∪ stdin Grok), rename to `.cjs` (monorepo `type:module`), `bun-test-guard.cjs`
- Drop provider `model:` and `permissionMode` from agents; neutral plugin branding / PR footers
- Bump **dev-core 0.9.8 → 0.10.0**

## Test plan

- [x] pre-commit + pre-push lefthook (typecheck, vitest 839, trufflehog, skill-version)
- [ ] Manual: `/code-review` dispatches `adversarial`
- [ ] Manual: `/implement` Step 1b on Grok uses `todo_write` path
- [ ] Manual: hooks fire after enable+trust dev-core on Grok

Generated with [Roxabi dev-core](https://github.com/Roxabi/roxabi-plugins) via `/ship`