### PR TITLE
ci: skip full CI on draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
 
 jobs:
   ci:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/plugins/dev-core/skills/shared/__tests__/workflows.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/workflows.test.ts
@@ -140,6 +140,14 @@ describe('generateCiYml', () => {
     const yml = generateCiYml({ stack: 'bun', test: 'vitest', deploy: 'none' })
     expect(yml).toContain('branches: [main, staging]')
   })
+
+  it('skips full CI on draft PRs and re-triggers on ready_for_review', () => {
+    const yml = generateCiYml({ stack: 'bun', test: 'vitest', deploy: 'none' })
+    expect(yml).toContain('types: [opened, synchronize, reopened, ready_for_review]')
+    expect(yml).toContain(
+      "if: github.event_name != 'pull_request' || !github.event.pull_request.draft",
+    )
+  })
 })
 
 describe('generateSecretScanYml', () => {

--- a/plugins/dev-core/skills/shared/workflows/workflow-generators.ts
+++ b/plugins/dev-core/skills/shared/workflows/workflow-generators.ts
@@ -427,16 +427,20 @@ export function generateCiYml(opts: WorkflowOpts): string {
       '      # If this is wrong, set commands.test + testing.unit and re-run /ci-setup.'
   }
 
+  // Draft PRs skip full CI (WIP). ready_for_review re-triggers when undrafted.
+  // `reviewed` remains the merge gate only (auto-merge / merge-on-green) — not a CI gate.
   return `name: CI
 on:
   push:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   ci:
     name: CI
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: ${ACTION_PINS.checkout}

--- a/plugins/dev-core/skills/shared/workflows/workflows-fleet.ts
+++ b/plugins/dev-core/skills/shared/workflows/workflows-fleet.ts
@@ -221,6 +221,7 @@ export function generateE2eJob(opts: WorkflowOpts): string {
   return `
   e2e:
     name: E2E
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/plugins/dev-init/skills/shared/workflows/workflow-generators.ts
+++ b/plugins/dev-init/skills/shared/workflows/workflow-generators.ts
@@ -429,16 +429,20 @@ export function generateCiYml(opts: WorkflowOpts): string {
       '      # If this is wrong, set commands.test + testing.unit and re-run /ci-setup.'
   }
 
+  // Draft PRs skip full CI (WIP). ready_for_review re-triggers when undrafted.
+  // `reviewed` remains the merge gate only (auto-merge / merge-on-green) — not a CI gate.
   return `name: CI
 on:
   push:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   ci:
     name: CI
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: ${ACTION_PINS.checkout}

--- a/plugins/dev-init/skills/shared/workflows/workflows-fleet.ts
+++ b/plugins/dev-init/skills/shared/workflows/workflows-fleet.ts
@@ -223,6 +223,7 @@ export function generateE2eJob(opts: WorkflowOpts): string {
   return `
   e2e:
     name: E2E
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## Summary
- Skip full CI jobs when `pull_request.draft` is true (WIP pushes no longer burn Actions minutes).
- Listen for `ready_for_review` so undrafting re-triggers CI.
- Leave secret-scan / pr-title / context-lint unchanged; `reviewed` stays the merge gate only.

## Test plan
- [ ] Open a draft PR → CI jobs show as skipped
- [ ] Mark ready for review → CI runs
- [ ] Push to a ready PR → CI still runs
- [ ] Push to main/staging → CI unchanged
