### PR TITLE
fix(dev-core): drop mandatory HTML sidecars from /spec Data Model

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. adversarial), dual-harness task list + worktrees, safety hooks (Claude + Grok).",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/README.md
+++ b/plugins/dev-core/README.md
@@ -6,7 +6,7 @@ Full development lifecycle orchestrator for Roxabi projects. Covers framing, ana
 
 - **Package manager** — Bun, npm, pnpm, or yarn (configured via `stack.yml`)
 - [GitHub CLI](https://cli.github.com/) (`gh`) — issue fetching, PR creation, label management
-- **[forge](https://github.com/Roxabi/roxabi-forge)** plugin — architecture diagrams in shape artifacts (`clarify`, `analyze`, `spec`, `plan`) are forge-chart sidecars in `artifacts/visuals/`, not inline mermaid/ASCII. Install: `claude plugin install forge`
+- **[forge](https://github.com/Roxabi/roxabi-forge)** plugin — architecture diagrams in shape artifacts (`clarify`, `analyze`, `plan`) are forge-chart sidecars in `artifacts/visuals/`, not inline mermaid/ASCII. (`/spec` data model is markdown only.) Install: `claude plugin install forge`
 - **Formatter** — optional; configure any formatter in `stack.yml` (`build.formatter_fix_cmd` or `build.formatters[]`). Biome, Prettier, Ruff, Black — all work. Leave empty to disable auto-formatting.
 
 ## Install

--- a/plugins/dev-core/references/forge-chart-sidecar.md
+++ b/plugins/dev-core/references/forge-chart-sidecar.md
@@ -1,6 +1,6 @@
 # Forge-Chart Sidecar — dev-core visual standard
 
-SSoT for architecture and data-flow visuals in dev-core shape artifacts. Read before generating any diagram in `clarify`, `analyze`, `spec`, or `plan`.
+SSoT for architecture and data-flow visuals in dev-core shape artifacts. Read before generating any diagram in `clarify`, `analyze`, or `plan`. (`/spec` Data Model is markdown-only — no forge-chart sidecars.)
 
 ## Rule
 
@@ -47,8 +47,6 @@ Open locally: `file://{absolute-path}/artifacts/visuals/{filename}.html`
 | `boundary` | `clarify` §2 | `architecture` — actors + boundary |
 | `shapes` | `analyze` §Shapes | `architecture` — shape comparison (zones per shape) |
 | `data-flow` | `analyze` §Fit Check, `plan` §Architecture | `architecture` + optional `useCases[]` |
-| `data-model` | `spec` §Data Model | fgraph `layered` — entities/fields/relations |
-| `consumers` | `spec` §Data Model | `hub-spoke` or `architecture` — data center + consumers |
 | `file-map` | `plan` §Architecture | `architecture` — files as nodes, call edges |
 
 `N` optional when no issue (free-text clarify) → `{slug}-{kind}.html`.
@@ -60,18 +58,14 @@ Open locally: `file://{absolute-path}/artifacts/visuals/{filename}.html`
 | `clarify` | §2 Business Architecture | always (≥2 actors or layers) |
 | `analyze` | §Shapes | F-lite/F-full, ≥2 shapes |
 | `analyze` | §Fit Check | F-lite/F-full, data flow or arch choice |
-| `spec` | §Data Model & Consumers | F-lite/F-full |
 | `plan` | §Architecture | always (τ ∈ {F-lite, F-full}) |
 
-Tier S may omit shape/fit sidecars in `analyze`; may omit Data Model sidecars in `spec`.
+Tier S may omit shape/fit sidecars in `analyze`.  
+`/spec` §Data Model & Consumers is **markdown only** (prose + optional table) — no HTML sidecars.
 
 ## Text flows in clarify §3
 
 Actor chains (`Actor → action → layer → outcome`) stay as one-line text — they are UX flows, not topology diagrams. ¬convert to mermaid/ASCII boxes.
-
-## Consumer summary table
-
-Keep the markdown table in `spec` §Data Model (consumer → fields → when → status). The sidecar is the visual; the table is the machine-readable index.
 
 ## Quality bar
 

--- a/plugins/dev-core/skills/spec/README.md
+++ b/plugins/dev-core/skills/spec/README.md
@@ -32,7 +32,7 @@ Triggers: `"write spec"` | `"spec this"` | `"solution design"` | `"acceptance cr
 artifacts/specs/{N}-{slug}-spec.md
 ```
 
-Sections: Context, Goal, Users, Expected Behavior, Data Model & Consumers (forge-chart sidecars in `artifacts/visuals/`), Breadboard, Slices, Success Criteria.
+Sections: Context, Goal, Users, Expected Behavior, Data Model & Consumers (markdown prose + optional consumer table — no HTML sidecars), Breadboard, Slices, Success Criteria.
 
 ## Chain position
 

--- a/plugins/dev-core/skills/spec/SKILL.md
+++ b/plugins/dev-core/skills/spec/SKILL.md
@@ -2,7 +2,7 @@
 name: spec
 argument-hint: '[--issue <N> | --analysis <path> | --frame <path> | --audit]'
 description: Solution spec — acceptance criteria, breadboard, slices. Triggers: "write spec" | "spec this" | "solution design" | "what will we build" | "design the solution" | "acceptance criteria" | "define acceptance criteria" | "spec it out" | "write the spec".
-version: 0.2.0
+version: 0.2.1
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, Skill, ToolSearch
 ---
 
@@ -103,8 +103,6 @@ Interview pre-fills from SRC. Focus on gaps to spec level:
 - Slices: vertical increments, independently demo-able
 - Ambiguity detection via 9-category taxonomy (see interview SKILL.md)
 
-F-lite/F-full: generate forge-chart sidecars per [forge-chart-sidecar.md](${CLAUDE_PLUGIN_ROOT}/references/forge-chart-sidecar.md) **before** writing σ.
-
 Write σ. Must include:
 
 | Section | Skip if |
@@ -113,28 +111,20 @@ Write σ. Must include:
 | `## Goal` — one-sentence outcome | — |
 | `## Users` — who is affected | — |
 | `## Expected Behavior` — narrative walkthrough | — |
-| `## Data Model & Consumers` — forge-chart sidecars (see below) | Tier S |
+| `## Data Model & Consumers` — prose types + optional consumer table (markdown only) | Tier S |
 | `## Breadboard` — affordance tables + wiring | Tier S |
 | `## Slices` — vertical increments table | Tier S |
 | `## Success Criteria` — `- [ ]` checkboxes, each binary | — |
 
-### Forge-Chart Sidecars (Tier F-lite, F-full)
+### Data Model & Consumers (Tier F-lite, F-full)
 
-Read [forge-chart-sidecar.md](${CLAUDE_PLUGIN_ROOT}/references/forge-chart-sidecar.md) before generating visuals.
+Markdown only — **¬** forge-chart HTML sidecars, **¬** required `artifacts/visuals/*-data-model.html` / `*-consumers.html`.
 
-`## Data Model & Consumers` must include:
-1. **Data structure sidecar** — `{N}-{slug}-data-model.html` (fgraph layered or fd-engine): core types/models, fields, relationships. Frozen/mutable in node labels.
-2. **Consumer map sidecar** — `{N}-{slug}-consumers.html` (hub-spoke or architecture): who consumes data, which fields, when. Solid edges = this issue; dashed = future.
-3. **Consumer summary table** — consumer → fields consumed, when, status (this issue / future).
+Include when data shape matters:
+1. **Data structure** — core types/models, fields, relationships; note frozen vs mutable where useful
+2. **Consumers** (optional table) — who consumes which fields, when, status (this issue / future)
 
-Link each sidecar (¬inline mermaid, ¬ASCII):
-
-```markdown
-**Data structure:** [{title}](../visuals/{N}-{slug}-data-model.html)
-**Consumer map:** [{title}](../visuals/{N}-{slug}-consumers.html)
-```
-
-Sidecars go BEFORE Breadboard. They answer "what is the data shape and who uses it" while Breadboard answers "how do pieces wire together."
+Section sits before Breadboard: shape of data vs how pieces wire together.
 
 May contain χ (max 3–5). χ items block `/plan` — must be resolved first.
 
@@ -194,7 +184,7 @@ Present summary: scope, |slices|, |acceptance criteria|, |χ|, pre-check results
 
 Q: **Approve** → continue pipeline | **Revise** → collect feedback → revise σ → loop from Step 3.
 
-On approval → commit: `git add artifacts/specs/{N}-{slug}-spec.md artifacts/visuals/` + commit per CLAUDE.md Rule 5.
+On approval → commit: `git add artifacts/specs/{N}-{slug}-spec.md` + commit per CLAUDE.md Rule 5.
 
 Run Gate 2.5 → update issue status:
 ```bash

--- a/plugins/dev-core/skills/spec/references/templates.md
+++ b/plugins/dev-core/skills/spec/references/templates.md
@@ -33,15 +33,9 @@ description: "{one-line description}"
 
 ### Data Structure
 
-**Diagram:** [{data model title}](../visuals/{N}-{slug}-data-model.html)
+{Core types/models, fields, relationships. Note frozen vs mutable where useful. Markdown only — no HTML sidecars.}
 
-{One-line summary of core types and frozen/mutable annotations.}
-
-### Consumer Map
-
-**Diagram:** [{consumer map title}](../visuals/{N}-{slug}-consumers.html)
-
-**Legend:** Solid edges = this issue. Dashed edges = future consumers.
+### Consumers
 
 | Consumer | Fields consumed | When | Status |
 |----------|----------------|------|--------|


### PR DESCRIPTION
## Summary
- `/spec` §Data Model & Consumers is **markdown only** (prose + optional consumer table)
- No more required `*-data-model.html` / `*-consumers.html` forge-chart sidecars
- Align template, forge-chart-sidecar mapping, and README
- Bump `spec` skill to 0.2.1 and `dev-core` plugin to 0.10.3

## Test Plan
- [x] pre-push vitest (841 pass)
- [ ] Spot-check: `/spec` no longer instructs forge-chart before writing σ

---
Generated via `/ship`