### PR TITLE
chore(deps): pin actions/checkout to v7.0.1 across fleet

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Full history + tags with the App token, so the tag-reachability floor is
       # never starved into a regressive v0.1.0 (release-consistency.yml scar).
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
           token: ${{ steps.app.outputs.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
       - run: bun install
       - name: Lint

--- a/.github/workflows/context-lint.yml
+++ b/.github/workflows/context-lint.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Lint agent-context files (@imports + placeholders)
         run: |
           set -u

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -18,7 +18,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
       - run: bun install
       - name: Deploy

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check PR title follows Conventional Commits
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v7.0.1
         with:
           types: |
             feat

--- a/.github/workflows/release-consistency.yml
+++ b/.github/workflows/release-consistency.yml
@@ -69,7 +69,7 @@ jobs:
       # the gate starves its own candidate set and reports GREEN on a drifted
       # repo. The shallow-clone failure is green, not loud.
       - name: Checkout (full history + tags)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -13,7 +13,7 @@ jobs:
   check-upstreams:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Check upstream drift
         env:

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. adversarial), dual-harness task list, safety hooks (Claude + Grok).",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/ci-setup/cookbooks/scanning.md
+++ b/plugins/dev-core/skills/ci-setup/cookbooks/scanning.md
@@ -40,7 +40,7 @@ yes:
        runs-on: ubuntu-latest
        timeout-minutes: 5
        steps:
-         - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
            with:
              fetch-depth: 0
          - name: TruffleHog secret scan

--- a/plugins/dev-core/skills/shared/workflows/workflow-pins.ts
+++ b/plugins/dev-core/skills/shared/workflows/workflow-pins.ts
@@ -3,7 +3,7 @@
  *  silently until a generated CI run dies at "Set up job".
  *  Verify before committing a change here: `bun run verify:pins`. */
 export const ACTION_PINS = {
-  checkout: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10', // v6
+  checkout: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1', // v7.0.1
   setupBun: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6', // v2
   setupNode: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020', // v4
   setupUv: 'astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86', // v5

--- a/plugins/dev-init/skills/shared/workflows/workflow-pins.ts
+++ b/plugins/dev-init/skills/shared/workflows/workflow-pins.ts
@@ -5,7 +5,7 @@
  *  silently until a generated CI run dies at "Set up job".
  *  Verify before committing a change here: `bun run verify:pins`. */
 export const ACTION_PINS = {
-  checkout: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10', // v6
+  checkout: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1', // v7.0.1
   setupBun: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6', // v2
   setupNode: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020', // v4
   setupUv: 'astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86', // v5


### PR DESCRIPTION
## Summary

- Bump `ACTION_PINS.checkout` **v6 → v7.0.1** (`3d3c42e5…`)
- Align all `.github/workflows/*` checkout pins + comments
- Copy-sync pin to `dev-init`
- dev-core **0.10.0 → 0.10.1**

Supersedes Dependabot [#391](https://github.com/Roxabi/roxabi-plugins/pull/391) (that PR only edited workflows and broke dogfood vs generator).

## Test plan

- [x] `auto-release-actionlint` dogfood green
- [x] `bun run verify:pins` all resolve
- [ ] CI green on PR