### PR TITLE
feat(dev-core): dual-harness worktree + draft CI skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
 
 jobs:
   ci:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-core",
-  "version": "0.10.1",
-  "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. adversarial), dual-harness task list, safety hooks (Claude + Grok).",
+  "version": "0.10.2",
+  "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. adversarial), dual-harness task list + worktrees, safety hooks (Claude + Grok).",
   "author": {
     "name": "Roxabi"
   }

--- a/plugins/dev-core/references/dev-process.md
+++ b/plugins/dev-core/references/dev-process.md
@@ -43,11 +43,20 @@ Artifacts = state markers for `/dev` progress detection + resumption.
 
 ### Worktree
 
-`/dev` bootstraps the worktree automatically before `frame` (Step 7 silent pre-step via `/setup-worktree`). All tiers (S, F-lite, F-full) execute inside a worktree.
+`/dev` bootstraps the worktree automatically before `frame` (Step 7 silent pre-step via `/setup-worktree`). All tiers (S, F-lite, F-full) execute **code** inside a non-principal worktree on `feat/{N}-{slug}`.
+
+**Invariants** (SSoT: `skills/shared/references/harness-worktree.md`):
+
+- **Principal** (default folder) stays on β (`staging` \| `main`) — never `git switch feat/…` there
+- **Branch + issue link** = dev-core (`gh issue develop` → `feat/{N}-{slug}`)
+- **Path layout** = harness (Claude: `.claude/worktrees/…` + EnterWorktree; Grok: `~/.grok/worktrees/…` or existing session ω)
 
 ```bash
-git worktree add .claude/worktrees/XXX-slug -b feat/XXX-slug origin/staging
-cd .claude/worktrees/XXX-slug && cp .env.example .env && bun install
+# Identity (always)
+gh issue develop N --base "$BASE" --name "feat/N-slug"
+# Placement (H_wt-specific — do not hardcode only Claude path)
+git worktree add <ω-path> "feat/N-slug"   # principal unchanged
+cd <ω-path> && cp .env.example .env && bun install
 ```
 
 **Exceptions:** `/promote` release artifacts.

--- a/plugins/dev-core/skills/analyze/SKILL.md
+++ b/plugins/dev-core/skills/analyze/SKILL.md
@@ -177,11 +177,15 @@ Skip if ¬technical uncertainty in Step 2 findings.
 
 ∃ signals → present choice **Spike now** (throwaway worktree, test hypothesis) | **Skip** (→ expert review).
 
-**Spike flow:**
-1. `EnterWorktree(name: "spike-{N}")` — creates isolated throwaway worktree on branch `spike-{N}`
-2. Investigate: minimal code, isolated test, confirm/reject hypothesis
-4. Report findings → incorporate into α
-5. `ExitWorktree(action: "remove", discard_changes: true)` — clean up throwaway worktree
+**Spike flow** (principal stays on β — [harness-worktree.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-worktree.md)):
+
+1. Create throwaway ω on branch `spike-{N}` **without** switching principal:
+   - H_wt claude-enter: `EnterWorktree(name: "spike-{N}")` if supported, else `git worktree add` under `.claude/worktrees/spike-{N}`
+   - H_wt harness-default: `git worktree add "$(suggested_grok_worktree_path "" "spike-${N}")" -b "spike-${N}"` (or from β)
+2. Investigate **inside ω only**: minimal code, isolated test, confirm/reject hypothesis
+3. Report findings → incorporate into α
+4. Teardown: `ExitWorktree(action: "remove", discard_changes: true)` **or** `git worktree remove --force "$SPIKE_PATH"` + `git branch -D spike-{N}`
+5. Assert principal still on β
 
 See [references/investigation.md](${CLAUDE_SKILL_DIR}/references/investigation.md) if ∃, else use inline flow above.
 

--- a/plugins/dev-core/skills/cleanup/SKILL.md
+++ b/plugins/dev-core/skills/cleanup/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, EnterWorktree, ExitWorktree, ToolSearch
 
 # Git Cleanup
 
-Let: β := branch | ω := worktree | π := open PR | Π := protected branch (main/master/staging) | safe(β) ⟺ fully_merged(β) ∧ ¬π(β) | merged(β) := regular_merge(β) ∨ squash_merge(β) | N := scope issue number (∅ if unscoped) | orphan_shell := leftover path under `~/.grok/worktrees/<slug>/` or `.claude/worktrees/` that is **not** in `git worktree list` (empty parent, unregistered content, or `worktrees.db` row with missing path)
+Let: β := branch | ω := worktree | π := open PR | Π := protected branch (main/master/staging) | safe(β) ⟺ fully_merged(β) ∧ ¬π(β) | merged(β) := regular_merge(β) ∨ squash_merge(β) | N := scope issue number (∅ if unscoped) | orphan_shell := leftover path under `~/.grok/worktrees/<slug>/` or `.claude/worktrees/` that is **not** in `git worktree list` (empty parent, unregistered content, or `worktrees.db` row with missing path) | principal := main checkout (must remain on Π — feature work lives only in ω; see harness-worktree.md)
 
 Safely clean local β, ω, and remote branches with **mandatory merge-status verification** before any deletion. End-of-session sweep also strips stuck pipeline labels from closed PRs, cancels long-queued CI runs, and surfaces **orphan worktree shells** that git no longer tracks.
 

--- a/plugins/dev-core/skills/dev/README.md
+++ b/plugins/dev-core/skills/dev/README.md
@@ -18,6 +18,8 @@ Single entry point for the full dev lifecycle — scan artifacts, detect state, 
 
 `/dev` scans existing artifacts (frames, analyses, specs, plans, worktrees, PRs) to determine where you left off, then drives the pipeline step by step without re-running completed work. Issue triage (`roxabi-issues:issue-triage`) is an **external** step that runs before `/dev` — it lives in the `roxabi-issues` plugin, not dev-core. `/dev`'s own pipeline starts with `/recheck` — a drift check that catches stale issues (git/symbol/dep drift) before any artifact is written.
 
+Worktrees: principal checkout stays on staging/main; feature work runs in a non-principal worktree on `feat/{N}-{slug}` (Claude or Grok layout). See `skills/shared/references/harness-worktree.md`.
+
 Pipeline phases:
 
 | Phase | Steps |

--- a/plugins/dev-core/skills/dev/SKILL.md
+++ b/plugins/dev-core/skills/dev/SKILL.md
@@ -2,7 +2,7 @@
 name: dev
 argument-hint: '[#N | "idea" | --from <step> | --audit]'
 description: Workflow orchestrator — single entry point for the full dev lifecycle. Triggers: "dev" | "start working on" | "work on issue" | "work on #" | "develop" | "pick up issue" | "tackle issue" | "let's work on".
-version: 0.3.1
+version: 0.3.2
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---
 
@@ -26,6 +26,8 @@ Let:
   ψ_r(P) ⟺ P.comments ∃ body: "## Code Review"
   ψ_f(P) ⟺ P.comments ∃ body: "## Review Fixes Applied"
   stale  := scan-state.sh `stale=true|false` — worktree ∃ ∨ local/remote branch matching N ∃ (anchored on N, see scan-state.sh)
+  ω    := non-principal worktree on `feat/{N}-*` (branch-first detect — [harness-worktree.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-worktree.md))
+  β    := base branch; **principal always stays on β** (¬checkout feat in default folder)
   bar   := output must read as hand-authored by a dev-core maintainer — match surrounding idiom, naming, comment density; calibrate against `plugins/dev-core/`; QG (format/lint/typecheck/test) = mechanical floor, ¬the bar
 
 Single entry point: scan artifacts → detect state → show progress → delegate to step skill → loop.
@@ -86,7 +88,7 @@ bash ${CLAUDE_SKILL_DIR}/scan-state.sh {N} {slug}
   analyze:   analysis artifact ∃,
   spec:      spec artifact ∃,
   plan:      plan artifact ∃,
-  implement: worktree ∃ (path: `.claude/worktrees/{N}-*` ∨ legacy `../${REPO}-{N}`) ∧ git diff --name-only origin/${BASE}..HEAD | grep -v '^artifacts/' is non-empty,
+  implement: worktree ∃ (branch-first: non-principal ω on feat/{N}-* — Claude path, Grok ~/.grok/worktrees, or legacy) ∧ git -C ω diff --name-only origin/${BASE}..HEAD | grep -v '^artifacts/' is non-empty,
   pr:        PR ∃,
   ci-watch:  null,       # Σ_s only
   validate:  null,       # Σ_s only
@@ -239,9 +241,14 @@ audit ∧ S* ∈ critical → reasoning audit per [reasoning-audit.md](${CLAUDE_
 
 ## Step 7 — Execute Step
 
-**Worktree bootstrap (silent pre-step):** `worktree` == false ∧ S* ∈ {frame, analyze, spec, plan, implement} → invoke `skill: "setup-worktree", args: "{N:+--issue $N }--slug {slug}"` first. After return, re-scan `worktree`. Still false → present choice: **Retry** | **Abort**.
+**Worktree bootstrap (silent pre-step):** `worktree` == false ∧ S* ∈ {frame, analyze, spec, plan, implement} → invoke `skill: "setup-worktree", args: "{N:+--issue $N }--slug {slug}"` first (ensures BRANCH linked + ω; **principal stays on β**). After return, re-scan `worktree` + `principal_ok`. Still false or `principal_ok=false` → present choice: **Retry** | **Abort**. SSoT: [harness-worktree.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-worktree.md).
 
-**Artifact sync (post-bootstrap):** If S* ∈ {frame, analyze, spec, plan} and the repo principal has artifacts that the worktree lacks (e.g. from a prior standalone run) → `rsync -a ../../../artifacts/ ./artifacts/` (idempotent, preserves future commits).
+**Artifact sync (post-bootstrap):** If S* ∈ {frame, analyze, spec, plan} and principal has artifacts that ω lacks → absolute rsync (path-agnostic — works for Claude *and* Grok layouts):
+```bash
+# PRINCIPAL + WT_PATH from scan-state.sh
+rsync -a "${PRINCIPAL}/artifacts/" "${WT_PATH}/artifacts/"
+```
+Idempotent. **¬** relative `../../../artifacts/` (wrong under `~/.grok/worktrees/…`).
 
 **Before invocation:** `TaskUpdate(task_id_map[S*], status: "in_progress")`. ¬∃ id → `TaskCreate` on-the-fly (drift safety net: a step not seeded in 2b that became active later).
 

--- a/plugins/dev-core/skills/dev/scan-state.sh
+++ b/plugins/dev-core/skills/dev/scan-state.sh
@@ -20,18 +20,29 @@ BASE=$(detect_base_branch)
 # "14-foo" contains "4-foo", so N=4 wrongly matched N=14's artifacts).
 N_ANCHOR="(^|[^0-9])${N}-"
 
-# worktree path (.claude/worktrees/ and legacy parent-dir).
-# Porcelain `worktree <path>` lines are space-safe — no column splitting on the
-# path, unlike `git worktree list | awk '{print $1}'` which breaks on spaces.
-# Legacy `../${REPO}-{N}` has no trailing slug (N can be the last path token),
-# so its right boundary is "non-digit or end" rather than a literal '-'; the
-# left boundary is already safe (always preceded by the literal "${REPO}-").
-[ -n "$REPO" ] && WT_PATTERN="${REPO}-${N}([^0-9]|\$)|worktrees/${N}-" || WT_PATTERN="worktrees/${N}-"
-WT_PATH=$(git worktree list --porcelain 2>/dev/null \
-  | sed -n 's/^worktree //p' \
-  | grep -E "$WT_PATTERN" \
-  | head -1 || true)
+# Principal freeze (must stay on β — staging|main|master)
+PRINCIPAL=$(principal_worktree_path)
+PRINCIPAL_BRANCH=$(principal_branch)
+if is_base_branch "$PRINCIPAL_BRANCH"; then
+  PRINCIPAL_OK=true
+else
+  PRINCIPAL_OK=false
+fi
+[ -n "$PRINCIPAL" ] && echo "principal=$PRINCIPAL" || echo "principal=false"
+echo "principal_branch=${PRINCIPAL_BRANCH:-false}"
+echo "principal_ok=$PRINCIPAL_OK"
+echo "base=$BASE"
+
+# Feature worktree: branch-first (feat/{N}-*), excludes principal.
+# See harness-worktree.md + find_feature_worktree in lib.sh.
+WT_PATH=$(find_feature_worktree "$N" "$SLUG")
 [ -n "$WT_PATH" ] && echo "worktree=$WT_PATH" || echo "worktree=false"
+if [ -n "$WT_PATH" ]; then
+  WT_BRANCH=$(git -C "$WT_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  echo "worktree_branch=${WT_BRANCH:-false}"
+else
+  echo "worktree_branch=false"
+fi
 
 # Helper: list artifacts in worktree if not found in current directory
 # (filtering is the caller's job — keeps the anchor consistent across

--- a/plugins/dev-core/skills/implement/README.md
+++ b/plugins/dev-core/skills/implement/README.md
@@ -19,7 +19,7 @@ Triggers: `"implement"` | `"build this"` | `"execute plan"` | `"start coding"` |
 ## How it works
 
 1. **Locate plan** — reads the plan artifact; probes host task tools (Claude `Task*` / Grok `todo_write` / artifact-only) and attaches or re-seeds accordingly.
-2. **Setup** — creates a worktree at `.claude/worktrees/{N}-{slug}`, checks out a feature branch from base (staging or main), runs `install`.
+2. **Setup** — ensures `feat/{N}-{slug}` linked to the issue; creates a **non-principal** worktree on that branch (Claude: `.claude/worktrees/…`; Grok: harness path under `~/.grok/worktrees/…`). Principal checkout stays on staging/main. Runs `install` inside the worktree.
 3. **Context injection** (F-tier) — injects relevant standards docs into each agent's prompt.
 4. **Implement**:
    - **Tier S** — lead implements directly, single session, no agent spawning.

--- a/plugins/dev-core/skills/implement/SKILL.md
+++ b/plugins/dev-core/skills/implement/SKILL.md
@@ -2,7 +2,7 @@
 name: implement
 argument-hint: '[--issue <N> | --plan <path> | --audit]'
 description: Execute plan — setup worktree, spawn agents, write code + tests. Triggers: "implement" | "build this" | "execute plan" | "start coding" | "write the code" | "code this up" | "let's build it" | "build it out" | "ship it".
-version: 0.3.1
+version: 0.3.2
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---
 
@@ -10,14 +10,16 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree,
 
 ## Success
 
-I := QG pass ∧ worktree ∃ ∧ commits > 0
-V := `cd .claude/worktrees/{N}-{slug} && {commands.format} && {commands.lint} && {commands.typecheck} && {commands.test}` → exit 0
+I := QG pass ∧ worktree ∃ ∧ commits > 0 ∧ principal on β
+V := `cd "$WT_PATH" && {commands.format} && {commands.lint} && {commands.typecheck} && {commands.test}` → exit 0
 
 Let:
   π := artifacts/plans/{N}-{slug}.md
   τ := tier (S | F-lite | F-full)
-  ω := worktree (managed via EnterWorktree/ExitWorktree)
+  ω := non-principal worktree on `feat/{N}-{slug}` (path = harness layout — see harness-worktree.md)
   β := base branch (staging if ∃ origin/staging, else main)
+  principal := main checkout — **always stays on β** (¬switch to feat)
+  H_wt := claude-enter | harness-default
   QG := `{commands.format} && {commands.lint} && {commands.typecheck} && {commands.test}`
   bar := mechanical floor (format/lint/typecheck/test pass), ¬the quality bar — output must read as hand-authored by a dev-core maintainer: match surrounding idiom, naming, and comment density; calibrate against `plugins/dev-core/`
 
@@ -46,6 +48,7 @@ Does NOT create a PR — that is `/pr` (next step).
 - This skill does NOT update its own dev-pipeline task
 - Sub-tasks: attach/re-seed plan-tasks from `/plan` (Step 6a), flip lifecycle as agents execute (Step 1b + Step 4)
 - **Host mapping SSoT:** [harness-task-list.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-task-list.md) — probe once, use H for all task ops
+- **Worktree SSoT:** [harness-worktree.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-worktree.md) — principal freezes on β; code only in ω
 
 ## Exit
 
@@ -66,8 +69,8 @@ Does NOT create a PR — that is `/pr` (next step).
 
 ## Pre-flight
 
-Success: QG pass ∧ worktree ∃ ∧ commits > 0
-Evidence: QG exit 0 inside .claude/worktrees/{N}-{slug}
+Success: QG pass ∧ worktree ∃ ∧ commits > 0 ∧ principal on β
+Evidence: QG exit 0 inside ω (`worktree=` from setup-preflight)
 Steps: locate-plan → setup → context-inject → implement → quality-gate → summary
 ¬clear → STOP + ask: "Do you have a plan to implement?"
 
@@ -134,32 +137,38 @@ No host task list. Skip attach/re-seed. Work from π micro-task table only; prog
 bash ${CLAUDE_SKILL_DIR}/setup-preflight.sh {N} {slug}
 ```
 
-Emits: `repo`, `base`, `branch_exists`, `legacy_worktree`, `worktree`, `dirty` (if worktree found), `fetch`.
+Emits: `repo`, `base`, `principal`, `principal_branch`, `principal_ok`, `branch_exists`, `legacy_worktree`, `worktree`, `worktree_branch`, `dirty` (if worktree found), `fetch`.
 
-ω: `.claude/worktrees/{N}-{slug}` (via EnterWorktree). Branch base: `base` from output.
+**Probe H_wt** (once): `EnterWorktree` ∃ → `claude-enter`; else `harness-default`.  
+SSoT: [harness-worktree.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-worktree.md).
 
-**2c. Branch guard:**
+ω path = `worktree=` from preflight (branch-first detect). Branch base: `base` from output.
 
-`branch_exists` ≠ false ∧ `worktree` = false → branch exists but no worktree → present choice **Recreate worktree** (invoke `skill: "setup-worktree", args: "{N:+--issue $N }--slug {slug}"`) | **Abort**
+**2c. Guards:**
 
-`worktree` ≠ false ∧ `dirty=true` ⇒ → present choice **Stash changes** (`git stash`) | **Reset** (`git checkout .`) | **Continue with dirty state** | **Abort**
+`principal_ok` = false → **STOP**. Principal must be on β. Present choice **Switch principal to base** | **Abort**. **¬** `git switch feat/…` on principal to “fix” this.
+
+`branch_exists` ≠ false ∧ `worktree` = false → branch exists but no ω → present choice **Recreate worktree** (invoke `skill: "setup-worktree", args: "{N:+--issue $N }--slug {slug}"`) | **Abort**
+
+`worktree` ≠ false ∧ `dirty=true` ⇒ → present choice **Stash changes** (`git -C "$WT_PATH" stash`) | **Reset** (`git -C "$WT_PATH" checkout .`) | **Continue with dirty state** | **Abort**
 
 **2e. Worktree:**
 
-Enter existing worktree (created by `/setup-worktree` or prior `/dev` run):
-```
-EnterWorktree(path: ".claude/worktrees/{N}-{slug}")
-```
+`worktree` = false → invoke `skill: "setup-worktree", args: "{N:+--issue $N }--slug {slug}"`, re-run preflight.
 
-`worktree` = false → fallback: invoke `skill: "setup-worktree", args: "{N:+--issue $N }--slug {slug}"` first, then enter.
+Enter existing ω (`WT_PATH` from preflight):
+
+- **H_wt = claude-enter:** `EnterWorktree(path: "$WT_PATH")`
+- **H_wt = harness-default:** all code ops use `cwd` / absolute paths under `$WT_PATH` — **¬** switch principal to BRANCH
 
 Inside ω:
 ```bash
+cd "$WT_PATH"   # or git -C / Write under WT_PATH
 cp .env.example .env 2>/dev/null; {package_manager} install
 # Optional: {commands.worktree_setup} <N>
 ```
 
-ω **mandatory** ∀ τ (XS, S, F-lite, F-full) — ¬exception. ¬"skip worktree" branch.
+ω **mandatory** ∀ τ (XS, S, F-lite, F-full) — ¬exception. ¬"skip worktree" branch. ¬feature commits on principal.
 
 ## Step 3 — Context Injection (τ=F only)
 
@@ -207,17 +216,22 @@ Read spec + ref patterns → create + implement → tests → QG → loop until 
 
 Spawn via host subagent tool (`Task` / `spawn_subagent`). Sequential ∨ parallel (2–3 max).
 
-**Worktree isolation:** Main context is already inside ω (Step 2). Subagents inherit this CWD. All file ops stay within `.claude/worktrees/{N}-{slug}`. Do not `cd` to repo root or other paths outside ω.
+**Worktree isolation:** Code only in ω (`$WT_PATH`). Principal stays on β.
+
+| H_wt | Lead | Subagents |
+|------|------|-----------|
+| claude-enter | session CWD = ω after EnterWorktree | inherit CWD |
+| harness-default | ops under `$WT_PATH` | `spawn_subagent(..., cwd: WT_PATH)` — **¬** `isolation: worktree` (anonymous trees break BRANCH link) |
 
 **Per agent spawn:**
 1. Claim task (H table).
 2. Load context (H table) → inject into subagent prompt.
 3. Spawn:
    ```
-   Task(   # or spawn_subagent on Grok
+   Task(   # or spawn_subagent on Grok with cwd: WT_PATH
      subagent_type: "dev-core:{agent}",
      description: "{agent}: {phase} — #{N} {slug}",
-     prompt: "Issue #{N}. Task: {task_description}. Target: {file_path}. Skeleton: {code_snippet}. Verify: {verify_command}. Ref pattern: {pattern_file}. Worktree: `.claude/worktrees/{N}-{slug}` — you are already inside it; do not leave this directory. ¬seed host tasks — task lifecycle managed by lead."
+     prompt: "Issue #{N}. Task: {task_description}. Target: {file_path}. Skeleton: {code_snippet}. Verify: {verify_command}. Ref pattern: {pattern_file}. Worktree: {WT_PATH} — stay inside this directory only; ¬checkout feat on principal. ¬seed host tasks — task lifecycle managed by lead."
    )
    ```
    Agent name map: `tester` → `dev-core:tester` | `frontend-dev` → `dev-core:frontend-dev` | `backend-dev` → `dev-core:backend-dev` | `devops` → `dev-core:devops` | `doc-writer` → `dev-core:doc-writer` | `architect` → `dev-core:architect` | `security-auditor` → `dev-core:security-auditor`
@@ -237,16 +251,17 @@ Agents create files from scratch (¬stubs). Include target path, shape/skeleton,
 
 ## Step 5 — Quality Gate
 
-Run QG inside ω (session already in ω after EnterWorktree):
+Run QG inside ω (`cd "$WT_PATH"` or `git -C` / shell with cwd=ω):
 
 ```bash
+cd "$WT_PATH"
 {commands.format} && {commands.lint} && {commands.typecheck} && {commands.test}
 ```
 
 > format before lint — auto-format first so the linter never flags style the formatter would have fixed (¬format-induced lint noise).
 
 ✓ → Step 6.
-✗ → fix loop (max 3). Spawn domain fixer agents as needed. 3✗ → present choice **Escalate to lead** | **Continue with failures** | **Abandon ω** (`ExitWorktree(action: "remove")` + delete branch).
+✗ → fix loop (max 3). Spawn domain fixer agents as needed. 3✗ → present choice **Escalate to lead** | **Continue with failures** | **Abandon ω** (H_wt claude: `ExitWorktree(action: "remove")`; harness-default: `git worktree remove "$WT_PATH"`) + delete branch.
 
 ## Step 6 — Summary
 
@@ -323,7 +338,8 @@ broke {source B} → test failed with {error B}
 Implement Complete
   Issue:    #N — title
   Branch:   feat/N-slug
-  Worktree: .claude/worktrees/{N}-{slug}
+  Worktree: {WT_PATH}
+  Principal: {principal} @ {β}
   Tier:     S|F-lite|F-full
   Agents:   list
   Files:    created/modified list
@@ -335,13 +351,20 @@ Implement Complete
 
 ## Rollback
 
+H_wt = claude-enter:
 ```
 ExitWorktree(action: "remove", discard_changes: true)
+```
+
+H_wt = harness-default:
+```bash
+git worktree remove --force "$WT_PATH"
 ```
 
 ```bash
 git branch -D feat/<N>-<slug>
 # Optional: {commands.worktree_teardown} <N>
+# Principal must still be on β after teardown
 ```
 
 ## Edge Cases
@@ -349,7 +372,8 @@ git branch -D feat/<N>-<slug>
 Read [references/edge-cases.md](${CLAUDE_SKILL_DIR}/references/edge-cases.md).
 
 | Merge conflict (ω setup) | `git rebase --abort` → present choice: **Resolve manually** (fix conflicts → `git rebase --continue`) \| **Abort** |
-| Abandon after 3✗ gate failures | `ExitWorktree(action: "remove", discard_changes: true)` then `git branch -D feat/<N>-<slug>` |
+| Abandon after 3✗ gate failures | remove ω (H_wt) then `git branch -D feat/<N>-<slug>`; principal stays on β |
+| Principal not on β | STOP — restore β before any feature work |
 
 ## Safety
 
@@ -359,5 +383,7 @@ Read [references/edge-cases.md](${CLAUDE_SKILL_DIR}/references/edge-cases.md).
 4. Always ω ∀ τ — ¬exception (XS, S, F-lite, F-full all require ω)
 5. Always HEREDOC for commit messages
 6. Pre-commit hook failure → fix, re-stage, NEW commit (¬amend)
+7. **¬** `git switch` / `checkout` feat on principal — principal freezes on β
+8. Grok: **¬** `isolation: worktree` for implement workers — use `cwd: WT_PATH`
 
 $ARGUMENTS

--- a/plugins/dev-core/skills/implement/setup-preflight.sh
+++ b/plugins/dev-core/skills/implement/setup-preflight.sh
@@ -15,22 +15,30 @@ BASE=$(detect_base_branch)
 echo "repo=$REPO"
 echo "base=$BASE"
 
-# existing feature branch
+# Principal freeze
+PRINCIPAL=$(principal_worktree_path)
+PRINCIPAL_BRANCH=$(principal_branch)
+[ -n "$PRINCIPAL" ] && echo "principal=$PRINCIPAL" || echo "principal=false"
+echo "principal_branch=${PRINCIPAL_BRANCH:-false}"
+if is_base_branch "$PRINCIPAL_BRANCH"; then
+  echo "principal_ok=true"
+else
+  echo "principal_ok=false"
+fi
+
+# existing feature branch (local or remote-tracking name)
 EXISTING_BRANCH=$(git branch -a --list "feat/${N}-*" | head -1 | xargs || true)
 [ -n "$EXISTING_BRANCH" ] && echo "branch_exists=$EXISTING_BRANCH" || echo "branch_exists=false"
 
 # legacy parent-dir worktree ([ -d ] test, not `ls -d` — SC2012)
 [ -d "../${REPO}-${N}" ] && echo "legacy_worktree=true" || echo "legacy_worktree=false"
 
-# .claude/worktrees/ worktree — porcelain path is space-safe
-WT_PATH=$(git worktree list --porcelain 2>/dev/null \
-  | sed -n 's/^worktree //p' \
-  | grep -F "worktrees/${N}-" \
-  | head -1 || true)
+# Feature worktree — branch-first via find_feature_worktree (excludes principal)
+WT_PATH=$(find_feature_worktree "$N" "$SLUG")
 [ -n "$WT_PATH" ] && echo "worktree=$WT_PATH" || echo "worktree=false"
-
-# dirty state (inside worktree if it exists)
 if [ -n "$WT_PATH" ]; then
+  WT_BRANCH=$(git -C "$WT_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  echo "worktree_branch=${WT_BRANCH:-false}"
   DIRTY=$(git -C "$WT_PATH" status --porcelain 2>/dev/null || true)
   [ -n "$DIRTY" ] && echo "dirty=true" || echo "dirty=false"
 fi

--- a/plugins/dev-core/skills/setup-worktree/SKILL.md
+++ b/plugins/dev-core/skills/setup-worktree/SKILL.md
@@ -2,7 +2,7 @@
 name: setup-worktree
 argument-hint: '[--issue <N> --slug <slug>]'
 description: Create + link feature branch to issue, then check out worktree. Triggers: "setup worktree" | "create worktree" | "prepare workspace" | "bootstrap branch".
-version: 0.3.1
+version: 0.3.2
 allowed-tools: Bash, Read, EnterWorktree, ExitWorktree, ToolSearch
 ---
 
@@ -10,16 +10,21 @@ allowed-tools: Bash, Read, EnterWorktree, ExitWorktree, ToolSearch
 
 ## Success
 
-I := branch ∃ on origin ∧ linked to issue (∃N) ∧ ω ∃ ∧ status "In Progress" (∃N)
-V := `gh issue develop --list {N} | grep feat/<N>-<slug>` ∧ `git worktree list | grep "$WT_PATH"`
+I := branch ∃ on origin ∧ linked to issue (∃N) ∧ ω ∃ ∧ principal on β ∧ status "In Progress" (∃N)
+V := `gh issue develop --list {N} | grep feat/<N>-<slug>` ∧ `find_feature_worktree` non-empty ∧ `principal_ok=true`
 
 Let:
   N    := issue number (∅ if frame-only)
   slug := kebab-case title slug
-  ω    := worktree at `.claude/worktrees/{N}-{slug}` (∃N) ∨ `.claude/worktrees/{slug}` (¬N)
-  β    := base branch (staging if ∃ origin/staging, else main)
+  BRANCH := `feat/{N}-{slug}` (∃N) ∨ `feat/{slug}` (¬N)
+  β    := base branch (staging if ∃ origin/staging, else main) — `detect_base_branch`
+  principal := main checkout (must stay on β — **never** switch to BRANCH)
+  ω    := non-principal worktree checked out on BRANCH (path = harness layout)
+  H_wt := claude-enter | harness-default — see [harness-worktree.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-worktree.md)
 
 One-time setup per issue. Idempotent — safe to re-run if branch/link/ω already exist.
+
+**SSoT dual-harness:** [harness-worktree.md](${CLAUDE_PLUGIN_ROOT}/skills/shared/references/harness-worktree.md)
 
 ## Entry
 
@@ -32,27 +37,40 @@ One-time setup per issue. Idempotent — safe to re-run if branch/link/ω alread
 
 | Step | ID | Required | Verifies via | Notes |
 |------|----|----------|---------------|-------|
-| 1 | detect | ✓ | β, WORKTREE, REMOTE_BRANCH, LINKED | idempotent |
+| 0 | probe H_wt | ✓ | claude-enter ∨ harness-default | tools available |
+| 1 | detect | ✓ | β, principal_ok, WORKTREE, REMOTE_BRANCH, LINKED | idempotent |
 | 2 | branch + link | ✓ | branch on origin + linked to issue | `gh issue develop` (atomic create+link) |
-| 3 | worktree + deps | ✓ | ω ∃ + deps installed | skip if exists |
+| 3 | worktree + deps | ✓ | ω ∃ + deps installed | skip if exists; **¬** touch principal branch |
 | 4 | status | — | issue status updated | optional |
+
+## Step 0 — Probe H_wt
+
+```
+if tools ∋ EnterWorktree ∧ ExitWorktree → H_wt := claude-enter
+else                                    → H_wt := harness-default
+```
 
 ## Step 1 — Detect
 
 ```bash
 BASE=$(. "${CLAUDE_SKILL_DIR}/../shared/lib.sh" && detect_base_branch)
+# shellcheck source=../shared/lib.sh
+. "${CLAUDE_SKILL_DIR}/../shared/lib.sh"
 git fetch origin "$BASE" 2>&1
 
-# Paths depend on mode (issue vs frame-only)
 if [ -n "$N" ]; then
-  WT_PATH=".claude/worktrees/${N}-${slug}"
   BRANCH="feat/${N}-${slug}"
 else
-  WT_PATH=".claude/worktrees/${slug}"
   BRANCH="feat/${slug}"
 fi
 
-git worktree list | grep -qF "$WT_PATH" && WORKTREE=exists || WORKTREE=false
+PRINCIPAL=$(principal_worktree_path)
+PRINCIPAL_BRANCH=$(principal_branch)
+is_base_branch "$PRINCIPAL_BRANCH" && PRINCIPAL_OK=true || PRINCIPAL_OK=false
+
+WT_PATH=$(find_feature_worktree "$N" "$slug")
+[ -n "$WT_PATH" ] && WORKTREE=exists || WORKTREE=false
+
 git ls-remote --heads origin "$BRANCH" 2>/dev/null | grep -q . && REMOTE_BRANCH=exists || REMOTE_BRANCH=false
 if [ -n "$N" ]; then
   gh issue develop --list "$N" 2>/dev/null | grep -qF "$BRANCH" && LINKED=exists || LINKED=false
@@ -61,7 +79,12 @@ else
 fi
 ```
 
+`PRINCIPAL_OK` = false → **STOP**. Present choice: **Switch principal to $BASE** (`git -C "$PRINCIPAL" switch "$BASE"` after user confirms) | **Abort**.  
+**¬** silently leave principal on a feat branch. **¬** use principal as ω.
+
 ## Step 2 — Create + Link Branch on Origin
+
+Run from principal CWD (or any path). **Never** `git switch "$BRANCH"` on principal.
 
 ∃ N ∧ `LINKED` = false ∧ `REMOTE_BRANCH` = false → atomic create + link via `gh issue develop`:
 ```bash
@@ -82,20 +105,56 @@ Why `gh issue develop`: the underlying `createLinkedBranch` GraphQL mutation **o
 
 ## Step 3 — Worktree + Install
 
-`WORKTREE` = false → fetch the now-existing remote branch + add worktree from it:
+`WORKTREE` = exists → skip create (ω already checked out on BRANCH).
+
+`WORKTREE` = false → fetch + add **non-principal** worktree:
+
 ```bash
 git fetch origin "$BRANCH"
+
+# Create path by H_wt (layout only — detection stays branch-first)
+if [ "$H_wt" = "claude-enter" ]; then
+  if [ -n "$N" ]; then
+    WT_PATH="${PRINCIPAL}/.claude/worktrees/${N}-${slug}"
+  else
+    WT_PATH="${PRINCIPAL}/.claude/worktrees/${slug}"
+  fi
+else
+  # harness-default (Grok): stable path under ~/.grok/worktrees/<slug>/
+  WT_PATH=$(suggested_grok_worktree_path "$N" "$slug")
+fi
+
+mkdir -p "$(dirname "$WT_PATH")"
 git worktree add "$WT_PATH" "$BRANCH"
 ```
 
-`WORKTREE` = exists → skip (worktree already checked out).
+**¬** `git checkout` / `switch` BRANCH on principal after add.
 
-Enter + install:
+### Enter + install
+
+**H_wt = claude-enter:**
 ```
 EnterWorktree(path: "$WT_PATH")
 ```
 ```bash
 cp .env.example .env 2>/dev/null; {package_manager} install
+# Optional: {commands.worktree_setup} <N>
+```
+
+**H_wt = harness-default:**  
+Do **not** expect `EnterWorktree`. All subsequent code ops use `$WT_PATH` as CWD (`cd` in bash, Write/Edit absolute under ω, or `spawn_subagent(cwd: WT_PATH)`). Session may already be inside a Grok worktree on BRANCH — if `find_feature_worktree` found it, skip create and use that path.
+
+```bash
+cd "$WT_PATH"
+cp .env.example .env 2>/dev/null; {package_manager} install
+# Optional: {commands.worktree_setup} <N>
+```
+
+### Post-assert
+
+```bash
+is_base_branch "$(principal_branch)" || { echo "FATAL: principal left base branch" >&2; exit 1; }
+git -C "$WT_PATH" rev-parse --abbrev-ref HEAD | grep -qx "$BRANCH"
 ```
 
 ## Step 4 — Issue Status (optional)
@@ -107,10 +166,11 @@ bun ${CLAUDE_PLUGIN_ROOT}/skills/issue-triage/triage.ts set "$N" --status "In Pr
 
 ## Exit
 
-- **Success:** branch on origin + link (∃N) + ω ∃. Return silently.
+- **Success:** BRANCH on origin + link (∃N) + ω ∃ + principal on β. Return silently.
 - **Idempotent re-run:** all detect flags exist → skip → return silently.
 - **Failure:** propagate `gh issue develop` errors (do not swallow — caller decides).
 - **Migration edge (remote branch pre-existed):** warn on stderr, continue with worktree; user links manually via UI.
+- **Principal not on β:** stop until user restores β (Step 1).
 
 ## Chain Position
 

--- a/plugins/dev-core/skills/shared/__tests__/lib-worktree.test.sh
+++ b/plugins/dev-core/skills/shared/__tests__/lib-worktree.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Integration test for lib.sh worktree helpers (principal freeze + branch-first detect).
+set -euo pipefail
+
+# Isolate from any inherited git context (hooks export GIT_DIR/GIT_WORK_TREE).
+unset $(git rev-parse --local-env-vars 2>/dev/null || true)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+. "$SCRIPT_DIR/../lib.sh"
+
+TMPDIR_FIXTURE="$(mktemp -d)"
+WT_CLAUDE="${TMPDIR_FIXTURE}/.claude/worktrees/42-dark-mode"
+WT_GROK="${TMPDIR_FIXTURE}/.grok-like/99-other"
+trap 'rm -rf "$TMPDIR_FIXTURE"' EXIT
+
+cd "$TMPDIR_FIXTURE"
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test User"
+git remote add origin "git@github.com:Roxabi/roxabi-plugins.git"
+
+echo "base" > README.md
+git add README.md
+git commit -q -m "chore: init"
+git branch -M main
+
+# Feature branches off main
+git branch feat/42-dark-mode main
+git branch feat/7-foo main
+git branch feat/70-bar main
+
+mkdir -p "$(dirname "$WT_CLAUDE")" "$(dirname "$WT_GROK")"
+git worktree add -q "$WT_CLAUDE" feat/42-dark-mode
+git worktree add -q "$WT_GROK" feat/7-foo
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" != "$actual" ]; then
+    echo "FAIL: $label expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+# Principal is first worktree, on main
+p="$(principal_worktree_path)"
+assert_eq "principal path is fixture root" "$TMPDIR_FIXTURE" "$p"
+assert_eq "principal branch main" "main" "$(principal_branch)"
+is_base_branch "$(principal_branch)"
+assert_eq "is_base_branch main" "0" "$?"
+
+# find by branch — Claude layout path
+found42="$(find_feature_worktree 42 dark-mode)"
+assert_eq "find #42" "$WT_CLAUDE" "$found42"
+
+# find by branch — non-Claude path (Grok-like) still works
+found7="$(find_feature_worktree 7 foo)"
+assert_eq "find #7 non-claude path" "$WT_GROK" "$found7"
+
+# anchored: N=7 must not match feat/70-bar (no worktree for 70)
+found70="$(find_feature_worktree 70 bar || true)"
+assert_eq "N=70 no worktree" "" "${found70:-}"
+
+# N=7 must not match something under 70
+found7b="$(find_feature_worktree 7)"
+assert_eq "N=7 still only feat/7-foo" "$WT_GROK" "$found7b"
+
+# principal must never be returned as feature worktree
+# (simulate mis-checkout: if principal were on feat, still exclude it)
+# Here principal is main — empty for missing issue
+found999="$(find_feature_worktree 999 missing || true)"
+assert_eq "missing issue empty" "" "${found999:-}"
+
+# is_base_branch negatives
+is_base_branch "feat/42-dark-mode" && exit 1 || true
+is_base_branch "staging"
+assert_eq "is_base_branch staging" "0" "$?"
+
+# suggested_grok_worktree_path uses origin remote slug Roxabi → Roxabi-roxabi-plugins
+# (owner alnum only)
+gpath="$(suggested_grok_worktree_path 42 dark-mode)"
+case "$gpath" in
+  */.grok/worktrees/Roxabiroxabi-plugins/42-dark-mode|*/.grok/worktrees/Roxabi-roxabi-plugins/42-dark-mode)
+    ;;
+  *)
+    # owner "Roxabi" is already alnum → Roxabi-roxabi-plugins
+    expected_suffix="/.grok/worktrees/Roxabi-roxabi-plugins/42-dark-mode"
+    case "$gpath" in
+      *"$expected_suffix") ;;
+      *)
+        echo "FAIL: suggested_grok_worktree_path got '$gpath'" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+esac
+
+# Principal still on main after all worktree ops
+assert_eq "principal still main" "main" "$(principal_branch)"
+
+echo "PASS: lib-worktree.test.sh"

--- a/plugins/dev-core/skills/shared/__tests__/lib-worktree.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/lib-worktree.test.ts
@@ -1,0 +1,12 @@
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SHELL_TEST = path.resolve(import.meta.dirname, 'lib-worktree.test.sh')
+
+describe('lib-worktree.test.sh', () => {
+  it('principal freeze + branch-first feature worktree detect', () => {
+    const output = execFileSync('bash', [SHELL_TEST], { encoding: 'utf8' })
+    expect(output.trim()).toContain('PASS: lib-worktree.test.sh')
+  })
+})

--- a/plugins/dev-core/skills/shared/__tests__/workflows.test.ts
+++ b/plugins/dev-core/skills/shared/__tests__/workflows.test.ts
@@ -140,6 +140,12 @@ describe('generateCiYml', () => {
     const yml = generateCiYml({ stack: 'bun', test: 'vitest', deploy: 'none' })
     expect(yml).toContain('branches: [main, staging]')
   })
+
+  it('skips full CI on draft PRs and re-triggers on ready_for_review', () => {
+    const yml = generateCiYml({ stack: 'bun', test: 'vitest', deploy: 'none' })
+    expect(yml).toContain('types: [opened, synchronize, reopened, ready_for_review]')
+    expect(yml).toContain("if: github.event_name != 'pull_request' || !github.event.pull_request.draft")
+  })
 })
 
 describe('generateSecretScanYml', () => {

--- a/plugins/dev-core/skills/shared/lib.sh
+++ b/plugins/dev-core/skills/shared/lib.sh
@@ -21,3 +21,129 @@ detect_base_branch() {
     done
     echo main
 }
+
+# True if $1 is a protected base branch (staging|main|master).
+is_base_branch() {
+    case "${1:-}" in
+        staging|main|master) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Principal (main) worktree path — first porcelain entry. Empty if not a git repo.
+principal_worktree_path() {
+    git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -1
+}
+
+# Branch checked out in the principal worktree (or empty).
+principal_branch() {
+    local p
+    p="$(principal_worktree_path)"
+    [ -n "$p" ] && git -C "$p" rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
+# Grok repo slug for ~/.grok/worktrees/<slug>/ — owner with non-alphanumerics
+# stripped + "-" + repo (matches cleanup/scan-orphan-worktree-shells.sh).
+grok_repo_slug() {
+    local url owner repo
+    url="$(git remote get-url origin 2>/dev/null || true)"
+    [ -z "$url" ] && return 1
+    if [[ "$url" =~ [:/]([^/:]+)/([^/]+?)(\.git)?$ ]]; then
+        owner="${BASH_REMATCH[1]}"
+        repo="${BASH_REMATCH[2]}"
+        repo="${repo%.git}"
+        owner="$(printf '%s' "$owner" | tr -cd '[:alnum:]')"
+        printf '%s-%s' "$owner" "$repo"
+        return 0
+    fi
+    return 1
+}
+
+# Suggested path for a new feature worktree under harness-default (Grok layout).
+# Args: N slug  — N may be empty (frame-only → dir = slug only).
+# Echoes absolute path; does not create. Empty if slug missing or slug resolve fails.
+suggested_grok_worktree_path() {
+    local n="${1:-}" slug="${2:-}" gslug leaf
+    [ -z "$slug" ] && return 1
+    gslug="$(grok_repo_slug)" || gslug="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+    if [ -n "$n" ]; then
+        leaf="${n}-${slug}"
+    else
+        leaf="${slug}"
+    fi
+    printf '%s/.grok/worktrees/%s/%s\n' "${HOME}" "$gslug" "$leaf"
+}
+
+# Find a non-principal worktree checked out on the feature branch for issue N.
+# Detection SSoT = branch (refs/heads/feat/{N}-*), not path layout.
+# Fallback: Claude `.claude/worktrees/{N}-*` path + legacy `../${REPO}-{N}`.
+# Args: N [slug]  — slug used for frame-only (N empty) and path fallback.
+# Echoes absolute path or empty.
+find_feature_worktree() {
+    local n="${1:-}" slug="${2:-}"
+    local principal wt="" branch="" found="" line repo pattern
+
+    principal="$(principal_worktree_path)"
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            worktree\ *)
+                wt="${line#worktree }"
+                ;;
+            branch\ *)
+                branch="${line#branch }"
+                if [ -n "$n" ]; then
+                    case "$branch" in
+                        "refs/heads/feat/${n}-"*)
+                            if [ -n "$wt" ] && [ "$wt" != "$principal" ]; then
+                                found="$wt"
+                            fi
+                            ;;
+                    esac
+                elif [ -n "$slug" ]; then
+                    case "$branch" in
+                        "refs/heads/feat/${slug}" | "refs/heads/feat/${slug}/"*)
+                            if [ -n "$wt" ] && [ "$wt" != "$principal" ]; then
+                                found="$wt"
+                            fi
+                            ;;
+                    esac
+                fi
+                ;;
+            "")
+                wt=""
+                branch=""
+                ;;
+        esac
+        [ -n "$found" ] && break
+    done < <(git worktree list --porcelain 2>/dev/null || true)
+
+    if [ -n "$found" ]; then
+        printf '%s\n' "$found"
+        return 0
+    fi
+
+    # Path fallback (Claude layout + legacy parent-dir) — branch may be missing
+    # from porcelain in rare states; still never return principal.
+    repo="$(gh repo view --json name --jq '.name' 2>/dev/null || echo "")"
+    if [ -n "$n" ]; then
+        if [ -n "$repo" ]; then
+            pattern="${repo}-${n}([^0-9]|\$)|worktrees/${n}-"
+        else
+            pattern="worktrees/${n}-"
+        fi
+        found="$(git worktree list --porcelain 2>/dev/null \
+            | sed -n 's/^worktree //p' \
+            | grep -E "$pattern" \
+            | head -1 || true)"
+    elif [ -n "$slug" ]; then
+        found="$(git worktree list --porcelain 2>/dev/null \
+            | sed -n 's/^worktree //p' \
+            | grep -F "worktrees/${slug}" \
+            | head -1 || true)"
+    fi
+
+    if [ -n "$found" ] && [ "$found" != "$principal" ]; then
+        printf '%s\n' "$found"
+    fi
+}

--- a/plugins/dev-core/skills/shared/references/harness-task-list.md
+++ b/plugins/dev-core/skills/shared/references/harness-task-list.md
@@ -87,4 +87,5 @@ Work only from π micro-tasks table. Present progress in the reply. No host list
 ## Related
 
 - Call shape (rich path): [`plan-task-schema.md`](plan-task-schema.md)
+- Worktree dual-harness (principal freeze + H_wt): [`harness-worktree.md`](harness-worktree.md)
 - Dual harness install notes: `dev-init` skill « Dual harness »

--- a/plugins/dev-core/skills/shared/references/harness-worktree.md
+++ b/plugins/dev-core/skills/shared/references/harness-worktree.md
@@ -1,0 +1,116 @@
+# Harness worktree (dual: Claude + Grok)
+
+> **SSoT for portable worktree ops.** Skills speak **generic** vocabulary; this file maps to host tools.  
+> Prefer **one skill body + capability branch** — never fork full SKILL.md per host.  
+> Pair with [harness-task-list.md](harness-task-list.md) (tasks) — same dual-harness pattern.
+
+## Principle
+
+| Layer | Rule |
+|-------|------|
+| Skill prose | Host-neutral: « ensure feature branch linked », « ensure ω isolated from principal », « work only in ω » |
+| Capability probe | Detect which tools exist **in this session** (schema / known names) |
+| **Branch + issue link** | **dev-core invariant** — harness-agnostic |
+| **Path / enter / exit** | **Harness owns layout** — do not dual-hardcode opaque Grok hash paths in skills |
+| **Principal freeze** | Principal checkout **always** stays on β (`staging` \| `main` \| `master`) — **never** `git switch` / `checkout` of `feat/…` there |
+
+## Invariants (all harnesses)
+
+Let:
+
+- β := `detect_base_branch` (staging if `origin/staging` ∃, else main/master)
+- BRANCH := `feat/{N}-{slug}` (∃N) ∨ `feat/{slug}` (¬N frame-only)
+- principal := main worktree path (`principal_worktree_path` in `lib.sh`)
+- ω := **non-principal** worktree whose HEAD branch is BRANCH
+
+| Invariant | Check |
+|-----------|--------|
+| Principal on β | `principal_branch` ∈ {staging, main, master} after setup |
+| Feature work only in ω | `git -C ω rev-parse --abbrev-ref HEAD` = BRANCH |
+| Issue link (∃N) | `gh issue develop` at **create** time (create-only GraphQL) |
+| ¬code on β for the feature | commits land in ω only |
+
+## Detection (orchestrator)
+
+```
+if tools ∋ EnterWorktree ∧ ExitWorktree → H_wt := claude-enter
+else                                    → H_wt := harness-default   # Grok (and future hosts)
+```
+
+¬probe by OS name. Probe **tools available in the current harness**.
+
+**Locate ω (scripts):** `find_feature_worktree N [slug]` in `skills/shared/lib.sh` —
+
+1. **Branch-first:** porcelain worktree whose `branch` is `refs/heads/feat/{N}-*` (excludes principal)
+2. **Path fallback:** Claude `.claude/worktrees/{N}-*` or legacy `../${REPO}-{N}`
+3. Grok hash dirs under `~/.grok/worktrees/` are found via (1) when they check out BRANCH
+
+Principal on β + ω on feat elsewhere = **healthy** (not “missing worktree”).
+
+## Capability matrix
+
+| Operation (generic) | Claude (`claude-enter`) | Grok (`harness-default`) | Notes |
+|---------------------|-------------------------|--------------------------|-------|
+| Ensure BRANCH + link | bash `gh issue develop` | idem | From **principal** CWD; ¬switch principal |
+| Create ω if missing | `git worktree add .claude/worktrees/{N}-{slug} BRANCH` | `git worktree add "$(suggested_grok_worktree_path N slug)" BRANCH` | Path is layout only; detection stays branch-first |
+| Enter ω (lead) | `EnterWorktree(path)` | CWD = ω path for all code ops; session may already be in ω | **¬** `git checkout BRANCH` on principal |
+| Spawn workers | inherit CWD after Enter | `spawn_subagent(..., cwd: ω)` — **¬** `isolation: worktree` for `/dev` implement | Isolation:worktree creates anonymous trees + apply; breaks issue-linked BRANCH |
+| Install / hooks | run inside ω | same | `worktree_setup` if project has it |
+| Teardown | `ExitWorktree` / `git worktree remove` | `git worktree remove` + orphan-shell scan (`/cleanup`) | |
+| Detect resume | `find_feature_worktree` | same | |
+
+### Create path conventions (only when creating)
+
+| H_wt | Path when creating |
+|------|--------------------|
+| claude-enter | `{principal}/.claude/worktrees/{N}-{slug}` |
+| harness-default | `~/.grok/worktrees/{grok_repo_slug}/{N}-{slug}` via `suggested_grok_worktree_path` |
+
+Do **not** encode Grok’s opaque session hash dirs in skills. If a session was started with `grok -w` on BRANCH, `find_feature_worktree` already sees it — skip create.
+
+## Setup procedure (generic)
+
+Run from principal (or any CWD; all git ops that touch principal use `-C` when needed):
+
+1. `BASE=$(detect_base_branch)` · `BRANCH=feat/{N}-{slug}`
+2. Assert or restore principal on BASE — if principal is on a feat branch: **warn + stop** (user must switch principal back to β; skill does not force-switch without explicit user choice)
+3. Ensure remote BRANCH + issue link (`gh issue develop` when N set and remote absent)
+4. `WT=$(find_feature_worktree N slug)`
+5. If empty → create via H_wt path table + `git worktree add "$WT" "$BRANCH"` (after `git fetch origin "$BRANCH"`)
+6. Enter per H_wt · install deps inside ω
+7. Re-assert `principal_branch` ∈ base set
+
+## Work rules (implement / code)
+
+- All Write/Edit/commit/QG: **inside ω only**
+- Orchestration (`/dev` scan, `gh`, read principal artifacts): may stay on principal
+- Artifact sync principal → ω: `rsync -a "$PRINCIPAL/artifacts/" "$WT/artifacts/"` (absolute paths — ¬`../../../` relative)
+
+## Anti-patterns
+
+| Don’t | Do |
+|-------|----|
+| `git switch feat/…` on principal | Create/use separate ω |
+| Force `.claude/worktrees/` under Grok | `H_wt` path table / existing harness ω |
+| Encode `~/.grok/worktrees/.../<hash>` in skills | Branch-first detect; stable create path only if missing |
+| `isolation: worktree` on every implement agent | Share session ω via `cwd` |
+| Detect ω only by Claude path | `find_feature_worktree` |
+| Leave Grok naming as `worktree-agent-*` | `gh issue develop` → BRANCH before coding |
+| Treat principal dirty on β as feature ω | Feature ω is always non-principal |
+
+## Consumers
+
+| Skill / script | Uses |
+|----------------|------|
+| `/setup-worktree` | Full setup procedure + H_wt |
+| `/dev` Step 7 bootstrap | invoke setup-worktree; artifact sync absolute |
+| `/implement` Step 2 | locate ω, enter per H_wt, work only in ω |
+| `/analyze` spike | throwaway ω; principal stays on β |
+| `scan-state.sh` / `setup-preflight.sh` | `find_feature_worktree`, principal ok flags |
+| `/cleanup` | remove ω by path; orphan Grok shells |
+
+## Related
+
+- Shared bash: `skills/shared/lib.sh` (`detect_base_branch`, `find_feature_worktree`, …)
+- Tasks dual-harness: [harness-task-list.md](harness-task-list.md)
+- Orphan shells: `skills/cleanup/scan-orphan-worktree-shells.sh`

--- a/plugins/dev-core/skills/shared/workflows/workflow-generators.ts
+++ b/plugins/dev-core/skills/shared/workflows/workflow-generators.ts
@@ -427,16 +427,20 @@ export function generateCiYml(opts: WorkflowOpts): string {
       '      # If this is wrong, set commands.test + testing.unit and re-run /ci-setup.'
   }
 
+  // Draft PRs skip full CI (WIP). ready_for_review re-triggers when undrafted.
+  // `reviewed` remains the merge gate only (auto-merge / merge-on-green) — not a CI gate.
   return `name: CI
 on:
   push:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   ci:
     name: CI
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: ${ACTION_PINS.checkout}

--- a/plugins/dev-core/skills/shared/workflows/workflows-fleet.ts
+++ b/plugins/dev-core/skills/shared/workflows/workflows-fleet.ts
@@ -221,6 +221,7 @@ export function generateE2eJob(opts: WorkflowOpts): string {
   return `
   e2e:
     name: E2E
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/plugins/dev-init/skills/shared/workflows/workflow-generators.ts
+++ b/plugins/dev-init/skills/shared/workflows/workflow-generators.ts
@@ -429,16 +429,20 @@ export function generateCiYml(opts: WorkflowOpts): string {
       '      # If this is wrong, set commands.test + testing.unit and re-run /ci-setup.'
   }
 
+  // Draft PRs skip full CI (WIP). ready_for_review re-triggers when undrafted.
+  // `reviewed` remains the merge gate only (auto-merge / merge-on-green) — not a CI gate.
   return `name: CI
 on:
   push:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   ci:
     name: CI
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: ${ACTION_PINS.checkout}

--- a/plugins/dev-init/skills/shared/workflows/workflows-fleet.ts
+++ b/plugins/dev-init/skills/shared/workflows/workflows-fleet.ts
@@ -223,6 +223,7 @@ export function generateE2eJob(opts: WorkflowOpts): string {
   return `
   e2e:
     name: E2E
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## Summary
- Dual-harness worktrees: principal checkout stays on staging/main; feature work only in a non-principal worktree (`feat/{N}-{slug}`). Claude uses EnterWorktree + `.claude/worktrees/`; Grok uses harness paths under `~/.grok/worktrees/`. Detection is branch-first via `find_feature_worktree`.
- Add `harness-worktree.md` SSoT, lib.sh helpers, and integration tests; update `/setup-worktree`, `/implement`, `/dev`, scan-state, analyze spike, cleanup notes.
- Skip full CI on draft PRs (`ready_for_review` re-triggers); `reviewed` remains merge gate only. Bump dev-core to 0.10.2.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | (no issue linked) | ad-hoc /ship |
| Implementation | 3 commits on `feat/harness-worktree-principal-freeze` | Complete |
| Verification | pre-push vitest 841 pass + lib-worktree | Passed |

## Test Plan
- [x] `vitest run` (pre-push) including `lib-worktree.test.ts` and `workflows.test.ts`
- [ ] Spot-check: `bash plugins/dev-core/skills/dev/scan-state.sh N slug` emits `principal_ok` + branch-first `worktree`
- [ ] Draft PR on a consumer repo should skip CI; undraft should re-run

---
Generated via `/ship`