### PR TITLE
feat(dev-core): lean /spec executive summary with Intent

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. adversarial), dual-harness task list + worktrees, safety hooks (Claude + Grok).",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/spec/README.md
+++ b/plugins/dev-core/skills/spec/README.md
@@ -25,7 +25,7 @@ Triggers: `"write spec"` | `"spec this"` | `"solution design"` | `"acceptance cr
 2. **Generate** — promote SRC → σ without interactive `/interview` AQs; unknowns become `[NEEDS CLARIFICATION]`.
 3. **Pre-check** — binary criteria, breadboard refs, χ budget, slice coverage; auto-fix cheap issues.
 4. **Expert review** — architect, doc-writer, product-lead, adversarial (devops/axial when relevant) in parallel.
-5. **Executive Summary** — one-liner, scope, users, slices, criteria, χ, pre-check, expert notes — then **stop**.
+5. **Executive Summary (lean)** — Intent (Solve + Done when) → Scope → Delivery → Gates; ≤30s scan; hard caps (≤5 criteria, ≤4 In bullets) — then **stop**.
 6. **React** — natural language: approve · change X · questions · re-spec · split. Revise loops re-print the summary.
 
 ## Output artifact
@@ -34,7 +34,7 @@ Triggers: `"write spec"` | `"spec this"` | `"solution design"` | `"acceptance cr
 artifacts/specs/{N}-{slug}-spec.md
 ```
 
-Sections: Context, Goal, Users, Expected Behavior, Data Model & Consumers (markdown prose + optional consumer table — no HTML sidecars), Breadboard, Slices, Success Criteria.
+Sections: Context, **Intent** (what we solve), Goal (done-when), Users, Expected Behavior, Data Model & Consumers (markdown prose + optional consumer table — no HTML sidecars), Breadboard, Slices, Success Criteria.
 
 ## Chain position
 

--- a/plugins/dev-core/skills/spec/SKILL.md
+++ b/plugins/dev-core/skills/spec/SKILL.md
@@ -87,6 +87,7 @@ Run /analyze --issue N (or /frame), or re-run with --analysis <path> / --frame <
 Read SRC → extract: title, issue#, tier, **problem/intent**, outcome, appetite, recommended shape (if α).
 - Intent (SRC Problem) → σ `## Intent` + exec summary **Solve**
 - Outcome → σ `## Goal` + exec summary **Done when**
+- Problem empty/sparse → Intent from title + outcome (1–2 lines), or χ if still unclear — ¬invent a problem SRC never stated
 
 ### 0b. Ensure GitHub Issue
 
@@ -106,7 +107,7 @@ Glob `artifacts/specs/{N}-*`, `artifacts/specs/*{slug}*`.
 
 | State | Action |
 |-------|--------|
-| ∃ σ ∧ `status: approved` | **Reuse.** Print short note + full **Executive Summary** of existing σ → Step 5/6 (chat: approve to keep & continue pipeline, or "re-spec" / changes). ¬regenerate unless user asks. |
+| ∃ σ ∧ `status: approved` | **Reuse.** Print short note + **lean Executive Summary** (Step 5 structure + hard caps) of existing σ → Step 5/6 (chat: approve to keep & continue pipeline, or "re-spec" / changes). ¬regenerate unless user asks. |
 | ∃ σ ∧ draft / no status | Load as base → Step 2 refine (fill gaps, re-check) |
 | ¬∃ σ | Step 2 generate fresh |
 
@@ -207,7 +208,7 @@ Print **exactly this structure** (fill from σ + Steps 3–4). HITL surface — 
 - Intent block: ≤4 short lines total
 - Scope In / Out: ≤4 / ≤3 one-line bullets
 - Criteria: first **5** only; if more → `+{n} in file`
-- Expert notes: ≤3 bullets or `clean`
+- Experts: ≤3 bullets or `clean`
 - Forbidden in summary: Expected Behavior narrative, breadboard tables, full criteria dump
 
 ```markdown

--- a/plugins/dev-core/skills/spec/SKILL.md
+++ b/plugins/dev-core/skills/spec/SKILL.md
@@ -2,7 +2,7 @@
 name: spec
 argument-hint: '[--issue <N> | --analysis <path> | --frame <path> | --audit]'
 description: Solution spec — acceptance criteria, breadboard, slices. Triggers: "write spec" | "spec this" | "solution design" | "what will we build" | "design the solution" | "acceptance criteria" | "define acceptance criteria" | "spec it out" | "write the spec".
-version: 0.3.0
+version: 0.3.1
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, Skill, ToolSearch
 ---
 
@@ -84,7 +84,9 @@ No analysis/frame found for #{N}.
 Run /analyze --issue N (or /frame), or re-run with --analysis <path> / --frame <path>.
 ```
 
-Read SRC → extract: title, issue#, tier, problem, outcome, appetite, recommended shape (if α).
+Read SRC → extract: title, issue#, tier, **problem/intent**, outcome, appetite, recommended shape (if α).
+- Intent (SRC Problem) → σ `## Intent` + exec summary **Solve**
+- Outcome → σ `## Goal` + exec summary **Done when**
 
 ### 0b. Ensure GitHub Issue
 
@@ -129,13 +131,16 @@ Write σ with `status: draft`. Must include:
 | Section | Skip if |
 |---------|---------|
 | `## Context` — source + promoted-from link | — |
-| `## Goal` — one-sentence outcome | — |
+| `## Intent` — what we seek to solve (pain / gap / broken invariant) + why now | — |
+| `## Goal` — one-sentence observable outcome | — |
 | `## Users` — who is affected | — |
 | `## Expected Behavior` — narrative walkthrough | — |
 | `## Data Model & Consumers` — prose types + optional consumer table (markdown only) | Tier S |
 | `## Breadboard` — affordance tables + wiring | Tier S |
 | `## Slices` — vertical increments table | Tier S |
 | `## Success Criteria` — `- [ ]` checkboxes, each binary | — |
+
+**Intent ≠ Goal.** Intent = *why / what problem*. Goal = *done-when*. Never collapse into one sentence.
 
 ### Data Model & Consumers (Tier F-lite, F-full)
 
@@ -196,58 +201,49 @@ Incorporate high-confidence feedback into σ. Unresolved expert concerns → lis
 
 Open σ for the user: `code artifacts/specs/{N}-{slug}-spec.md` (or print path if `code` unavailable).
 
-Print **exactly this structure** (fill from σ + Steps 3–4). This is the HITL surface — keep it scannable, not a paste of the whole file:
+Print **exactly this structure** (fill from σ + Steps 3–4). HITL surface — **scannable in ≤30s**, not a paste of σ.
+
+**Hard size caps (enforce):**
+- Intent block: ≤4 short lines total
+- Scope In / Out: ≤4 / ≤3 one-line bullets
+- Criteria: first **5** only; if more → `+{n} in file`
+- Expert notes: ≤3 bullets or `clean`
+- Forbidden in summary: Expected Behavior narrative, breadboard tables, full criteria dump
 
 ```markdown
 ## Spec — Executive Summary
 
-**Issue:** #{N} — {title}
-**Path:** `artifacts/specs/{N}-{slug}-spec.md`
-**Tier:** {τ} · **Status:** draft
-**Source:** {α|φ path}
+**#{N}** — {title}
+`artifacts/specs/{N}-{slug}-spec.md` · **{τ}** · draft · src `{α|φ short path}`
 
-### One-liner
-{Goal — one sentence}
+### Intent
+**Solve:** {1–2 sentences — pain / gap / broken invariant we fix; why now}
+**Done when:** {Goal — one observable outcome sentence}
+**Today → Target:** {optional one-liner each; omit if obvious}
 
 ### Scope
-- **In:** {3–6 bullets from Goal / Expected Behavior / Slices}
-- **Out:** {from Context / explicit non-goals, or "—"}
+- **In:** {≤4 one-line bullets}
+- **Out:** {≤3 one-line bullets, or "—"}
+- **Who:** {primary (+ secondary) — one line}
 
-### Users
-{Primary (+ secondary if any) — one line each}
-
-### Slices
-| # | Slice | Demo value |
-|---|-------|------------|
+### Delivery
+| # | Slice | Demo |
+|---|-------|------|
 | V1 | … | … |
-| V2 | … | … |
 
-(or "— (Tier S / no slices)" )
+(or "— (Tier S)" )
 
-### Success criteria ({count})
-1. …
-2. …
-(list all binary criteria; if >12, list first 10 + "… +{n} more in file")
+**Criteria ({n}):** 1) … 2) … 3) … 4) … 5) … {if n>5: `+{n-5} in file`}
+**χ ({n}):** {each short, or "none"}
 
-### Open / χ ({count})
-- {each NEEDS CLARIFICATION, or "none"}
-
-### Pre-check
-{pass | N failed — bullets}
-
-### Expert notes
-{0–5 bullets of unresolved concerns, or "clean"}
-
-### Data model
-{1–3 lines from §Data Model & Consumers, or "—"}
+### Gates
+**Pre-check:** {pass | fail — ≤3 bullets}
+**Experts:** {clean | ≤3 unresolved}
+**Data model:** {1–2 lines from §Data Model & Consumers, or "—"}
 
 ---
 **Your move (free text — no menu):**
-- approve / ok / ship → commit & mark approved
-- change … / drop slice V2 / tighten criterion 3 → I revise σ and re-print this summary
-- question … → I answer; revise only if you ask
-- re-spec → regenerate from SRC
-- split → propose smart-split (if criteria/slices large)
+approve / ok → commit + mark approved · change … → revise + re-print · question … → answer · re-spec · split
 ```
 
 **STOP this turn** after printing the summary. Do not commit. Do not invoke `/plan`. Do not AskUserQuestion.

--- a/plugins/dev-core/skills/spec/references/templates.md
+++ b/plugins/dev-core/skills/spec/references/templates.md
@@ -17,9 +17,13 @@ description: "{one-line description}"
 **Promoted from:** [{analysis title}]({relative path to analysis})
 **GitHub issue:** #{N}
 
+## Intent
+
+{1–3 short paragraphs or bullets: what we seek to solve — pain / gap / broken invariant, why now, observable impact. From SRC Problem. Not the solution shape.}
+
 ## Goal
 
-{one sentence — what this builds and why}
+{one sentence — observable done-when outcome}
 
 ## Users
 


### PR DESCRIPTION
## Summary

Follow-up to #398 (chat-native `/spec` Executive Summary). The merged summary was still too large and led with a Goal-only one-liner — no **intent** of what we seek to solve.

- Add **`## Intent`** to σ (distinct from Goal: why/problem vs done-when)
- Replace bloated Step 5 card with lean template: **Intent → Scope → Delivery → Gates**
- Hard size caps (≤30s scan, top 5 criteria, ≤4 In / ≤3 Out bullets)
- Keep **markdown-only** Data Model from #400 (no HTML sidecars reintroduced)
- Bump `spec` skill **0.3.1**, `dev-core` **0.10.5**

## Test plan

- [ ] `/spec --issue N` prints compact summary with **Solve** / **Done when** first
- [ ] Spec file on disk has `## Intent` before `## Goal`
- [ ] Criteria >5 → only 5 listed + `+N in file`
- [ ] Free-text `approve` still works; no AskUserQuestion
- [ ] No forge-chart / `artifacts/visuals/*-data-model.html` requirements reappear