### PR TITLE
feat(dev-core): lean HITL gates — less AQ, chat-native /spec

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. adversarial), dual-harness task list + worktrees, safety hooks (Claude + Grok).",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -31,7 +31,7 @@ Let:
   bar   := output must read as hand-authored by a dev-core maintainer — match surrounding idiom, naming, comment density; calibrate against `plugins/dev-core/`; QG (format/lint/typecheck/test) = mechanical floor, ¬the bar
 
 Single entry point: scan artifacts → detect state → show progress → delegate to step skill → loop.
-¬rewrite step skill logic. ¬auto-advance phases. Present choice at each gate and wait for user reply.
+¬rewrite step skill logic. Gate skills own their AQs; **auto-advance when unambiguous** (labels, approved artifacts, informative-only recheck). Present choice only when ≥2 plausible outcomes.
 
 ## Entry
 
@@ -105,8 +105,11 @@ bash ${CLAUDE_SKILL_DIR}/scan-state.sh {N} {slug}
 
 ## Step 2 — Determine Tier
 
-τ ∃ → skip.
-¬τ → present choice **S** (≤3 files, no arch) | **F-lite** (clear scope, 1 domain) | **F-full** (complex, multi-domain).
+τ ∃ (from φ.tier or size label mapping in Step 1) → skip. Print nothing.
+
+¬τ → try size labels again (XS/S→S, M→F-lite, L/XL→F-full). ∃ mapping → set τ silently.
+
+¬τ still (no frame, no size label) → present choice **S** (≤3 files, no arch) | **F-lite** (clear scope, 1 domain) | **F-full** (complex, multi-domain).
 
 ## Step 2b — Seed Pipeline Tasks
 
@@ -207,13 +210,13 @@ Walk: Σ[step] == true ∨ Σ_s[step] == true ∨ should_skip(step) ⇒ done/ski
 
 | Gate trigger | Behavior |
 |-------------|----------|
-| S* == frame (¬Σ.frame) | Show φ if ∃ draft, ask approval |
-| S* == spec (Σ.frame ∧ ¬Σ.spec) | Gate after spec runs |
+| S* == frame (¬Σ.frame) | **no pre-gate AQ** — invoke `/frame` immediately. Skill auto-reuses approved, auto-continues draft, auto-approves when seed has no gaps; AQ only on real gaps. |
+| S* == spec (Σ.frame ∧ ¬Σ.spec) | Gate after `/spec`: **chat Executive Summary** (¬AskUserQuestion). Free-form approve/revise in next turn, then re-scan → `/plan`. |
 | S* == plan (Σ.spec ∧ ¬Σ.plan) ∧ τ == F-full | Architecture sketch (see block below) → user confirm → THEN invoke /plan. ¬fires for τ ∈ {S, F-lite}. |
-| S* == plan (Σ.spec ∧ ¬Σ.plan) ∧ τ ∈ {S, F-lite} | Gate after plan runs |
+| S* == plan (Σ.spec ∧ ¬Σ.plan) ∧ τ ∈ {S, F-lite} | Gate after plan runs (inside `/plan`) |
 | S* == review | Post-review gate handled inside /code-review |
 
-Gate fires → Step 7 skips its own prompt (gate IS confirmation). ¬double-prompt.
+Gate fires → Step 7 skips its own prompt (gate IS confirmation). ¬double-prompt. **¬pre-ask** what the child skill will decide or auto-resolve.
 
 ### Architecture Sketch Gate (F-full only, pre-plan)
 

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -86,8 +86,11 @@ bash ${CLAUDE_SKILL_DIR}/scan-state.sh {N} {slug}
   recheck:   null,       # Σ_s only — runs every session, no on-disk state
   frame:     φ ∃ ∧ φ.status == 'approved',
   analyze:   analysis artifact ∃,
-  spec:      spec artifact ∃,
-  plan:      plan artifact ∃,
+  # Gates must not flip true on draft-only artifacts (chat HITL writes draft before approve).
+  # frame: status: approved. spec: status: approved (legacy: missing status ≡ approved; only status: draft blocks).
+  # plan: ## Task IDs written only after Step 6 approve (+ seed).
+  spec:      σ ∃ ∧ σ.status ≠ 'draft',
+  plan:      π ∃ ∧ (## Task IDs section ∃ in π),
   implement: worktree ∃ (branch-first: non-principal ω on feat/{N}-* — Claude path, Grok ~/.grok/worktrees, or legacy) ∧ git -C ω diff --name-only origin/${BASE}..HEAD | grep -v '^artifacts/' is non-empty,
   pr:        PR ∃,
   ci-watch:  null,       # Σ_s only

--- a/plugins/dev-core/skills/frame/README.md
+++ b/plugins/dev-core/skills/frame/README.md
@@ -4,7 +4,7 @@ Problem framing — capture the problem, constraints, scope, and tier before wri
 
 ## Why
 
-Jumping straight to implementation without a clear problem statement leads to scope creep and rework. `/frame` forces a structured interview, produces an approved frame artifact, and auto-detects the implementation tier (S / F-lite / F-full) so the rest of the pipeline is correctly scoped.
+Jumping straight to implementation without a clear problem statement leads to scope creep and rework. `/frame` produces an approved frame artifact and auto-detects the implementation tier (S / F-lite / F-full) so the rest of the pipeline is correctly scoped.
 
 ## Usage
 
@@ -17,16 +17,16 @@ Triggers: `"frame"` | `"frame this"` | `"what's the problem"` | `"define the pro
 
 ## How it works
 
-1. **Parse + Seed** — reads the GitHub issue (title, body, labels) or free text as context.
-2. **Interview** — asks 3–5 focused questions (skips what's already clear from the issue body): problem/pain, affected users, constraints, out-of-scope, related work.
-3. **Premise-validity gate** — required before tier classification. Captures three fields:
-   - `success_in_6mo` — what does success look like? (concrete, observable)
-   - `failure_in_6mo` — what does failure look like? (must be falsifiable)
-   - `simplest_alternative` + why it's insufficient — forces explicit comparison against the minimal solution
-   Cannot proceed without all three. Non-falsifiable failure modes trigger an abort prompt.
-4. **Tier detection** — infers S / F-lite / F-full from complexity signals (file count, domain breadth, unknowns); lets you override.
-5. **Write frame doc** — creates `artifacts/frames/{N}-{slug}-frame.md` with status: `draft`.
-6. **User approval** — presents the frame for confirmation; loops on revisions until approved.
+**Policy: auto when unambiguous; AQ only for real gaps.**
+
+1. **Parse + Seed** — reads the GitHub issue (title, body, labels) or free text.
+   - Approved frame already on disk → **reuse**, exit (no re-approve).
+   - Draft exists → **continue** (no "Start fresh?" prompt).
+2. **Interview** — asks only fields missing from the seed (0 questions when the issue body is rich).
+3. **Premise-validity gate** — three fields (`success_in_6mo`, `failure_in_6mo`, `simplest_alternative` + why-not). Extract from seed/draft when present; AQ only for missing fields. Non-falsifiable failure modes still trigger an abort prompt.
+4. **Tier detection** — from size label or unanimous signals → auto. Contested signals only → Confirm AQ.
+5. **Write frame doc** — `artifacts/frames/{N}-{slug}-frame.md` with status: `draft`.
+6. **Approval** — **auto-approve** when interview/premise/tier had zero AQs this run; otherwise Approve | Revise.
 7. **Commit + status update** — sets issue status to `Analysis` and commits the artifact.
 
 ## Output artifact

--- a/plugins/dev-core/skills/frame/SKILL.md
+++ b/plugins/dev-core/skills/frame/SKILL.md
@@ -2,7 +2,7 @@
 name: frame
 argument-hint: '["idea" | --issue <N>]'
 description: Problem framing — capture problem, constraints, scope, tier. Triggers: "frame" | "frame this" | "what's the problem" | "define the problem" | "scope this out" | "define the scope" | "what are we solving" | "help me think through this problem" | "problem statement".
-version: 0.4.0
+version: 0.5.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, ToolSearch
 ---
 
@@ -18,8 +18,10 @@ Let:
   N := issue number (∅ if free text)
   τ := tier ∈ {S, F-lite, F-full}
   AQ := present choice, wait for user reply
+  gap := field/answer not extractable from seed with high confidence
 
-idea | issue → approved frame doc. Interview → detect τ → write φ → user approves.
+idea | issue → approved frame doc. Interview → detect τ → write φ → approve.
+**Default-auto when unambiguous:** AQ only for real gaps. ¬re-ask confirmations whose answer is already determined.
 Standalone-safe: callable without `/dev`. Output consumed by `/analyze`, `/spec`, `/dev`.
 
 ## Entry
@@ -33,12 +35,12 @@ Standalone-safe: callable without `/dev`. Output consumed by `/analyze`, `/spec`
 
 | Step | ID | Required | Verifies via | Notes |
 |------|----|----------|---------------|-------|
-| 0 | parse | ✓ | `gh issue view N` → JSON | — |
-| 1 | interview | — | — | 3–5 Q max |
-| 1b | premise | ✓ | 3 fields non-empty | **gate** — blocks Step 2 |
-| 2 | tier | ✓ | τ ∈ frontmatter | — |
+| 0 | parse | ✓ | `gh issue view N` → JSON | auto-reuse approved; auto-continue draft |
+| 1 | interview | — | — | only missing gaps; 0 AQ if seed complete |
+| 1b | premise | ✓ | 3 fields non-empty | extract from seed if present; AQ only gaps |
+| 2 | tier | ✓ | τ ∈ frontmatter | auto if label/signals unanimous; AQ if contested |
 | 3 | write | ✓ | φ ∃ | — |
-| 4 | approval | ✓ | `status: approved` | gate |
+| 4 | approval | ✓ | `status: approved` | auto if zero gaps this run; else AQ |
 
 ## Pre-flight
 
@@ -46,6 +48,15 @@ Success: φ written ∧ status: approved
 Evidence: `ls artifacts/frames/` after execution
 Steps: parse → interview → premise-gate → tier → write → approval
 ¬clear → STOP + ask: "What problem are you solving?"
+
+## AQ policy (global)
+
+```
+if answer is uniquely determined by seed/labels/existing artifact → act, print one-line note, ¬AQ
+if ≥2 plausible paths with different outcomes → AQ
+```
+
+Never invent premise fields. Prefer extract-from-seed over asking.
 
 ## Step 0 — Parse + Seed
 
@@ -63,43 +74,63 @@ Check ∃ φ:
 # glob artifacts/frames/*{slug}*
 ```
 
-∃ φ ∧ `status: approved` → AQ: **Use existing** (→ Step 4) | **Re-frame** (→ Step 1, fresh).
-∃ φ ∧ `status: draft` → AQ: **Continue draft** (→ Step 3) | **Start fresh** (→ Step 1).
+### Existing artifact (auto when unambiguous)
+
+| State | Action | AQ? |
+|-------|--------|-----|
+| ∃ φ ∧ `status: approved` | **Reuse** — print `Reusing approved frame {path} (tier={τ}).` → **Exit** (already done). ¬re-approve. | ¬ |
+| ∃ φ ∧ `status: draft` ∧ all required sections non-empty | **Continue draft** — print `Continuing draft frame {path}.` → Step 2 (re-detect τ if missing) → Step 3 overwrite → Step 4 | ¬ at Step 0 |
+| ∃ φ ∧ `status: draft` ∧ incomplete (empty Problem / Premise / …) | **Continue draft** silently → Step 1 for remaining gaps only | ¬ at Step 0 |
+
+¬offer "Re-frame" / "Start fresh" as a blocking prompt. User can say "re-frame" or "start fresh" in chat to force Step 1 from scratch — reactive, not proactive AQ.
 
 ## Step 1 — Interview
 
-3–5 questions max. Skip answers clear from seed. Group into 1–2 AQ calls.
+3–5 questions max. **Skip any answer clear from seed.** Group remaining into **at most one** AQ call. If zero gaps → print nothing for this step, continue.
 
 | # | Question | Skip if |
 |---|----------|---------|
 | 1 | What is the problem/pain? What triggers this? | Issue body has clear problem |
 | 2 | Who is affected? Primary + secondary users. | Issue body names users |
 | 3 | What constraints apply? (time, tech, dependencies) | Labels or body imply these |
-| 4 | What is explicitly out of scope? | Scope already narrow |
-| 5 | Related work, prior attempts, adjacent issues? | ∅ context → optional |
+| 4 | What is explicitly out of scope? | Scope already narrow or body lists non-goals |
+| 5 | Related work, prior attempts, adjacent issues? | always optional — skip unless seed is thin |
 
 ¬ask all 5 if seed is rich — ask only what's missing.
+Track `interview_gaps = count of questions actually asked` (0 when fully skipped).
 
 ## Step 1b — Premise-Validity Gate
 
-**Gate: cannot proceed to Step 2 without all 3 fields answered.**
+**Gate: cannot proceed to Step 2 without all 3 fields filled** — but fill from seed first.
 
-Capture in a single AQ (present all 3 together):
+### 1b.0 Extract from seed (no AQ)
+
+Scan issue body / free-text / draft φ for sections or headings matching (case-insensitive):
+- success / success criteria / outcome in 6 months / definition of done
+- failure / failure mode / abort if / kill criteria
+- simplest / alternative / why not / MVP insufficient
+
+If a field is already present and meets evaluation rules → use it, mark filled.
+
+### 1b.1 AQ only for remaining gaps
 
 | Field | Prompt | Requirement |
 |-------|--------|-------------|
 | `success_in_6mo` | "What does success look like in 6 months?" | Concrete, observable outcome — ¬vague ("things are better") |
-| `failure_in_6mo` | "What does failure look like in 6 months?" | Must be **falsifiable** — a condition you could actually observe ∧ decide to abort |
-| `simplest_alternative` | "What's the simplest version that would meet the goal — and why isn't it enough?" | Forces explicit comparison; the "why not" is required, ¬optional |
+| `failure_in_6mo` | "What does failure look like in 6 months?" | Must be **falsifiable** — measurable outcome + time horizon |
+| `simplest_alternative` | "What's the simplest version that would meet the goal — and why isn't it enough?" | Both halves required |
+
+- All 3 extractable → print one line `Premise extracted from seed.` → Step 2. ¬AQ.
+- Partial → single AQ with **only the missing fields** (not the full triad again).
+- None → single AQ with all 3 (present together).
 
 Evaluation rules:
 
-- `failure_in_6mo` falsifiability rule: must reference a **measurable outcome** (number, threshold, or boolean state) AND a **time horizon**. Vibes-only failure modes are rejected.
-- `failure_in_6mo` ¬falsifiable (e.g. "people aren't happy") → reject, re-ask. Example of falsifiable: "DEBT count stays flat or rises despite 3 sprint cycles." Example of non-falsifiable: "the team doesn't feel better."
-- `simplest_alternative` answer omits the "why not" half → re-ask: "You described the simpler version — why won't it be enough?"
-- Any field empty or answered with ≤5 words → treat as unanswered, re-ask.
+- `failure_in_6mo` ¬falsifiable (e.g. "people aren't happy") → reject, re-ask that field only.
+- `simplest_alternative` omits "why not" → re-ask that half only.
+- Any field empty or ≤5 words → treat as unanswered.
 
-**Abort signal:** if the user answers `failure_in_6mo` with a description that matches "we'd still have the problem but with extra bookkeeping" (i.e. the initiative measures proxy metrics, ¬the underlying issue) → surface: "This failure mode suggests the premise may be invalid. Do you want to reframe the problem or abort?" AQ: **Reframe** | **Abort**.
+**Abort signal:** if `failure_in_6mo` matches proxy-metric patterns (bookkeeping compliance, annotation density, ticket-close rate as sole success, etc.) → surface: "This failure mode suggests the premise may be invalid." AQ: **Reframe** | **Abort**.
 
 Canonical proxy-metric patterns (LLM anchors — any of these triggers the abort signal):
 - "compliance count stays the same / unchanged"
@@ -108,7 +139,9 @@ Canonical proxy-metric patterns (LLM anchors — any of these triggers the abort
 - "dashboard stays red / metric won't budge"
 - "we'd still have the underlying problem but with extra bookkeeping"
 
-Origin: pattern surfaced by Roxabi/lyra#1162 — quality-debt annotation infrastructure (~1100 LOC + 6 registry files) where the ratchet measured bookkeeping compliance, not code quality. A falsification check at /frame would have caught this.
+Origin: Roxabi/lyra#1162 — quality-debt annotation infrastructure where the ratchet measured bookkeeping, not quality.
+
+Track `premise_gaps = count of fields that required AQ`.
 
 ## Step 2 — Tier Detection
 
@@ -125,7 +158,16 @@ Auto-detect τ from complexity signals:
 
 See [tier-classification.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/tier-classification.md) for canonical rules.
 
-AQ: **Confirm {τ}** | **Override → S** | **Override → F-lite** | **Override → F-full**
+### Auto vs AQ
+
+| Condition | Action |
+|-----------|--------|
+| Issue has size label XS/S/M/L/XL | τ from label (label wins). Print `Tier {τ} (from size label).` ¬AQ |
+| No size label ∧ signals unanimous (all point to same τ) | use that τ. Print `Tier {τ} (auto).` ¬AQ |
+| No size label ∧ signals contested (split) | default higher τ; AQ: **Confirm {τ}** \| **Override → S** \| **Override → F-lite** \| **Override → F-full** |
+| `/dev` already passed τ via context (φ.tier already set this session) | reuse. ¬AQ |
+
+Track `tier_aq = true` only if Confirm AQ fired.
 
 ## Step 3 — Write Frame Doc
 
@@ -177,11 +219,23 @@ date: {YYYY-MM-DD}
 
 ## Step 4 — User Approval
 
-Present summary: problem statement, τ, key constraints, scope boundary.
-AQ: **Approve** | **Revise** (specify what to change).
+### Auto-approve when unambiguous
 
-**Revise** → apply edits inline → re-present → loop until Approve.
-**Approve** → update frontmatter `status: approved` via Edit.
+```
+unambiguous := interview_gaps == 0 ∧ premise_gaps == 0 ∧ ¬tier_aq
+```
+
+If unambiguous:
+1. Present a short summary (problem one-liner, τ, constraints) as **prose/output — not AQ**.
+2. Set `status: approved` immediately.
+3. Print: `Frame auto-approved (seed complete, no gaps).`
+4. Continue to Completion.
+
+If ¬unambiguous (any gap required AQ this run):
+1. Present summary: problem statement, τ, key constraints, scope boundary.
+2. AQ: **Approve** | **Revise** (specify what to change).
+3. **Revise** → apply edits → re-present → loop until Approve.
+4. **Approve** → update frontmatter `status: approved` via Edit.
 
 ## Completion
 
@@ -194,21 +248,23 @@ Commit: `git add artifacts/frames/{N}-{slug}-frame.md` + commit per CLAUDE.md Ru
 bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts set N --status Analysis
 ```
 
-Inform: "Frame approved. Run `/dev #N` to continue, or `/analyze --issue N` for deep technical exploration."
+- **Via `/dev`:** return silently after commit. ¬ask "proceed to /analyze?".
+- **Standalone:** print one line: `Approved. Next: /analyze --issue N` (F-full) or `/spec --issue N` (F-lite).
 
 ## Edge Cases
 
-- Free text ∧ ¬clear slug → derive from first 4 nouns/verbs. AQ to confirm if ambiguous.
+- Free text ∧ ¬clear slug → derive from first 4 nouns/verbs. AQ only if two equally good slugs (rare); else auto.
 - Issue ¬exists (gh 404) → proceed in free-text mode using title as seed.
-- Tier contested (signals split evenly) → default to higher τ; note: "Defaulted to {τ} — downgrade if scope narrows."
-- User approves then requests major change → reset `status: draft`, revise, re-approve.
+- Tier contested (signals split evenly) → default to higher τ; AQ Confirm (only contested path).
+- User says "re-frame" after auto-reuse → reset, run Step 1 fresh.
+- User approves then requests major change → reset `status: draft`, revise, re-approve (AQ).
 
 ## Chain Position
 
 - **Phase:** Frame
 - **Predecessor:** `/issue-triage` (or free-text entry)
 - **Successor:** `/analyze` (F-full) ∨ `/spec` (F-lite)
-- **Class:** gate (user approval of frame artifact required)
+- **Class:** gate (approved artifact required; AQ only when gaps remain)
 
 ## Task Integration
 
@@ -220,6 +276,7 @@ Inform: "Frame approved. Run `/dev #N` to continue, or `/analyze --issue N` for 
 
 - **Approved via `/dev`:** write artifact with `status: approved`, commit, return silently. ¬ask "proceed to /analyze?". `/dev` re-scans and auto-chains to successor in the same turn.
 - **Approved standalone:** print one line: `Approved. Next: /analyze --issue N` (F-full) or `/spec --issue N` (F-lite). Stop.
+- **Reuse existing approved:** print one-line reuse note, return (Σ.frame already true).
 - **Modify requested:** loop in-skill, re-present.
 - **Rejected/aborted:** return → `/dev` marks task `cancelled`.
 

--- a/plugins/dev-core/skills/plan/README.md
+++ b/plugins/dev-core/skills/plan/README.md
@@ -18,12 +18,14 @@ Triggers: `"plan"` | `"plan this"` | `"implementation plan"` | `"break it down"`
 
 ## How it works
 
-1. **Locate spec** — reads the spec artifact; checks for unresolved `[NEEDS CLARIFICATION]` items.
-2. **Scope** — Globs + Greps the codebase to identify files to create/modify; finds reference patterns.
-3. **Agents** — assigns tasks to: `frontend-dev`, `backend-dev`, `tester`, `devops`, `doc-writer`, `architect`, `security-auditor` based on file paths from `stack.yml`.
-4. **Micro-tasks** — generates tasks with: description, file path, code skeleton, verify command, expected output, time estimate, parallel-safe flag, phase (RED/GREEN/REFACTOR/RED-GATE).
-5. **Write artifact** — creates `artifacts/plans/{N}-{slug}-plan.md` with forge-chart sidecars (`data-flow`, `file-map`) linked from `artifacts/visuals/`.
-6. **Seed tasks** — seeds the host task list for every micro-task (rich deps when available; portable checklist otherwise); persists blueprint / IDs in the artifact.
+**AQ policy:** continuous pipeline + **one** approval gate (Step 6). Auto when path is unique (slice, budget splits). `/spec` remains chat-native HITL (exec summary) — this skill does not weaken that.
+
+1. **Locate spec** — reads the spec; if leftover `[NEEDS CLARIFICATION]` → AQ; else silent.
+2. **Scope + agents + tasks** — continuous (no mid-plan Approve). Budget overruns force-split automatically. Multi-slice: auto next unimplemented when clear.
+3. **Micro-tasks** — description, file, skeleton, verify, phase (RED/GREEN/REFACTOR/RED-GATE), agent instances.
+4. **Write artifact** — `artifacts/plans/{N}-{slug}-plan.md` + forge-chart sidecars (`data-flow`, `file-map`).
+5. **Approve (sole gate)** — Approve | Modify | Return to spec.
+6. **Seed tasks** — host task list (Claude `Task*` / Grok `todo_write`) + persist blueprint / `## Task IDs`, then commit.
 
 ## Output artifact
 

--- a/plugins/dev-core/skills/plan/SKILL.md
+++ b/plugins/dev-core/skills/plan/SKILL.md
@@ -2,7 +2,7 @@
 name: plan
 argument-hint: '[--issue <N> | --spec <path> | --audit]'
 description: Implementation plan — tasks, agents, file groups, dependencies. Triggers: "plan" | "plan this" | "implementation plan" | "break it down" | "plan this feature" | "how should we build this" | "make a plan" | "create a plan" | "break this down into tasks" | "task breakdown".
-version: 0.4.0
+version: 0.5.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---
 
@@ -20,7 +20,8 @@ Let:
 
 Spec → micro-tasks → agent assignments → plan artifact.
 
-**Flow: single continuous pipeline. ¬stop between steps. Decision response → immediately execute next step. Stop only on: Cancel/Abort or Step 6 completion.**
+**Flow: single continuous pipeline. ¬stop between steps except (a) χ ambiguity pre-flight, (b) optional `--audit`, (c) Step 6 single approval gate.**  
+**AQ policy:** auto when the path is unique; one human gate at Step 6. ¬double-approve (no mid-plan 2f + final 6).
 
 ```
 /plan --issue 42         Generate plan from spec for issue #42
@@ -32,12 +33,12 @@ Spec → micro-tasks → agent assignments → plan artifact.
 
 | Step | ID | Required | Verifies via | Notes |
 |------|----|----------|---------------|-------|
-| 1 | locate-spec | ✓ | σ ∃ | — |
-| 2 | plan | ✓ | τ + agents defined | — |
+| 1 | locate-spec | ✓ | σ ∃ | χ>0 → AQ; χ=0 silent |
+| 2 | plan | ✓ | τ + agents defined | continuous — ¬mid-plan approve |
 | 3 | refs | — | ref paths noted | — |
 | 4 | micro-tasks | — | tasks ∃ in π | Tier F only |
 | 5 | write | ✓ | π ∃ | — |
-| 6 | approve | ✓ | `git log` shows commit | gate |
+| 6 | approve | ✓ | `git log` shows commit | **sole plan gate** |
 
 ## Pre-flight
 
@@ -55,7 +56,11 @@ Steps: locate-spec → plan → refs → micro-tasks → write → approve
 ### Pre-flight: Ambiguity Check
 
 Grep `\[NEEDS CLARIFICATION` in σ (count).
-count > 0 → present choice **Resolve now** | **Return to spec** | **Proceed anyway**
+
+| count | Action |
+|------:|--------|
+| 0 | continue silently |
+| > 0 | present choice **Resolve now** \| **Return to spec** \| **Proceed anyway** — real ambiguity (spec HITL already ran; leftover χ is a plan blocker decision) |
 
 ## Step 2 — Plan
 
@@ -65,11 +70,11 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/dev-process.md` + σ.
 
 `--audit` → after reading σ, present reasoning audit per [reasoning-audit.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/reasoning-audit.md) (plan guidance).
 → present choice **Proceed** | **Adjust approach** | **Abort**
-¬`--audit` → continue to Step 2a.
+¬`--audit` → continue to Step 2a. (Explicit flag = intentional AQ.)
 
 **2a. Scope:** Glob + Grep → files to create/modify + reference features for patterns.
 
-**2b. Tier:** S | F-lite | F-full per dev-process.md. ∃ `artifacts/frames/` ∧ `tier` field → use it. Else assess from σ complexity.
+**2b. Tier:** S | F-lite | F-full per dev-process.md. ∃ `artifacts/frames/` ∧ `tier` field → use it (silent). Else assess from σ complexity (silent). ¬AQ for tier at plan time — frame/dev already resolved it.
 
 **2c. Agents:**
 
@@ -103,16 +108,19 @@ Cost classes:
 | `judgmental` | 4–6 | read + context + judge + edit |
 | `exploratory` | 8–15 | open-ended cross-file search |
 
-Rules:
-1. **Per-task cap:** `estimated_total_ops > 50` for a task → **force-split** the task into smaller sub-tasks, or present a user choice **Split now** | **Keep as-is (flag)** decision before proceeding.
-2. **Per-instance cap:** after agent_instance assignment, aggregate ops per instance. `Σ ops/instance > 50` OR `|tasks/instance| > 4` OR `distinct subjects/instance > 2` → **force-split** into a new instance (`backend-dev-A` → `backend-dev-A` + `backend-dev-B`). This catches the case where each task is small but stacking 6 tasks on one agent overflows its context.
+Rules (auto — ¬AQ):
+1. **Per-task cap:** `estimated_total_ops > 50` → **force-split** into smaller sub-tasks. Note split in budget table. ¬ask Keep as-is.
+2. **Per-instance cap:** `Σ ops/instance > 50` OR `|tasks/instance| > 4` OR `distinct subjects/instance > 2` → **force-split** into a new instance. Note in budget table.
 
-**2e. Slice Selection (multi-slice only):** ≥2 slices → present multi-select 1 option/slice `V{N}: {desc} ({files}, {agents})`.
-Default: next unimplemented slice. Respect deps. Re-run `/plan` for remaining.
+**2e. Slice Selection (multi-slice only):**
 
-**2f. Present Plan:** → present choice τ, slices, files, agents, tasks with `[parallel-safe: Y/N]`.
-Options: **Approve** | **Modify** | **Cancel**
-**Approve → immediately continue to Step 3 (¬stop).**
+| Situation | Action |
+|-----------|--------|
+| 0–1 slice | use it. ¬AQ |
+| ≥2 slices ∧ clear next (deps order / first unimplemented) | auto-select that slice. Print `Planning slice V{N} (next unimplemented).` ¬AQ. Re-run `/plan` later for remaining. |
+| ≥2 slices ∧ no unique next (parallel roots, user previously mixed) | multi-select AQ: 1 option/slice `V{N}: {desc} ({files}, {agents})` |
+
+**2f. removed.** Mid-plan Approve/Modify/Cancel was a double-gate with Step 6. Pipeline continues to Step 3 without stopping. Summary for the user is deferred to Step 6 (sole approval).
 
 ## Step 3 — Ref Patterns
 
@@ -229,7 +237,7 @@ After the wave table, include a **Budget Table** derived from Step 2d classifica
 | tester-A | T9, T10 | 12 | auth | — |
 ```
 
-Tasks marked `YES — split required` (either table) must be resolved (split or DP-approved) before the plan is finalized. Per-instance fails dominate: a single agent loaded with too many distinct subjects must be split even if each individual task is small.
+Tasks marked `YES — split required` (either table) **must already be force-split** before write (Step 2d auto). Per-instance fails dominate: a single agent loaded with too many distinct subjects is split even if each individual task is small. ¬surface Keep-as-is AQ.
 
 Rules:
 - Wave 1 = all tasks with no deps.
@@ -273,9 +281,11 @@ Rules:
 - Tasks that chain sequentially on the same agent instance (T11→T12) still get separate rows.
 - Wave heading comment states the trigger condition so `/implement` knows when to start each wave.
 
-## Step 6 — Approve + Commit
+## Step 6 — Approve + Commit (sole plan gate)
 
-→ present choice complexity, τ, task count, agents, consistency, slices.
+**Single human gate for `/plan`.** Present once after π is written — not mid-pipeline.
+
+Present summary: complexity, τ, slices planned, task count, agents, consistency (covered/total), budget total ops, link to π path.
 Options: **Approve** | **Modify** | **Return to spec**
 
 On Approve → **immediately** continue to 6a (seed tasks), 6b (persist IDs), 6c (commit). ¬stop between substeps.
@@ -319,8 +329,8 @@ Read [references/edge-cases.md](${CLAUDE_SKILL_DIR}/references/edge-cases.md).
 
 1. ¬`git add -A` ∨ `git add .` — specific files only
 2. ¬create issue without user approval
-3. Always present plan (2f) before writing artifact
-4. Show full task list (¬truncate) when |tasks| > 30
+3. Always present plan **once at Step 6** before seed/commit (sole approval gate — ¬mid-plan 2f)
+4. Show full task list (¬truncate) when |tasks| > 30 — warn if > 30, continue (¬AQ; user can Modify at Step 6)
 
 ## Chain Position
 

--- a/plugins/dev-core/skills/plan/references/edge-cases.md
+++ b/plugins/dev-core/skills/plan/references/edge-cases.md
@@ -3,10 +3,11 @@
 | Scenario | Behavior |
 |----------|----------|
 | No spec found | Suggest `/spec` or `/dev`. Stop. |
-| Unresolved `[NEEDS CLARIFICATION]` | Pre-flight warns. User: resolve ∨ return to spec ∨ proceed |
+| Unresolved `[NEEDS CLARIFICATION]` | Pre-flight AQ: resolve ∨ return to spec ∨ proceed (real ambiguity) |
 | No Breadboard ∧ no Success Criteria | Skip micro-tasks, warn, use text tasks from Step 2d |
-| Task count > 30 | Warn, show full list, suggest splitting |
-| Multi-slice spec | Step 2e: select slices. Default 1/run. Re-run `/plan` for rest. |
+| Task count > 30 | Warn + full list; ¬AQ; Modify available at Step 6 |
+| Multi-slice spec | Step 2e: auto next unimplemented slice when unique; AQ only if no unique next. 1 slice/run default. Re-run `/plan` for rest. |
+| Mid-plan double approve | Forbidden — sole gate is Step 6 (2f removed) |
 | All slices implemented | Detect via code/tests. Suggest `/code-review`. |
 | Consistency 0 coverage | Block agents. Return to spec ∨ regenerate. |
 | Affordance > 5 min | Split into 2-3 sub-tasks |

--- a/plugins/dev-core/skills/plan/references/micro-tasks.md
+++ b/plugins/dev-core/skills/plan/references/micro-tasks.md
@@ -86,7 +86,7 @@ Partial (one of Breadboard/Slices ¬both): fallback if ∃ Success Criteria, els
 | F-lite | 5–15 | 2 |
 | F-full | 15–30 | 2 |
 
-\> 30 ⇒ → present choice: warn, suggest splitting. Show full list (¬truncate).
+\> 30 ⇒ warn + suggest splitting (print only). Show full list (¬truncate). ¬AQ — user can Modify at Step 6 sole gate.
 < 2 ⇒ warn, suggest text tasks from Step 2d.
 
 ## 4f.5 Consistency Check
@@ -147,12 +147,13 @@ generated: {ISO}
 
 ## 4f.7 Present for Approval
 
-→ present choice: complexity, τ, μ count, α, consistency, slices.
+Owned by **SKILL.md Step 6** (sole plan gate) — not a second mid-pipeline prompt.
+→ present choice once: complexity, τ, μ count, α, consistency, slices.
 Options: **Approve** | **Modify** | **Return to spec**
 
 ## 4f.8 Commit Plan
 
-Standalone commit (¬amend): `git add artifacts/plans/{N}-{slug}-plan.md` + commit per CLAUDE.md Rule 5.
+After Step 6 Approve only. Standalone commit (¬amend): `git add artifacts/plans/{N}-{slug}-plan.md` + commit per CLAUDE.md Rule 5.
 
 ## 4f.9 Dispatch TaskCreate
 

--- a/plugins/dev-core/skills/recheck/README.md
+++ b/plugins/dev-core/skills/recheck/README.md
@@ -16,9 +16,9 @@ The riskiest path is S-tier: `/dev` jumps straight from triage to implementation
 /recheck #N
 ```
 
-Called standalone, `/recheck` runs all three drift checks, then presents a 3-option decision prompt (Proceed | Close | Abort) if any signal fires.
+Called standalone, `/recheck` runs all three drift checks. **AQ only when signals are ambiguous** (`symbol-missing` and/or `dep-resolved`) — Proceed | Close | Abort. Pure `git-drift` is printed and auto-proceeds (no prompt).
 
-When invoked by `/dev` as part of the pipeline, the same checks run but the decision prompt includes a fourth option — **Update issue first** — which re-runs `/issue-triage` and then re-runs `/recheck` exactly once. If signals still fire on the second run, the Update option is removed and the user must choose a terminal outcome.
+When invoked by `/dev`, the same rules apply; the ambiguous DP adds **Update issue first** (re-runs `/issue-triage` then `/recheck` once). On the second run, Update is omitted.
 
 Triggers: `"recheck"` | `"is this issue still valid"` | `"check drift"` | `"check issue staleness"`
 
@@ -34,7 +34,9 @@ Three deterministic checks run in parallel (no LLM calls):
 
 When **all checks are clean**: prints `Issue still relevant.` (one line in pipeline mode; a richer summary with signal counts in standalone mode) and returns silently with no artifact written.
 
-When **any signal fires**: prints a `## Drift Signals` summary listing each signal kind and its evidence (commit SHAs, missing symbol names, closed blocker numbers), then presents a decision prompt:
+When **only git-drift fires** (informative): prints `## Drift Signals` + one proceed line — **no decision prompt**. Code moved nearby is expected; symbols still found and blockers still open (or none).
+
+When **ambiguous signals fire** (`symbol-missing` and/or `dep-resolved`): prints `## Drift Signals`, then presents a decision prompt:
 
 | Option | Pipeline | Standalone | Effect |
 |---|---|---|---|
@@ -54,6 +56,6 @@ No on-disk artifact (per frame Out-of-Scope). Session-only tracking inside `/dev
 `/recheck` only earns its place in the pipeline if it actually catches stale issues. The original frame defines two checkpoints:
 
 - **Success in 6 months:** at least one stale issue caught per month before `/implement` runs; zero S-tier issues silently re-implementing already-fixed bugs.
-- **Revisit trigger (3-month window):** if `/recheck` fires zero signals across three months of usage, **or** users skip past the prompt more than 80% of the time when signals fire, the cost-benefit no longer holds — re-open the design.
+- **Revisit trigger (3-month window):** if `/recheck` fires zero *ambiguous* signals across three months of usage, **or** users still override/close more often than they Proceed when the DP fires, re-open the design (git-drift-only auto-proceed is expected and not counted as skip friction).
 
 Tracking is **manual**: no metric is written to disk by design (no recheck-log artifact). Operators should periodically grep recent `/dev` runs for "Drift Signals" appearances and note skip-rate informally. If the revisit trigger fires, open an issue to re-evaluate.

--- a/plugins/dev-core/skills/recheck/SKILL.md
+++ b/plugins/dev-core/skills/recheck/SKILL.md
@@ -2,7 +2,7 @@
 name: recheck
 argument-hint: '[#N | --issue N]'
 description: Drift-check an issue before work begins — fails fast when code has evolved (git-drift, symbol-missing, dep-resolved). Triggers: "recheck" | "is this issue still valid" | "check drift" | "check issue staleness".
-version: 0.1.0
+version: 0.2.0
 allowed-tools: Bash, Read, Grep, Glob, Skill, ToolSearch
 ---
 
@@ -10,22 +10,23 @@ allowed-tools: Bash, Read, Grep, Glob, Skill, ToolSearch
 
 ## Success
 
-I := signals computed ∧ (¬signals → silent return) ∨ (signals → DP A presented)
+I := signals computed ∧ (S == ∅ ∨ informative → auto-proceed) ∨ (S ambiguous → DP presented)
 
 Let:
   N  := issue number
   S  := signal set { git-drift, symbol-missing, dep-resolved }
   M  := mode ∈ { pipeline, standalone }
-  
+  ambiguous(S) ≔ S contains `symbol-missing` ∨ `dep-resolved`
+  informative(S) ≔ S ≠ ∅ ∧ ¬ambiguous(S)   # git-drift only
 
-Drift-check N against 3 deterministic signals (no LLM); block pipeline via user choice when S ≠ ∅.
+Drift-check N against 3 deterministic signals (no LLM). **AQ only when signals are ambiguous** (missing symbols / closed blockers). Pure git-drift is informational — print and auto-proceed.
 Standalone-safe: callable without `/dev`. Invoked by `/dev` between `triage` and `frame`.
 
 ## Entry
 
 ```
-/recheck #N            standalone — signal-fire DP has 3 options (Proceed | Close | Abort)
-(invoked by /dev)      pipeline  — signal-fire DP has 4 options (adds Update issue first)
+/recheck #N            standalone — DP only if ambiguous signals (Proceed | Close | Abort)
+(invoked by /dev)      pipeline  — same; DP adds Update issue first when ambiguous
 ```
 
 ## Pipeline
@@ -36,7 +37,7 @@ Standalone-safe: callable without `/dev`. Invoked by `/dev` between `triage` and
 | 1    | fetch   | ✓        | `gh issue view N --json number,title,body,labels,createdAt` |
 | 2    | extract | ✓        | cited paths, symbols, blocked-by numbers from body |
 | 3    | check   | ✓        | run 3 drift checks (parallel, deterministic)   |
-| 4    | decide  | ✓        | S == ∅ → silent return ; S ≠ ∅ → present choice        |
+| 4    | decide  | ✓        | S==∅ silent; informative auto-proceed; ambiguous → AQ |
 
 ## Step 0 — Parse + Detect Mode
 
@@ -136,6 +137,16 @@ API failures (auth, network, rate-limit, repo-not-found) are surfaced as warning
 
 ## Step 4 — Decide
 
+### Severity split (before any AQ)
+
+| Class | Condition | Action |
+|-------|-----------|--------|
+| clean | S == ∅ | silent return (below) |
+| informative | S ≠ ∅ ∧ kinds ⊆ {git-drift} | print signals + **auto-proceed** — ¬AQ |
+| ambiguous | ∃ kind ∈ {symbol-missing, dep-resolved} | print signals + **present choice** |
+
+Rationale: git-drift alone means “code moved nearby” — issue still open, symbols found, blockers still open (or none). Default path is always Proceed; asking is pure friction. symbol-missing / dep-resolved can mean the issue is moot or needs rewrite → real decision.
+
 ### S == ∅ (no signals)
 
 - **Pipeline mode (M == pipeline):**
@@ -150,7 +161,17 @@ API failures (auth, network, rate-limit, repo-not-found) are surfaced as warning
   ```
   Exit 0.
 
-### S ≠ ∅ (signals fired)
+### informative (git-drift only — auto-proceed)
+
+Render `## Drift Signals` block (same table as below), then print exactly one line and return exit 0:
+
+```
+Drift noted (git-drift only) — proceeding. Re-run /recheck or update the issue if scope looks stale.
+```
+
+¬AQ. Pipeline and standalone share this path. `/dev` continues to next step.
+
+### ambiguous (symbol-missing and/or dep-resolved — AQ)
 
 Render `## Drift Signals` block:
 
@@ -164,13 +185,15 @@ Render `## Drift Signals` block:
 | dep-resolved   | blocker #179 is now closed           | #179                 |
 ```
 
+(Include any co-occurring git-drift rows for context.)
+
 Then present user choice:
 
 **Pipeline DP (4 options — M == pipeline ∧ ¬--update-iter=2):**
 
 ```
-── Decision: Issue #N drift detected ──
-Context:     <signal count> signal(s) fired (see ## Drift Signals above)
+── Decision: Issue #N ambiguous drift ──
+Context:     symbol-missing and/or dep-resolved (see ## Drift Signals above)
 Target:      decide whether to continue, update, close, or abort
 Path:        executed immediately after choice
 
@@ -179,7 +202,7 @@ Options:
   2. Update issue first    — re-invoke /issue-triage, then re-run /recheck once
   3. Close as resolved/obsolete — gh issue close N --reason completed ; abort /dev
   4. Abort                 — exit /dev cleanly, no mutation
-Recommended: Option 1 or 2 — depends on signal severity
+Recommended: Option 2 if symbols/blockers suggest rewrite; Option 3 if issue is moot
 ```
 
 **Pipeline DP on 2nd run (M == pipeline ∧ --update-iter=2):**
@@ -188,8 +211,8 @@ Same block, but Option 2 (Update issue first) is OMITTED. Forces terminal decisi
 **Standalone DP (3 options — M == standalone):**
 
 ```
-── Decision: Issue #N drift detected ──
-Context:     <signal count> signal(s) fired (see ## Drift Signals above)
+── Decision: Issue #N ambiguous drift ──
+Context:     symbol-missing and/or dep-resolved (see ## Drift Signals above)
 Target:      decide whether to continue, close, or abort
 Path:        executed immediately after choice
 
@@ -197,7 +220,7 @@ Options:
   1. Proceed    — continue with current premise
   2. Close as resolved/obsolete — gh issue close N --reason completed
   3. Abort      — exit cleanly, no mutation
-Recommended: Option 1 or 3 — depends on signal severity
+Recommended: Option 2 if issue is moot; Option 1 if premise still holds
 ```
 
 ## DP Outcomes — Implementation
@@ -213,10 +236,10 @@ Recommended: Option 1 or 3 — depends on signal severity
 
 No on-disk artifact. `/dev` tracks recheck as Σ_s (session-only) like `validate`, `ci-watch`. Re-running `/dev #N` in a new session re-runs `/recheck` — acceptable: deterministic checks are cheap and fresh state is more valuable than skip-on-resume.
 
-`RecheckResult` is ephemeral — built during execution, consumed by user choice prompt, then discarded:
+`RecheckResult` is ephemeral — built during execution, consumed by decide step, then discarded:
 - `issue_number: int`
 - `signals: Signal[]` — empty on clean path; `Signal` = { `kind`, `description`, `evidence[]` }
-- `blocking: bool` — `true` iff `signals` non-empty
+- `blocking: bool` — `true` iff `ambiguous(signals)` (symbol-missing ∨ dep-resolved). git-drift-only → `blocking: false`
 
 ## Task Integration
 
@@ -236,12 +259,14 @@ No on-disk artifact. `/dev` tracks recheck as Σ_s (session-only) like `validate
 | Path                              | Effect                                                                 |
 |-----------------------------------|------------------------------------------------------------------------|
 | Via `/dev` — clean                | Print `Issue still relevant.` → return silently → `/dev` continues     |
-| Via `/dev` — Proceed on signals   | Return exit 0 → `/dev` re-scans → next step                           |
+| Via `/dev` — informative          | Print drift table + proceed line → exit 0 → `/dev` continues           |
+| Via `/dev` — Proceed on ambiguous | Return exit 0 → `/dev` re-scans → next step                           |
 | Via `/dev` — Update issue first   | Invoke `issue-triage` → re-run self once (`--update-iter=2`)          |
 | Via `/dev` — Close                | `gh issue close N` → exit with abort signal → `/dev` marks cancelled  |
 | Via `/dev` — Abort                | Exit cleanly, no mutation → `/dev` halts                              |
 | Standalone — clean                | Print richer summary (counts per check) → exit 0                      |
-| Standalone — signal               | Render `## Drift Signals` + 3-option DP → apply outcome               |
+| Standalone — informative          | Print drift table + proceed line → exit 0                              |
+| Standalone — ambiguous            | Render `## Drift Signals` + 3-option DP → apply outcome               |
 
 ## Edge Cases
 

--- a/plugins/dev-core/skills/spec/README.md
+++ b/plugins/dev-core/skills/spec/README.md
@@ -12,19 +12,21 @@ A spec translates the chosen architectural shape into something implementable: b
 /spec --issue 42            Generate spec from analysis for issue #42
 /spec --analysis path       Use an explicit analysis file as source
 /spec --frame path          Use a frame directly (analysis was skipped)
-/spec --issue 42 --audit    Show reasoning checkpoint before writing
+/spec --issue 42 --audit    Show reasoning checkpoint (prose) then write
 ```
 
 Triggers: `"write spec"` | `"spec this"` | `"solution design"` | `"acceptance criteria"` | `"define acceptance criteria"`
 
 ## How it works
 
-1. **Resolve source** — finds the analysis (or frame if F-lite) for the issue.
-2. **Generate** — runs a structured interview (via `/interview`) to fill gaps between analysis and spec level: acceptance criteria, breadboard, slices, ambiguity detection.
-3. **Pre-check** — validates the spec before expert review: testable criteria (binary pass/fail), no dangling breadboard refs, ≤5 `[NEEDS CLARIFICATION]` items, slice coverage of all affordances.
-4. **Expert review** — spawns architect, doc-writer, product-lead, adversarial (and devops if infra criteria) in parallel.
-5. **Smart splitting** (optional) — if > 8 acceptance criteria or > 3 slices, offers to split into sub-issues.
-6. **User approval** — presents scope, criteria count, unresolved concerns; loops on revisions.
+**No AskUserQuestion.** Human-in-the-loop is chat-native: full draft → **Executive Summary** → free-form reply.
+
+1. **Resolve source** — analysis (or frame if F-lite); stop with prose if missing.
+2. **Generate** — promote SRC → σ without interactive `/interview` AQs; unknowns become `[NEEDS CLARIFICATION]`.
+3. **Pre-check** — binary criteria, breadboard refs, χ budget, slice coverage; auto-fix cheap issues.
+4. **Expert review** — architect, doc-writer, product-lead, adversarial (devops/axial when relevant) in parallel.
+5. **Executive Summary** — one-liner, scope, users, slices, criteria, χ, pre-check, expert notes — then **stop**.
+6. **React** — natural language: approve · change X · questions · re-spec · split. Revise loops re-print the summary.
 
 ## Output artifact
 
@@ -36,4 +38,4 @@ Sections: Context, Goal, Users, Expected Behavior, Data Model & Consumers (markd
 
 ## Chain position
 
-**Predecessor:** `/analyze` (F-full) or `/frame` (F-lite) | **Successor:** `/plan`
+**Predecessor:** `/analyze` (F-full) or `/frame` (F-lite) | **Successor:** `/plan` (after free-form approve)

--- a/plugins/dev-core/skills/spec/SKILL.md
+++ b/plugins/dev-core/skills/spec/SKILL.md
@@ -2,7 +2,7 @@
 name: spec
 argument-hint: '[--issue <N> | --analysis <path> | --frame <path> | --audit]'
 description: Solution spec — acceptance criteria, breadboard, slices. Triggers: "write spec" | "spec this" | "solution design" | "what will we build" | "design the solution" | "acceptance criteria" | "define acceptance criteria" | "spec it out" | "write the spec".
-version: 0.2.1
+version: 0.3.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, Skill, ToolSearch
 ---
 
@@ -10,8 +10,8 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, Skill, ToolSearch
 
 ## Success
 
-I := σ written ∧ pre-check pass ∧ |χ| ≤ 5
-V := `ls artifacts/specs/{N}-*.md*` ∧ pre-check: 0 failures
+I := σ written ∧ pre-check reported ∧ executive summary shown ∧ (approved → committed)
+V := `ls artifacts/specs/{N}-*.md*` ∧ (on approve) `status: approved` ∧ commit ∃
 
 Let:
   α := artifacts/analyses/{N}-{slug}-analysis.md
@@ -19,12 +19,22 @@ Let:
   φ := artifacts/frames/{slug}-frame.md
   ρ := reviewer set
   χ := `[NEEDS CLARIFICATION]`
-  Ω := `skill: "interview"`
-  Q := present choice, wait for user reply
   SRC := source doc (α ∨ φ)
 
-Analysis (or frame) → approved spec. Interview → pre-check → expert review → user approval.
+Analysis (or frame) → draft σ → **executive summary in chat** → free-form human reaction → approve/revise.
 ¬worktree, ¬PR. Shape phase only. Implementation → `/plan`.
+
+## Hard ban — AskUserQuestion
+
+**Never call AskUserQuestion / `present choice` / multi-select tool prompts in this skill.**
+
+Human-in-the-loop is **chat-native**:
+1. Produce the work.
+2. Print a clear **Executive Summary**.
+3. **Stop this turn** and wait for the user's free-form reply.
+4. Interpret natural language (approve / change X / question / re-spec) and act.
+
+No button menus. No forced option lists. If something is missing, write it into the summary or as χ — do not quiz via AQ.
 
 ## Entry
 
@@ -32,26 +42,28 @@ Analysis (or frame) → approved spec. Interview → pre-check → expert review
 /spec --issue N          → find analysis for #N (or frame if analysis skipped)
 /spec --analysis path    → use provided analysis as source
 /spec --frame path       → use provided frame (analysis was skipped)
+/spec --issue N --audit  → print reasoning audit as prose, then continue (¬AQ)
 ```
 
 ## Pipeline
 
 | Step | ID | Required | Verifies via | Notes |
 |------|----|----------|---------------|-------|
-| 0 | resolve | ✓ | SRC ∃ | — |
-| 1 | scan | — | σ ∃? | — |
-| 1b | audit | — | — | `--audit` only |
-| 2 | generate | ✓ | σ written | Ω interview |
-| 3 | pre-check | ✓ | 0 failures | — |
-| 4 | review | — | agents return | ∥ spawn |
-| 5 | approval | ✓ | `git log` shows commit | gate |
+| 0 | resolve | ✓ | SRC ∃ | prose stop if missing |
+| 1 | scan | — | σ ∃? | auto path — ¬AQ |
+| 1b | audit | — | — | `--audit` only; prose, ¬AQ |
+| 2 | generate | ✓ | σ written | from SRC; ¬interactive interview |
+| 3 | pre-check | ✓ | report printed | auto-fix when cheap; else note in summary |
+| 4 | review | — | agents return | ∥ spawn; auto-select ρ |
+| 5 | summary | ✓ | exec summary shown | **stop turn** — wait for chat |
+| 6 | react | ✓ | free-form | approve → commit; else revise loop |
 
 ## Pre-flight
 
-Success: σ written ∧ pre-check pass ∧ |χ| ≤ 5
-Evidence: `ls artifacts/specs/` ∧ pre-check output
-Steps: resolve → generate → pre-check → review → approval
-¬clear → STOP + ask: "What artifact should this spec derive from?"
+Success: σ written ∧ executive summary shown ∧ (on approve) committed
+Evidence: `ls artifacts/specs/` + chat summary + optional commit
+Steps: resolve → generate → pre-check → review → executive summary → chat react
+¬clear → STOP with prose: "What artifact should this spec derive from? Pass `--analysis` / `--frame` / `--issue`."
 
 ## Step 0 — Resolve Input + Ensure GitHub Issue
 
@@ -66,44 +78,53 @@ grep -rl "issue: N" artifacts/frames/ 2>/dev/null | head -1
 ```
 
 `--analysis path` / `--frame path` → read directly.
-¬SRC found → Q: "Run `/analyze --issue N` first, or provide path directly?"
+¬SRC found → **stop** with prose (not AQ):
+```
+No analysis/frame found for #{N}.
+Run /analyze --issue N (or /frame), or re-run with --analysis <path> / --frame <path>.
+```
 
 Read SRC → extract: title, issue#, tier, problem, outcome, appetite, recommended shape (if α).
 
 ### 0b. Ensure GitHub Issue
 
 ∃ issue (`--issue N` ∨ found in SRC frontmatter) → use it.
-¬∃ issue → draft from SRC:
+¬∃ issue → create from SRC (auto — no ask):
 
 ```bash
 gh issue create --title "<title>" --body "<body>"
 # body: ## Problem\n{problem}\n\n## Outcome\n{outcome}
 ```
 
-Capture returned issue #N.
+Capture returned issue #N. Print one line: `Created issue #N.`
 
 ## Step 1 — Scan Existing Spec
 
 Glob `artifacts/specs/{N}-*`, `artifacts/specs/*{slug}*`.
-∃ σ → Q: **Reuse existing** (→ Step 3) | **Start fresh**
+
+| State | Action |
+|-------|--------|
+| ∃ σ ∧ `status: approved` | **Reuse.** Print short note + full **Executive Summary** of existing σ → Step 5/6 (chat: approve to keep & continue pipeline, or "re-spec" / changes). ¬regenerate unless user asks. |
+| ∃ σ ∧ draft / no status | Load as base → Step 2 refine (fill gaps, re-check) |
+| ¬∃ σ | Step 2 generate fresh |
 
 ## Step 1b — Reasoning Audit (optional)
 
-`--audit` → after reading SRC, present reasoning audit per [reasoning-audit.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/reasoning-audit.md) (spec guidance).
-→ Q: **Proceed** | **Adjust approach** | **Abort**
+`--audit` → print reasoning audit per [reasoning-audit.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/reasoning-audit.md) as **prose in chat**. Continue to Step 2. ¬AQ Proceed/Adjust/Abort — user can interrupt in the next turn if they disagree.
+
 ¬`--audit` → skip to Step 2.
 
 ## Step 2 — Generate Spec
 
-`Ω, args: "--promote artifacts/analyses/{N}-{slug}-analysis.md"` (or frame path if no α).
+**¬invoke interactive `/interview`.** Promote SRC → σ in this skill: pre-fill everything clear from SRC; mark unknowns as χ (max 3–5). Use the 9-category ambiguity taxonomy from interview as a silent checklist (Functional Scope, Domain & Data, UX, NFR, Integrations, Edge Cases, Constraints, Terminology, Completion Signals) — do not fire interview AQs.
 
-Interview pre-fills from SRC. Focus on gaps to spec level:
+Focus content:
 - Acceptance criteria (binary pass/fail)
 - Breadboard: affordance tables (UI/API elements → handlers → data)
 - Slices: vertical increments, independently demo-able
-- Ambiguity detection via 9-category taxonomy (see interview SKILL.md)
+- χ only where SRC is truly silent
 
-Write σ. Must include:
+Write σ with `status: draft`. Must include:
 
 | Section | Skip if |
 |---------|---------|
@@ -126,7 +147,7 @@ Include when data shape matters:
 
 Section sits before Breadboard: shape of data vs how pieces wire together.
 
-May contain χ (max 3–5). χ items block `/plan` — must be resolved first.
+May contain χ (max 3–5). χ items block `/plan` — must be resolved before plan (via chat revise, not AQ).
 
 ## Step 3 — Pre-check
 
@@ -140,14 +161,9 @@ May contain χ (max 3–5). χ items block `/plan` — must be resolved first.
 | Slice coverage | Every affordance appears in ≥1 slice | ¬Breadboard ∨ ¬Slices |
 | Edge completeness | Each edge case has handling strategy | — |
 
-≥2 failures → inform user:
-```
-Pre-check: 2 of 5 checks failed
-  ✗ Testable criteria: "The UI should feel fast" is not binary
-  ✗ Ambiguity budget: 7 [NEEDS CLARIFICATION] items found (max 5)
-```
+**Auto-fix** cheap failures when obvious (rephrase non-binary criteria into binary, add missing slice rows for orphan IDs). Re-run checks once after auto-fix.
 
-Q: **Fix spec first** (open σ, collect corrections, revise, re-check) | **Continue to review anyway**
+Remaining failures → list in Executive Summary under **Pre-check** (do not AQ Fix/Continue). Prefer fixing over shipping a broken draft when the fix is unambiguous.
 
 ## Step 4 — Expert Review
 
@@ -162,7 +178,7 @@ Auto-select ρ (¬ask user). Architect always included:
 | devops | ∃ CI/CD / deploy / infra criteria | Operational feasibility |
 | axial-adr-review | ∃ axial ADR (`axial: true` ∈ `docs/architecture/adr/`) ∧ (spec adds adapter/integration/target ∨ touches `infrastructure/`) | Drift along non-primary axis (N×M trap) — read-only review |
 
-> **Note on axial-adr-review asymmetry (intentional):** The `/spec` condition is **semantic/intent-based** — it triggers when the spec proposes adding a new adapter/integration/target or touches `infrastructure/`. The code-review phase (`/code-review`) uses a **structural** condition (diff touches `infrastructure/`, `adapters/`, `domains/`, or `stages/`). The two are complementary: `/spec` catches intent-level N×M violations, `/code-review` catches implementation-level ones. A spec that adds infrastructure/ changes without proposing a new adapter is not a spec-level axial concern but may still be caught at code-review. See `plugins/shared/references/axial-decomposition.md`.
+> **Note on axial-adr-review asymmetry (intentional):** The `/spec` condition is **semantic/intent-based** — it triggers when the spec proposes adding a new adapter/integration/target or touches `infrastructure/`. The code-review phase (`/code-review`) uses a **structural** condition (diff touches `infrastructure/`, `adapters/`, `domains/`, or `stages/`). The two are complementary: `/spec` catches intent-level N×M violations, `/code-review` catches implementation-level ones. See `plugins/shared/references/axial-decomposition.md`.
 
 ∀ r ∈ ρ → spawn ∥:
 ```
@@ -174,57 +190,124 @@ Task(
 ```
 Agent name map: `architect` → `dev-core:architect` | `doc-writer` → `dev-core:doc-writer` | `product-lead` → `dev-core:product-lead` | `adversarial` → `dev-core:adversarial` | `devops` → `dev-core:devops` | `axial-adr-review` → `dev-core:axial-adr-review`
 
-Incorporate feedback → revise σ → note unresolved concerns.
+Incorporate high-confidence feedback into σ. Unresolved expert concerns → list in Executive Summary (not AQ).
 
-## Step 5 — User Approval
+## Step 5 — Executive Summary (always)
 
-Open σ: `code artifacts/specs/{N}-{slug}-spec.md`.
+Open σ for the user: `code artifacts/specs/{N}-{slug}-spec.md` (or print path if `code` unavailable).
 
-Present summary: scope, |slices|, |acceptance criteria|, |χ|, pre-check results, unresolved expert concerns.
+Print **exactly this structure** (fill from σ + Steps 3–4). This is the HITL surface — keep it scannable, not a paste of the whole file:
 
-Q: **Approve** → continue pipeline | **Revise** → collect feedback → revise σ → loop from Step 3.
+```markdown
+## Spec — Executive Summary
 
-On approval → commit: `git add artifacts/specs/{N}-{slug}-spec.md` + commit per CLAUDE.md Rule 5.
+**Issue:** #{N} — {title}
+**Path:** `artifacts/specs/{N}-{slug}-spec.md`
+**Tier:** {τ} · **Status:** draft
+**Source:** {α|φ path}
 
-Run Gate 2.5 → update issue status:
+### One-liner
+{Goal — one sentence}
+
+### Scope
+- **In:** {3–6 bullets from Goal / Expected Behavior / Slices}
+- **Out:** {from Context / explicit non-goals, or "—"}
+
+### Users
+{Primary (+ secondary if any) — one line each}
+
+### Slices
+| # | Slice | Demo value |
+|---|-------|------------|
+| V1 | … | … |
+| V2 | … | … |
+
+(or "— (Tier S / no slices)" )
+
+### Success criteria ({count})
+1. …
+2. …
+(list all binary criteria; if >12, list first 10 + "… +{n} more in file")
+
+### Open / χ ({count})
+- {each NEEDS CLARIFICATION, or "none"}
+
+### Pre-check
+{pass | N failed — bullets}
+
+### Expert notes
+{0–5 bullets of unresolved concerns, or "clean"}
+
+### Data model
+{1–3 lines from §Data Model & Consumers, or "—"}
+
+---
+**Your move (free text — no menu):**
+- approve / ok / ship → commit & mark approved
+- change … / drop slice V2 / tighten criterion 3 → I revise σ and re-print this summary
+- question … → I answer; revise only if you ask
+- re-spec → regenerate from SRC
+- split → propose smart-split (if criteria/slices large)
+```
+
+**STOP this turn** after printing the summary. Do not commit. Do not invoke `/plan`. Do not AskUserQuestion.
+
+## Step 6 — React (free-form chat)
+
+On the user's next message, interpret intent (no AQ):
+
+| Intent signals (examples) | Action |
+|---------------------------|--------|
+| approve, ok, LGTM, ship, good, go, looks good, approved | → **Approve path** |
+| change / revise / drop / add / tighten / rewrite … | Edit σ → re-run cheap pre-check → re-print Executive Summary → **stop again** |
+| question / why / what about / clarify … | Answer in chat; revise σ only if they also request a change |
+| re-spec / start over / regenerate | Wipe draft content, re-run from Step 2 |
+| split / sub-issues | Run Gate 2.5 proposal **as prose** in chat; create only if they confirm in free text |
+| abort / stop / cancel | Stop; leave draft on disk; return cancel to `/dev` if applicable |
+
+Ambiguous free text → ask **one short prose clarifying question** in the message (plain text). Still ¬AskUserQuestion.
+
+### Approve path
+
+1. Set frontmatter `status: approved` via Edit.
+2. Commit: `git add artifacts/specs/{N}-{slug}-spec.md` + commit per CLAUDE.md Rule 5.
+3. Run Gate 2.5 only if triggers fire **and** user already said "split" — otherwise skip (do not force-split).
+4. Update issue status:
 ```bash
 bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts set <N> --status Specs
 ```
+5. Exit per Exit section.
 
-∄ sub-issues → "Spec complete. Run `/plan --issue <N>` to generate the implementation plan."
-∃ sub-issues → "Run `/plan --issue <sub_N>` for each sub-issue in dependency order."
-
-## Gate 2.5: Smart Splitting (Optional)
+## Gate 2.5: Smart Splitting (optional, chat-only)
 
 Tier S → skip. Read [references/smart-splitting.md](${CLAUDE_SKILL_DIR}/references/smart-splitting.md).
 
 **Triggers:** |acceptance criteria| > 8 ∨ |slices| > 3.
-- Acceptance criteria := `- [ ]` checkboxes in `## Success Criteria`
-- Slices := rows in `## Slices` table
 
-¬triggers ∧ ¬both sections present → skip.
-∃ triggers → run smart splitting per reference doc.
+On trigger at approve time: **mention once** in the post-approve message as optional next step ("Say 'split' if you want sub-issues"). ¬auto-create. ¬AQ menu.
+
+When user says split: present proposal as prose table → wait free-form confirm → then create. See smart-splitting.md (chat mode).
 
 ## Edge Cases
 
 | Scenario | Behavior |
 |----------|----------|
-| ¬α ∧ ¬φ found | Q: run `/analyze` first or provide path |
-| ∃ σ, user picks reuse | Present existing → jump to Step 3 |
-| Analysis skipped (F-lite) | Use frame as SRC for interview promotion |
-| `--issue N` ∧ ¬GitHub issue | Create issue from SRC content |
-| Expert subagent fails | Report error, continue without that reviewer |
-| All pre-checks fail | Strongly recommend fix before review (¬block, user decides) |
-| |χ| > 5 | Pre-check failure — inform, request reduction |
+| ¬α ∧ ¬φ found | Prose stop + how to provide SRC |
+| ∃ approved σ | Reuse + exec summary; re-spec on request |
+| Analysis skipped (F-lite) | Use frame as SRC |
+| `--issue N` ∧ ¬GitHub issue | Create issue from SRC (auto) |
+| Expert subagent fails | Report in Expert notes; continue |
+| Pre-check still failing | List in summary; user can still approve (warn) or request fixes |
+| \|χ\| > 5 | Reduce during generate; leftover listed in summary |
 | Tier S | Skip Breadboard + Slices |
-| Circular deps in split | Reject split proposal, inform user |
+| Circular deps in split | Reject split proposal in prose |
 
 ## Chain Position
 
 - **Phase:** Shape
 - **Predecessor:** `/analyze` (F-full) ∨ `/frame` (F-lite, analyze skipped)
 - **Successor:** `/plan`
-- **Class:** gate (user approval of spec artifact required)
+- **Class:** gate — **chat executive summary**, not AskUserQuestion
 
 ## Task Integration
 
@@ -234,9 +317,10 @@ Tier S → skip. Read [references/smart-splitting.md](${CLAUDE_SKILL_DIR}/refere
 
 ## Exit
 
-- **Approved via `/dev`:** write artifact with `status: approved`, commit, return silently. ¬ask "proceed to /plan?". `/dev` re-scans and auto-chains to `/plan` in the same turn.
+- **While waiting for reaction:** turn ends after Executive Summary. Task stays in progress from `/dev`'s POV until approve/abort.
+- **Approved via `/dev`:** commit, return silently. ¬ask "proceed to /plan?" via AQ. `/dev` re-scans and auto-chains to `/plan` in the same turn **after** the approve message is processed.
 - **Approved standalone:** print one line: `Approved. Next: /plan --issue N`. Stop.
-- **Modify requested:** loop in-skill, re-present.
-- **Rejected/aborted:** return → `/dev` marks task `cancelled`.
+- **Revise loop:** re-print Executive Summary after each edit; stop again.
+- **Abort:** return → `/dev` marks task `cancelled`.
 
 $ARGUMENTS

--- a/plugins/dev-core/skills/spec/references/smart-splitting.md
+++ b/plugins/dev-core/skills/spec/references/smart-splitting.md
@@ -2,7 +2,7 @@
 
 Let: N := parent issue number | τ := tier
 
-After Gate 2 approval. Decomposes feature → sub-issues. Always optional — user can skip.
+After spec approve (optional). Decomposes feature → sub-issues. Always optional — user opts in via free-form chat ("split"). **¬AskUserQuestion.**
 
 ## Pre-checks
 
@@ -13,7 +13,7 @@ After Gate 2 approval. Decomposes feature → sub-issues. Always optional — us
 gh api graphql -f query='{ repository(owner: "{owner}", name: "{repo}") { issue(number: {N}) { subIssues(first: 10) { nodes { number title state } } } } }'
 ```
 
-∃ sub-issues ⇒ → present choice: Keep existing | Replace (close old) | Add additional
+∃ sub-issues ⇒ print them as prose. Ask in free text whether to keep / replace / add — interpret next message (no tool menu).
 
 ## Trigger Detection
 
@@ -22,7 +22,7 @@ Read spec, count:
 - Slices: rows in `## Slices` table
 
 **Trigger:** criteria > 8 ∨ slices > 3.
-¬trigger ∨ ¬(criteria ∧ slices sections) ⇒ skip.
+¬trigger ∨ ¬(criteria ∧ slices sections) ⇒ skip (unless user explicitly said "split").
 
 ## Propose Sub-Issues
 
@@ -42,17 +42,21 @@ Split heuristics (priority order):
 | Size | XS/S/M/L/XL from τ |
 | Priority | Inherit parent ∨ default Medium |
 
-Present via user choice:
+Present as **prose table** (chat), then stop:
 
 ```
-Smart Split: {title}
-Parent: #{N} | Trigger: {criteria}/{slices}/{phases}
+## Smart Split proposal — #{N} {title}
+Trigger: {criteria} criteria / {slices} slices
 
-  1. {title} — {scope} [Size: {S/M/L}] Deps: none
-  2. {title} — {scope} [Size: {S/M/L}] Deps: #1
+| # | Title | Scope | Size | Deps |
+|---|-------|-------|------|------|
+| 1 | … | … | S/M/L | none |
+| 2 | … | … | S/M/L | #1 |
+
+Reply free text: create / adjust … / skip
 ```
 
-Options: **Approve** | **Adjust** (re-propose) | **Skip** (no split)
+¬tool menus. Create only after free-form confirm.
 
 ## Create Sub-Issues
 
@@ -112,6 +116,6 @@ Inform: "Created {N} sub-issues under #{parent}. Run `/dev #N` for each sub-issu
 |----------|----------|
 | Only 1 sub-issue | Skip — no value |
 | Circular deps | Reject split, inform user |
-| Partial creation failure | Report success/fail, ask: Retry ∨ Continue partial |
-| Spec revised after split | Warn stale, offer re-run Gate 2.5 |
-| All criteria tightly coupled | Recommend "Skip" |
+| Partial creation failure | Report success/fail in prose; wait free-form retry/continue |
+| Spec revised after split | Warn stale in prose; re-run Gate 2.5 on request |
+| All criteria tightly coupled | Recommend skip in prose |


### PR DESCRIPTION
## Summary

- **recheck / frame / plan**: auto-advance when unambiguous; keep AQ only for real ambiguity
- **/spec**: ban AskUserQuestion; draft → **Executive Summary** → free-form chat approve/revise (intent)
- **/dev**: silent tier from labels; no pre-gate AQ before `/frame`; chat gate for `/spec`; **draft specs ≠ done** (`status ≠ draft`)
- Rebased on `main` after #399 (worktree dual-harness) + #400 (Data Model **markdown only** — no HTML sidecars)
- Bump `dev-core` **0.10.4**, `spec` skill **0.3.0**

## Test plan

- [ ] `/recheck` with git-drift only → proceeds without menu
- [ ] `/recheck` with symbol-missing or dep-resolved → still DP
- [ ] `/frame --issue N` with rich issue + size label → minimal/no AQ, auto-approve when gaps=0
- [ ] `/plan` → single approve at end (no mid-plan 2f)
- [ ] `/spec` → exec summary, no AskUserQuestion; free-text "approve" commits; **no** data-model HTML sidecars
- [ ] `/dev #N` F-lite path does not double-prompt tier/frame; mid-draft σ does not skip to `/plan`