### PR TITLE
feat(promote): re-emit Closes #N on staging→main PR body

### DIFF
--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. /adversarial, /advisory), dual-harness task list + worktrees, safety hooks (Claude + Grok).",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. /adversarial, /advisory), dual-harness task list + worktrees, safety hooks (Claude + Grok).",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/skills/promote/README.md
+++ b/plugins/dev-core/skills/promote/README.md
@@ -25,7 +25,7 @@ Triggers: `"promote staging"` | `"release"` | `"deploy"` | `"cut a release"` | `
 3. **Deploy preview** (optional) — triggers `deploy-preview.yml` workflow and waits for it.
 4. **Summary** — shows version, commit count, file count, CI status, preview result.
 5. **Changelog commit** — creates a temp branch (if staging is protected), commits changelog, merges via PR.
-6. **Promotion PR** — `gh pr create --base main --head staging`.
+6. **Promotion PR** — `gh pr create --base main --head staging`, body includes a **Closes** section re-emitted from feature PR/commit keywords (`collect-closing-issues.sh`). GitHub auto-closes those issues when the promote merges into `main` (default branch only — feature→staging merges do not close).
 7. **Post-merge reminder** — merge commit only, never squash (see `../shared/references/release-convention.md`).
 
 ## Finalize (`--finalize`)

--- a/plugins/dev-core/skills/promote/README.md
+++ b/plugins/dev-core/skills/promote/README.md
@@ -25,7 +25,7 @@ Triggers: `"promote staging"` | `"release"` | `"deploy"` | `"cut a release"` | `
 3. **Deploy preview** (optional) — triggers `deploy-preview.yml` workflow and waits for it.
 4. **Summary** — shows version, commit count, file count, CI status, preview result.
 5. **Changelog commit** — creates a temp branch (if staging is protected), commits changelog, merges via PR.
-6. **Promotion PR** — `gh pr create --base main --head staging`, body includes a **Closes** section re-emitted from feature PR/commit keywords (`collect-closing-issues.sh`). GitHub auto-closes those issues when the promote merges into `main` (default branch only — feature→staging merges do not close).
+6. **Promotion PR** — **forced** via `create-promote-pr.sh` (always harvests + injects Closes; refuses on degraded harvest unless `--allow-degraded`). No free-form `gh pr create` for promote. GitHub auto-closes listed issues when the promote merges into `main`.
 7. **Post-merge reminder** — merge commit only, never squash (see `../shared/references/release-convention.md`).
 
 ## Finalize (`--finalize`)

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -237,21 +237,12 @@ Promotion Summary
 
 ## Step 7 — Create Promotion PR
 
-**Closing issues (auto-close on merge to `main`).** Feature PRs often carry `Closes #N` but merge into **`staging`**, so GitHub never closes those issues (keywords only fire on the **default branch**). Re-emit them on the promote PR:
+**Forced path (no free-form `gh pr create`).** Use `create-promote-pr.sh` — it always runs `collect-closing-issues.sh` and injects the Closes section. Skipping harvest is impossible without editing the wrapper.
 
 ```bash
-CLOSES_SECTION=$(bash "${CLAUDE_SKILL_DIR}/collect-closing-issues.sh" main staging --section)
-# Harvest: commit messages + PR bodies (gh pr list — squash-safe).
-# Extract/format SSOT: lib/closing-issues.ts via closing-issues-cli.ts (bun).
-# Open issues only when gh can resolve state. Empty section when none — omit is fine.
-# Review stderr WARNs (partial harvest) before merge.
-```
-
-```bash
-gh pr create \
-  --base main --head staging \
-  --title "chore: promote staging to main ($VERSION)" \
-  --body "$(cat <<EOF
+# 1) Write body WITHOUT Closes (wrapper appends harvest)
+BODY_FILE="$(mktemp)"
+cat >"$BODY_FILE" <<EOF
 ## Promotion: staging → main ($VERSION)
 
 {changelog}
@@ -262,16 +253,23 @@ gh pr create \
 - [{preview_check}] Deploy preview verified
 - [x] Release notes committed to staging
 
-${CLOSES_SECTION}
 ---
 Generated with [Roxabi dev-core](https://github.com/Roxabi/roxabi-plugins) via \`/promote\`
 EOF
-)"
+
+# 2) Create or update staging→main PR (harvest + inject mandatory)
+# Exit 1 if harvest degraded (exit 3 from collect) unless --allow-degraded after human review.
+PR_URL=$(bash "${CLAUDE_SKILL_DIR}/create-promote-pr.sh" \
+  --base main --head staging \
+  --title "chore: promote staging to main ($VERSION)" \
+  --body-file "$BODY_FILE")
+# Optional after reviewing WARNs: add --allow-degraded
+rm -f "$BODY_FILE"
 ```
 
-**Does this auto-close?** For every `Closes #N` **listed in the promote body** after harvest: yes, when the promote PR **merges into `main`**. Harvest is **best-effort** (same-repo keyword adjacency only; open issues at harvest; review stderr WARNs / exit 3 = degraded). Cross-repo `owner/repo#N` is **not** re-emitted. Always eyeball the Closes section before merge.
+**Does this auto-close?** For every `Closes #N` **listed in the promote body** after harvest: yes, when the promote PR **merges into `main`**. Harvest is **best-effort** (same-repo keyword adjacency only; open issues at harvest). Degraded harvest **REFUSE**s the PR create unless `--allow-degraded`. Cross-repo `owner/repo#N` is not re-emitted. Eyeball the Closes section before merge.
 
-Display PR URL.
+Display PR URL (`$PR_URL`).
 
 ## Step 8 — Post-merge Reminder
 
@@ -403,9 +401,11 @@ Under `release.model: trunk` the contract changes on four points:
 | Open PRs on σ | Warn, list, Q |
 | CI failing | Warn, show failures, Q |
 | Preview fails | Show error, Q |
-| PR already exists | Detect via `gh pr list`, offer update (refresh body + Closes section) |
-| No closing keywords in range | Omit `## Issues closed by this promote` (ok) |
-| Closing keywords only on feature→staging PRs | Re-emitted on promote via `collect-closing-issues.sh` |
+| PR already exists | `create-promote-pr.sh` updates open staging→main PR (title + body + Closes) |
+| No closing keywords in range | Omit Closes section (ok) |
+| Closing keywords only on feature→staging PRs | Re-emitted via forced collect in `create-promote-pr.sh` |
+| Harvest degraded (collect exit 3) | REFUSE create-pr unless `--allow-degraded` after human review |
+| Free-form `gh pr create` for promote | **Forbidden** — use `create-promote-pr.sh` only |
 | `--dry-run` | Summary only, ¬create PR/commit |
 | ¬merged (`--finalize`) | REFUSE: merge first |
 | Tag exists (`--finalize`) | REFUSE |

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -237,6 +237,14 @@ Promotion Summary
 
 ## Step 7 — Create Promotion PR
 
+**Closing issues (auto-close on merge to `main`).** Feature PRs often carry `Closes #N` but merge into **`staging`**, so GitHub never closes those issues (keywords only fire on the **default branch**). Re-emit them on the promote PR:
+
+```bash
+CLOSES_SECTION=$(bash "${CLAUDE_SKILL_DIR}/collect-closing-issues.sh" main staging --section)
+# Pure extract helpers (tests): lib/closing-issues.ts
+# Empty section when no keywords in origin/main..origin/staging — omit is fine.
+```
+
 ```bash
 gh pr create \
   --base main --head staging \
@@ -252,11 +260,14 @@ gh pr create \
 - [{preview_check}] Deploy preview verified
 - [x] Release notes committed to staging
 
+${CLOSES_SECTION}
 ---
 Generated with [Roxabi dev-core](https://github.com/Roxabi/roxabi-plugins) via \`/promote\`
 EOF
 )"
 ```
+
+**Does this auto-close?** Yes — when the promote PR **merges into `main`** (default branch), GitHub closes every `Closes #N` / `Fixes #N` / `Resolves #N` listed in the body (same-repo issues). Same-repo only; cross-repo needs `owner/repo#N` form and still only links, not always auto-close.
 
 Display PR URL.
 
@@ -390,7 +401,9 @@ Under `release.model: trunk` the contract changes on four points:
 | Open PRs on σ | Warn, list, Q |
 | CI failing | Warn, show failures, Q |
 | Preview fails | Show error, Q |
-| PR already exists | Detect via `gh pr list`, offer update |
+| PR already exists | Detect via `gh pr list`, offer update (refresh body + Closes section) |
+| No closing keywords in range | Omit `## Issues closed by this promote` (ok) |
+| Closing keywords only on feature→staging PRs | Re-emitted on promote via `collect-closing-issues.sh` |
 | `--dry-run` | Summary only, ¬create PR/commit |
 | ¬merged (`--finalize`) | REFUSE: merge first |
 | Tag exists (`--finalize`) | REFUSE |

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -269,7 +269,7 @@ EOF
 )"
 ```
 
-**Does this auto-close?** Yes — when the promote PR **merges into `main`** (default branch), GitHub closes every `Closes #N` / `Fixes #N` / `Resolves #N` listed in the body (same-repo issues). Same-repo only; cross-repo needs `owner/repo#N` form and still only links, not always auto-close.
+**Does this auto-close?** For every `Closes #N` **listed in the promote body** after harvest: yes, when the promote PR **merges into `main`**. Harvest is **best-effort** (same-repo keyword adjacency only; open issues at harvest; review stderr WARNs / exit 3 = degraded). Cross-repo `owner/repo#N` is **not** re-emitted. Always eyeball the Closes section before merge.
 
 Display PR URL.
 

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -241,8 +241,10 @@ Promotion Summary
 
 ```bash
 CLOSES_SECTION=$(bash "${CLAUDE_SKILL_DIR}/collect-closing-issues.sh" main staging --section)
-# Pure extract helpers (tests): lib/closing-issues.ts
-# Empty section when no keywords in origin/main..origin/staging — omit is fine.
+# Harvest: commit messages + PR bodies (gh pr list — squash-safe).
+# Extract/format SSOT: lib/closing-issues.ts via closing-issues-cli.ts (bun).
+# Open issues only when gh can resolve state. Empty section when none — omit is fine.
+# Review stderr WARNs (partial harvest) before merge.
 ```
 
 ```bash

--- a/plugins/dev-core/skills/promote/__tests__/closing-issues.test.ts
+++ b/plugins/dev-core/skills/promote/__tests__/closing-issues.test.ts
@@ -4,6 +4,7 @@ import {
   extractClosingIssueNumbers,
   extractMergedPrNumbersFromSubjects,
   formatClosesSection,
+  formatIssuesJson,
 } from '../lib/closing-issues'
 
 describe('extractClosingIssueNumbers', () => {
@@ -32,6 +33,19 @@ describe('extractClosingIssueNumbers', () => {
     expect(extractClosingIssueNumbers('')).toEqual([])
     expect(extractClosingIssueNumbers('no keywords')).toEqual([])
   })
+
+  it('extracts multi-ref on one keyword line', () => {
+    expect(extractClosingIssueNumbers('Closes #10, #11, #12')).toEqual([10, 11, 12])
+    expect(extractClosingIssueNumbers('Fixes #1 and #2')).toEqual([1, 2])
+  })
+
+  it('accepts optional colon after keyword', () => {
+    expect(extractClosingIssueNumbers('Closes: #42')).toEqual([42])
+  })
+
+  it('is case-insensitive for keyword', () => {
+    expect(extractClosingIssueNumbers('CLOSES #7\nFIXES #8')).toEqual([7, 8])
+  })
 })
 
 describe('collectClosingIssueNumbers', () => {
@@ -50,8 +64,14 @@ describe('formatClosesSection', () => {
     expect(md).toContain('## Issues closed by this promote')
     expect(md).toContain('Closes #135')
     expect(md).toContain('Closes #140')
-    // GitHub needs the keyword on its own line or with the number
     expect(md.match(/^Closes #\d+$/gm)).toEqual(['Closes #135', 'Closes #140'])
+  })
+})
+
+describe('formatIssuesJson', () => {
+  it('wraps array', () => {
+    expect(formatIssuesJson([1, 2])).toBe('{"issues":[1,2]}')
+    expect(formatIssuesJson([])).toBe('{"issues":[]}')
   })
 })
 

--- a/plugins/dev-core/skills/promote/__tests__/closing-issues.test.ts
+++ b/plugins/dev-core/skills/promote/__tests__/closing-issues.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectClosingIssueNumbers,
+  extractClosingIssueNumbers,
+  extractMergedPrNumbersFromSubjects,
+  formatClosesSection,
+} from '../lib/closing-issues'
+
+describe('extractClosingIssueNumbers', () => {
+  it('extracts Closes / Fixes / Resolves variants', () => {
+    const text = `
+      Closes #135
+      fixes #10
+      Fixed #11
+      resolve #12
+      Resolved #13
+      close #14
+      closed #15
+    `
+    expect(extractClosingIssueNumbers(text)).toEqual([10, 11, 12, 13, 14, 15, 135])
+  })
+
+  it('dedupes and sorts', () => {
+    expect(extractClosingIssueNumbers('Closes #3\nCloses #1\nFixes #3')).toEqual([1, 3])
+  })
+
+  it('ignores bare (#N) titles and Refs', () => {
+    expect(extractClosingIssueNumbers('feat(api): images (#135)\nRefs #99\nSee #42')).toEqual([])
+  })
+
+  it('returns [] for empty', () => {
+    expect(extractClosingIssueNumbers('')).toEqual([])
+    expect(extractClosingIssueNumbers('no keywords')).toEqual([])
+  })
+})
+
+describe('collectClosingIssueNumbers', () => {
+  it('unions texts', () => {
+    expect(collectClosingIssueNumbers(['Closes #1', 'Fixes #2\nCloses #1'])).toEqual([1, 2])
+  })
+})
+
+describe('formatClosesSection', () => {
+  it('returns empty when no issues', () => {
+    expect(formatClosesSection([])).toBe('')
+  })
+
+  it('emits one Closes line per issue', () => {
+    const md = formatClosesSection([135, 140])
+    expect(md).toContain('## Issues closed by this promote')
+    expect(md).toContain('Closes #135')
+    expect(md).toContain('Closes #140')
+    // GitHub needs the keyword on its own line or with the number
+    expect(md.match(/^Closes #\d+$/gm)).toEqual(['Closes #135', 'Closes #140'])
+  })
+})
+
+describe('extractMergedPrNumbersFromSubjects', () => {
+  it('parses merge commit subjects', () => {
+    expect(
+      extractMergedPrNumbersFromSubjects([
+        'Merge pull request #136 from go-silex/feat/135-pat-ticket-images',
+        'Merge pull request #142 from go-silex/staging',
+        'feat: not a merge',
+      ]),
+    ).toEqual([136, 142])
+  })
+})

--- a/plugins/dev-core/skills/promote/__tests__/closing-issues.test.ts
+++ b/plugins/dev-core/skills/promote/__tests__/closing-issues.test.ts
@@ -5,7 +5,25 @@ import {
   extractMergedPrNumbersFromSubjects,
   formatClosesSection,
   formatIssuesJson,
+  parseClosingRefList,
 } from '../lib/closing-issues'
+
+describe('parseClosingRefList', () => {
+  it('parses local multi-ref lists', () => {
+    expect(parseClosingRefList('#10, #11, #12')).toEqual([10, 11, 12])
+    expect(parseClosingRefList('#1 and #2')).toEqual([1, 2])
+  })
+
+  it('stops at non-ref prose', () => {
+    expect(parseClosingRefList('this after #99 lands')).toEqual([])
+    expect(parseClosingRefList('auth. See #88')).toEqual([])
+  })
+
+  it('skips cross-repo refs without harvesting the number', () => {
+    expect(parseClosingRefList('Roxabi/other#42')).toEqual([])
+    expect(parseClosingRefList('#10, go-silex/other#11')).toEqual([10])
+  })
+})
 
 describe('extractClosingIssueNumbers', () => {
   it('extracts Closes / Fixes / Resolves variants', () => {
@@ -46,6 +64,17 @@ describe('extractClosingIssueNumbers', () => {
   it('is case-insensitive for keyword', () => {
     expect(extractClosingIssueNumbers('CLOSES #7\nFIXES #8')).toEqual([7, 8])
   })
+
+  it('does not harvest distant #N after prose (false-positive guard)', () => {
+    expect(extractClosingIssueNumbers('we will fix this after #99 lands')).toEqual([])
+    expect(extractClosingIssueNumbers('Fixed auth. See #88 for follow-up')).toEqual([])
+    expect(extractClosingIssueNumbers('docs: mention fix for #12')).toEqual([])
+  })
+
+  it('does not re-emit cross-repo owner/repo#N as same-repo #N', () => {
+    expect(extractClosingIssueNumbers('Fixes Roxabi/other#42')).toEqual([])
+    expect(extractClosingIssueNumbers('Closes #10, go-silex/other#11')).toEqual([10])
+  })
 })
 
 describe('collectClosingIssueNumbers', () => {
@@ -64,6 +93,7 @@ describe('formatClosesSection', () => {
     expect(md).toContain('## Issues closed by this promote')
     expect(md).toContain('Closes #135')
     expect(md).toContain('Closes #140')
+    expect(md).toContain('best-effort')
     expect(md.match(/^Closes #\d+$/gm)).toEqual(['Closes #135', 'Closes #140'])
   })
 })

--- a/plugins/dev-core/skills/promote/collect-closing-issues.sh
+++ b/plugins/dev-core/skills/promote/collect-closing-issues.sh
@@ -3,28 +3,42 @@
 #
 # Sources (union):
 #   1. Closing keywords in commit messages origin/BASE..origin/HEAD
-#   2. Closing keywords in bodies of PRs whose merge commits appear in that range
+#   2. Bodies of PRs merged into HEAD whose merge commit is in that range
+#      (via `gh pr list` — works for squash/rebase, not only "Merge pull request #N")
+#
+# Extract/format SSOT: lib/closing-issues.ts via closing-issues-cli.ts (bun).
+# Open-issue filter: when `gh` works, drop numbers that are already closed.
 #
 # Usage:
 #   bash collect-closing-issues.sh [BASE] [HEAD]
-#   bash collect-closing-issues.sh main staging --section   # markdown section
-#   bash collect-closing-issues.sh main staging --json      # {"issues":[...]}
+#   bash collect-closing-issues.sh --section
+#   bash collect-closing-issues.sh main staging --section
+#   bash collect-closing-issues.sh main staging --json
 #
-# Exit 0 always when git works (empty list is success). Exit 1 on git failure.
+# Exit 0 when git works (empty list is success). Exit 1 on git ref failure.
+# Exit 2 on unknown flags. WARN on stderr when gh degrades (partial harvest).
 set -euo pipefail
 
-BASE="${1:-main}"
-HEAD="${2:-staging}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE="main"
+HEAD="staging"
 MODE="list" # list | section | json
-for a in "${@:3}"; do
+ARGS=()
+for a in "$@"; do
   case "$a" in
     --section) MODE=section ;;
     --json) MODE=json ;;
     --list) MODE=list ;;
+    -*)
+      echo "error: unknown flag: $a" >&2
+      exit 2
+      ;;
+    *) ARGS+=("$a") ;;
   esac
 done
+BASE="${ARGS[0]:-$BASE}"
+HEAD="${ARGS[1]:-$HEAD}"
 
-# Prefer origin/ when present (promote runs after fetch).
 ref() {
   local b="$1"
   if git rev-parse --verify "origin/$b" >/dev/null 2>&1; then
@@ -47,72 +61,126 @@ if ! git rev-parse --verify "$HEAD_REF" >/dev/null 2>&1; then
 fi
 
 RANGE="${BASE_REF}..${HEAD_REF}"
-
-# Pure keyword extract (mirrors lib/closing-issues.ts)
-extract_kw() {
-  # shellcheck disable=SC2001
-  grep -oE '\b([Cc]lose[sd]?|[Ff]ix(e[sd])?|[Rr]esolve[sd]?)\s+#[0-9]+' \
-    | grep -oE '#[0-9]+' \
-    | tr -d '#' \
-    || true
-}
-
 TEXTS_FILE="$(mktemp)"
-trap 'rm -f "$TEXTS_FILE"' EXIT
+RANGE_SHAS="$(mktemp)"
+trap 'rm -f "$TEXTS_FILE" "$RANGE_SHAS"' EXIT
+
+git rev-list "$RANGE" 2>/dev/null >"$RANGE_SHAS" || true
 
 # 1) Commit messages in range
-git log "$RANGE" --format='%B%n---' 2>/dev/null >>"$TEXTS_FILE" || true
-
-# 2) Bodies of merge PRs in range
-PR_NUMS=$(
-  git log "$RANGE" --merges --pretty=format:'%s' 2>/dev/null \
-    | sed -n 's/^Merge pull request #\([0-9][0-9]*\).*/\1/p' \
-    | sort -n -u \
-    || true
-)
-
-if [ -n "$PR_NUMS" ] && command -v gh >/dev/null 2>&1; then
-  while IFS= read -r pr; do
-    [ -z "$pr" ] && continue
-    body="$(gh pr view "$pr" --json body --jq '.body // empty' 2>/dev/null || true)"
-    if [ -n "$body" ]; then
-      printf '%s\n---\n' "$body" >>"$TEXTS_FILE"
-    fi
-  done <<<"$PR_NUMS"
+if ! git log "$RANGE" --format='%B%n---' >>"$TEXTS_FILE" 2>/dev/null; then
+  echo "warn: git log $RANGE failed — commit texts skipped" >&2
 fi
 
-ISSUES=$(
-  extract_kw <"$TEXTS_FILE" \
-    | sort -n -u \
-    | grep -E '^[1-9][0-9]*$' \
-    || true
-)
+GH_DEGRADED=0
+PR_BODY_HITS=0
+
+in_range() {
+  local oid="$1"
+  [ -n "$oid" ] && grep -qxF "$oid" "$RANGE_SHAS" 2>/dev/null
+}
+
+append_pr_body() {
+  local pr="$1"
+  local body
+  body="$(gh pr view "$pr" --json body --jq '.body // empty' 2>/dev/null)" || {
+    GH_DEGRADED=1
+    echo "warn: gh pr view #$pr failed" >&2
+    return 0
+  }
+  if [ -n "$body" ]; then
+    printf '%s\n---\n' "$body" >>"$TEXTS_FILE"
+    PR_BODY_HITS=$((PR_BODY_HITS + 1))
+  fi
+}
+
+# 2) PR bodies via API (squash-safe)
+if command -v gh >/dev/null 2>&1; then
+  PR_META="$(gh pr list --base "$HEAD" --state merged --limit 200 \
+    --json number,mergeCommit 2>/dev/null)" || PR_META=""
+  if [ -z "$PR_META" ]; then
+    GH_DEGRADED=1
+    echo "warn: gh pr list failed — trying merge-commit subject fallback" >&2
+  else
+    while IFS=$'\t' read -r pr oid; do
+      [ -z "$pr" ] && continue
+      in_range "$oid" || continue
+      append_pr_body "$pr"
+    done < <(printf '%s' "$PR_META" | jq -r '
+      .[]
+      | select(.mergeCommit != null and .mergeCommit.oid != null)
+      | "\(.number)\t\(.mergeCommit.oid)"
+      ' 2>/dev/null || true)
+  fi
+
+  # Fallback: classic merge subjects
+  if [ "$PR_BODY_HITS" -eq 0 ]; then
+    PR_NUMS=$(
+      git log "$RANGE" --merges --pretty=format:'%s' 2>/dev/null \
+        | sed -n 's/^Merge pull request #\([0-9][0-9]*\).*/\1/p' \
+        | sort -n -u \
+        || true
+    )
+    if [ -n "$PR_NUMS" ]; then
+      while IFS= read -r pr; do
+        [ -z "$pr" ] && continue
+        append_pr_body "$pr"
+      done <<<"$PR_NUMS"
+    fi
+  fi
+else
+  GH_DEGRADED=1
+  echo "warn: gh not installed — PR bodies not harvested (commit messages only)" >&2
+fi
+
+CLI="$SCRIPT_DIR/lib/closing-issues-cli.ts"
+if ! command -v bun >/dev/null 2>&1; then
+  echo "error: bun required to run closing-issues-cli.ts (SSOT extract)" >&2
+  exit 1
+fi
+
+RAW_ISSUES="$(bun run "$CLI" --list <"$TEXTS_FILE")"
+
+# Keep only OPEN issues when gh can resolve state (skip already closed)
+ISSUES=""
+if [ -n "$RAW_ISSUES" ] && command -v gh >/dev/null 2>&1; then
+  while IFS= read -r n; do
+    [ -z "$n" ] && continue
+    st="$(gh issue view "$n" --json state --jq '.state' 2>/dev/null || echo "")"
+    if [ -z "$st" ]; then
+      echo "warn: could not resolve issue #$n state — keeping for re-emit" >&2
+      ISSUES="${ISSUES}${n}"$'\n'
+      GH_DEGRADED=1
+    elif [ "$st" = "OPEN" ]; then
+      ISSUES="${ISSUES}${n}"$'\n'
+    fi
+  done <<<"$RAW_ISSUES"
+  ISSUES="$(printf '%s' "$ISSUES" | sed '/^$/d')"
+else
+  ISSUES="$RAW_ISSUES"
+fi
+
+if [ "$GH_DEGRADED" -eq 1 ]; then
+  echo "warn: partial harvest (gh degraded) — review Closes list before merge" >&2
+fi
 
 case "$MODE" in
   json)
-    # Build JSON array without jq dependency for empty case
     if [ -z "$ISSUES" ]; then
       echo '{"issues":[]}'
     else
-      arr=$(echo "$ISSUES" | paste -sd, -)
-      echo "{\"issues\":[$arr]}"
+      printf '%s\n' "$ISSUES" | awk '{print "Closes #" $1}' | bun run "$CLI" --json
     fi
     ;;
   section)
     if [ -z "$ISSUES" ]; then
       exit 0
     fi
-    echo "## Issues closed by this promote"
-    echo ""
-    echo "Re-emitted from feature PR / commit closing keywords. GitHub auto-closes"
-    echo "these when this PR merges into the default branch (\`main\`):"
-    echo ""
-    while IFS= read -r n; do
-      [ -n "$n" ] && echo "Closes #$n"
-    done <<<"$ISSUES"
-    echo ""
+    printf '%s\n' "$ISSUES" | awk '{print "Closes #" $1}' | bun run "$CLI" --section
     ;;
   list|*)
-    echo "$ISSUES"
+    if [ -n "$ISSUES" ]; then
+      printf '%s\n' "$ISSUES"
+    fi
     ;;
 esac

--- a/plugins/dev-core/skills/promote/collect-closing-issues.sh
+++ b/plugins/dev-core/skills/promote/collect-closing-issues.sh
@@ -102,6 +102,11 @@ if command -v gh >/dev/null 2>&1; then
     GH_DEGRADED=1
     echo "warn: gh pr list failed — trying merge-commit subject fallback" >&2
   else
+    PR_COUNT=$(printf '%s' "$PR_META" | jq 'length' 2>/dev/null || echo 0)
+    if [ "$PR_COUNT" = "200" ]; then
+      echo "warn: gh pr list hit --limit 200 — may under-harvest; paginate if needed" >&2
+      GH_DEGRADED=1
+    fi
     while IFS=$'\t' read -r pr oid; do
       [ -z "$pr" ] && continue
       in_range "$oid" || continue
@@ -162,6 +167,7 @@ fi
 
 if [ "$GH_DEGRADED" -eq 1 ]; then
   echo "warn: partial harvest (gh degraded) — review Closes list before merge" >&2
+  echo "warn: exit 3 (degraded) — agents must not ignore stderr" >&2
 fi
 
 case "$MODE" in
@@ -174,7 +180,11 @@ case "$MODE" in
     ;;
   section)
     if [ -z "$ISSUES" ]; then
+      [ "$GH_DEGRADED" -eq 1 ] && exit 3
       exit 0
+    fi
+    if [ "$GH_DEGRADED" -eq 1 ]; then
+      echo "<!-- promote-closes:degraded -->"
     fi
     printf '%s\n' "$ISSUES" | awk '{print "Closes #" $1}' | bun run "$CLI" --section
     ;;
@@ -184,3 +194,7 @@ case "$MODE" in
     fi
     ;;
 esac
+
+# Non-zero when harvest integrity is partial so $(...) callers can detect degrade.
+[ "$GH_DEGRADED" -eq 1 ] && exit 3
+exit 0

--- a/plugins/dev-core/skills/promote/collect-closing-issues.sh
+++ b/plugins/dev-core/skills/promote/collect-closing-issues.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# collect-closing-issues.sh — list issue numbers to re-emit as Closes #N on a promote PR.
+#
+# Sources (union):
+#   1. Closing keywords in commit messages origin/BASE..origin/HEAD
+#   2. Closing keywords in bodies of PRs whose merge commits appear in that range
+#
+# Usage:
+#   bash collect-closing-issues.sh [BASE] [HEAD]
+#   bash collect-closing-issues.sh main staging --section   # markdown section
+#   bash collect-closing-issues.sh main staging --json      # {"issues":[...]}
+#
+# Exit 0 always when git works (empty list is success). Exit 1 on git failure.
+set -euo pipefail
+
+BASE="${1:-main}"
+HEAD="${2:-staging}"
+MODE="list" # list | section | json
+for a in "${@:3}"; do
+  case "$a" in
+    --section) MODE=section ;;
+    --json) MODE=json ;;
+    --list) MODE=list ;;
+  esac
+done
+
+# Prefer origin/ when present (promote runs after fetch).
+ref() {
+  local b="$1"
+  if git rev-parse --verify "origin/$b" >/dev/null 2>&1; then
+    echo "origin/$b"
+  else
+    echo "$b"
+  fi
+}
+
+BASE_REF="$(ref "$BASE")"
+HEAD_REF="$(ref "$HEAD")"
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "error: unknown base ref $BASE_REF" >&2
+  exit 1
+fi
+if ! git rev-parse --verify "$HEAD_REF" >/dev/null 2>&1; then
+  echo "error: unknown head ref $HEAD_REF" >&2
+  exit 1
+fi
+
+RANGE="${BASE_REF}..${HEAD_REF}"
+
+# Pure keyword extract (mirrors lib/closing-issues.ts)
+extract_kw() {
+  # shellcheck disable=SC2001
+  grep -oE '\b([Cc]lose[sd]?|[Ff]ix(e[sd])?|[Rr]esolve[sd]?)\s+#[0-9]+' \
+    | grep -oE '#[0-9]+' \
+    | tr -d '#' \
+    || true
+}
+
+TEXTS_FILE="$(mktemp)"
+trap 'rm -f "$TEXTS_FILE"' EXIT
+
+# 1) Commit messages in range
+git log "$RANGE" --format='%B%n---' 2>/dev/null >>"$TEXTS_FILE" || true
+
+# 2) Bodies of merge PRs in range
+PR_NUMS=$(
+  git log "$RANGE" --merges --pretty=format:'%s' 2>/dev/null \
+    | sed -n 's/^Merge pull request #\([0-9][0-9]*\).*/\1/p' \
+    | sort -n -u \
+    || true
+)
+
+if [ -n "$PR_NUMS" ] && command -v gh >/dev/null 2>&1; then
+  while IFS= read -r pr; do
+    [ -z "$pr" ] && continue
+    body="$(gh pr view "$pr" --json body --jq '.body // empty' 2>/dev/null || true)"
+    if [ -n "$body" ]; then
+      printf '%s\n---\n' "$body" >>"$TEXTS_FILE"
+    fi
+  done <<<"$PR_NUMS"
+fi
+
+ISSUES=$(
+  extract_kw <"$TEXTS_FILE" \
+    | sort -n -u \
+    | grep -E '^[1-9][0-9]*$' \
+    || true
+)
+
+case "$MODE" in
+  json)
+    # Build JSON array without jq dependency for empty case
+    if [ -z "$ISSUES" ]; then
+      echo '{"issues":[]}'
+    else
+      arr=$(echo "$ISSUES" | paste -sd, -)
+      echo "{\"issues\":[$arr]}"
+    fi
+    ;;
+  section)
+    if [ -z "$ISSUES" ]; then
+      exit 0
+    fi
+    echo "## Issues closed by this promote"
+    echo ""
+    echo "Re-emitted from feature PR / commit closing keywords. GitHub auto-closes"
+    echo "these when this PR merges into the default branch (\`main\`):"
+    echo ""
+    while IFS= read -r n; do
+      [ -n "$n" ] && echo "Closes #$n"
+    done <<<"$ISSUES"
+    echo ""
+    ;;
+  list|*)
+    echo "$ISSUES"
+    ;;
+esac

--- a/plugins/dev-core/skills/promote/create-promote-pr.sh
+++ b/plugins/dev-core/skills/promote/create-promote-pr.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# create-promote-pr.sh — forced promote PR path for /promote Step 7.
+#
+# Always harvests closing issues and injects them into the PR body.
+# Cannot be skipped by forgetting CLOSES_SECTION in free-form `gh pr create`.
+#
+# Usage:
+#   bash create-promote-pr.sh \
+#     --title "chore: promote staging to main (v1.2.3)" \
+#     --body-file /tmp/promote-body.md \
+#     [--base main] [--head staging] \
+#     [--allow-degraded] [--dry-run]
+#
+# --body-file: markdown WITHOUT the Closes section (wrapper appends it).
+# Exit 0 + prints PR URL. Exit 1 REFUSE (degraded without flag, missing args, gh fail).
+# Exit 2 bad flags.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE="main"
+HEAD="staging"
+TITLE=""
+BODY_FILE=""
+ALLOW_DEGRADED=0
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base) BASE="${2:-}"; shift 2 ;;
+    --head) HEAD="${2:-}"; shift 2 ;;
+    --title) TITLE="${2:-}"; shift 2 ;;
+    --body-file) BODY_FILE="${2:-}"; shift 2 ;;
+    --allow-degraded) ALLOW_DEGRADED=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help)
+      sed -n '2,20p' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      exit 2
+      ;;
+    *)
+      echo "error: unexpected arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$TITLE" ]; then
+  echo "REFUSE: --title required" >&2
+  exit 1
+fi
+if [ -z "$BODY_FILE" ] || [ ! -f "$BODY_FILE" ]; then
+  echo "REFUSE: --body-file required and must exist" >&2
+  exit 1
+fi
+if ! command -v gh >/dev/null 2>&1; then
+  echo "REFUSE: gh CLI required" >&2
+  exit 1
+fi
+
+COLLECT="$SCRIPT_DIR/collect-closing-issues.sh"
+if [ ! -x "$COLLECT" ] && [ ! -f "$COLLECT" ]; then
+  echo "REFUSE: collect-closing-issues.sh missing at $COLLECT" >&2
+  exit 1
+fi
+
+ERR_FILE="$(mktemp)"
+OUT_BODY=""
+trap 'rm -f "$ERR_FILE"; [ -n "$OUT_BODY" ] && rm -f "$OUT_BODY"' EXIT
+
+# Harvest Closes (exit 3 = degraded)
+set +e
+CLOSES_SECTION="$(bash "$COLLECT" "$BASE" "$HEAD" --section 2>"$ERR_FILE")"
+RC=$?
+set -e
+if [ -s "$ERR_FILE" ]; then
+  cat "$ERR_FILE" >&2
+fi
+
+if [ "$RC" -eq 3 ]; then
+  if [ "$ALLOW_DEGRADED" -ne 1 ]; then
+    echo "REFUSE: closing-issues harvest degraded (exit 3)." >&2
+    echo "  Review stderr WARNs, then re-run with --allow-degraded if the list is still OK." >&2
+    exit 1
+  fi
+  echo "WARN: proceeding with --allow-degraded after partial harvest" >&2
+elif [ "$RC" -ne 0 ]; then
+  echo "REFUSE: collect-closing-issues.sh failed (rc=$RC)" >&2
+  exit 1
+fi
+
+BASE_BODY="$(cat "$BODY_FILE")"
+# Strip trailing whitespace-only lines for clean join
+BASE_BODY="$(printf '%s' "$BASE_BODY" | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}')"
+
+if [ -n "$CLOSES_SECTION" ]; then
+  FULL_BODY="$(printf '%s\n\n%s' "$BASE_BODY" "$CLOSES_SECTION")"
+else
+  FULL_BODY="$BASE_BODY"
+  echo "info: no open closing-keyword issues in $BASE..$HEAD — body without Closes section" >&2
+fi
+
+OUT_BODY="$(mktemp)"
+printf '%s\n' "$FULL_BODY" >"$OUT_BODY"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "DRY-RUN: would create/update PR $HEAD → $BASE"
+  echo "title: $TITLE"
+  echo "--- body ---"
+  cat "$OUT_BODY"
+  echo "--- end ---"
+  exit 0
+fi
+
+EXISTING="$(gh pr list --base "$BASE" --head "$HEAD" --state open \
+  --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+
+if [ -n "$EXISTING" ]; then
+  gh pr edit "$EXISTING" --title "$TITLE" --body-file "$OUT_BODY" >/dev/null
+  URL="$(gh pr view "$EXISTING" --json url --jq .url)"
+  echo "updated existing promote PR #$EXISTING" >&2
+else
+  URL="$(gh pr create --base "$BASE" --head "$HEAD" --title "$TITLE" --body-file "$OUT_BODY")"
+fi
+
+printf '%s\n' "$URL"

--- a/plugins/dev-core/skills/promote/lib/closing-issues-cli.ts
+++ b/plugins/dev-core/skills/promote/lib/closing-issues-cli.ts
@@ -1,0 +1,36 @@
+/**
+ * CLI for collect-closing-issues.sh — SSOT extract/format path.
+ *
+ * Usage:
+ *   bun run lib/closing-issues-cli.ts --list    < texts
+ *   bun run lib/closing-issues-cli.ts --section < texts
+ *   bun run lib/closing-issues-cli.ts --json    < texts
+ *
+ * Reads UTF-8 text from stdin; writes formatted output to stdout.
+ * Exit 0 always when parse succeeds (empty list is success).
+ */
+import { extractClosingIssueNumbers, formatClosesSection, formatIssuesJson } from './closing-issues'
+
+const modeArg = process.argv.find((a) => a === '--list' || a === '--section' || a === '--json')
+const mode = modeArg === '--section' ? 'section' : modeArg === '--json' ? 'json' : 'list'
+
+const chunks: Buffer[] = []
+for await (const chunk of process.stdin) {
+  chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+}
+const text = Buffer.concat(chunks).toString('utf8')
+const issues = extractClosingIssueNumbers(text)
+
+switch (mode) {
+  case 'json':
+    process.stdout.write(`${formatIssuesJson(issues)}\n`)
+    break
+  case 'section': {
+    const section = formatClosesSection(issues)
+    if (section) process.stdout.write(section)
+    break
+  }
+  default:
+    if (issues.length > 0) process.stdout.write(`${issues.join('\n')}\n`)
+    break
+}

--- a/plugins/dev-core/skills/promote/lib/closing-issues.ts
+++ b/plugins/dev-core/skills/promote/lib/closing-issues.ts
@@ -8,20 +8,77 @@
  * Keywords (GitHub docs): close[sd]?, fix(e[sd])?, resolve[sd]?
  * Bare `(#N)` in titles is NOT a closing keyword — ignored here.
  *
- * Multi-ref: `Closes #10, #11` / `Fixes #1 and #2` → all numbers on that keyword line.
+ * Multi-ref (adjacency only): `Closes #10, #11` / `Fixes #1 and #2`.
+ * Does NOT harvest distant `#N` after prose (`we will fix this after #99`).
+ * Cross-repo `owner/repo#N` is skipped (re-emit is same-repo only).
+ *
  * This module is the **SSOT** for extract/format — collect-closing-issues.sh pipes
- * harvested text here via closing-issues-cli.ts (do not reimplement regex in bash).
+ * harvested text here via closing-issues-cli.ts.
  */
 
 /** Keyword at start of a closing phrase (optional colon). */
 const KEYWORD_PREFIX_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*/gi
 
+/** Leading separators between issue refs on a keyword line. */
+const SEP_RE = /^(?:,|and|&)\s*/i
+
+/** Same-repo `#N`. */
+const LOCAL_REF_RE = /^#(\d+)\b/
+
+/** Cross-repo `owner/repo#N` — skipped for promote re-emit. */
+const CROSS_REF_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#(\d+)\b/
+
+/**
+ * After a closing keyword, parse only the contiguous ref list (GitHub grammar).
+ * Stops at the first non-ref token so prose `#N` later on the line is ignored.
+ * Cross-repo refs are consumed but not added (same-repo re-emit only).
+ */
+export function parseClosingRefList(rest: string): number[] {
+  const nums: number[] = []
+  let pos = 0
+  const s = rest
+  // Allow leading whitespace only (already often consumed by keyword regex)
+  const lead = s.match(/^\s*/)
+  if (lead) pos += lead[0].length
+
+  let expectSep = false
+  while (pos < s.length) {
+    if (expectSep) {
+      const sep = s.slice(pos).match(SEP_RE)
+      if (!sep) break
+      pos += sep[0].length
+      const sp = s.slice(pos).match(/^\s*/)
+      if (sp) pos += sp[0].length
+    }
+
+    const cross = s.slice(pos).match(CROSS_REF_RE)
+    if (cross) {
+      pos += cross[0].length
+      expectSep = true
+      const trail = s.slice(pos).match(/^\s*/)
+      if (trail) pos += trail[0].length
+      continue
+    }
+
+    const local = s.slice(pos).match(LOCAL_REF_RE)
+    if (local) {
+      const n = Number.parseInt(local[1] ?? '', 10)
+      if (Number.isFinite(n) && n > 0) nums.push(n)
+      pos += local[0].length
+      expectSep = true
+      const trail = s.slice(pos).match(/^\s*/)
+      if (trail) pos += trail[0].length
+      continue
+    }
+
+    break
+  }
+  return nums
+}
+
 /**
  * Extract unique issue numbers referenced by closing keywords in free text
  * (PR body, commit message). Sorted ascending.
- *
- * Scans each keyword occurrence, then takes every `#N` on the remainder of that line
- * (GitHub multi-ref form).
  */
 export function extractClosingIssueNumbers(text: string): number[] {
   if (!text) return []
@@ -31,10 +88,7 @@ export function extractClosingIssueNumbers(text: string): number[] {
     let m: RegExpExecArray | null = KEYWORD_PREFIX_RE.exec(line)
     while (m !== null) {
       const rest = line.slice(m.index + m[0].length)
-      for (const hm of rest.matchAll(/#(\d+)\b/g)) {
-        const n = Number.parseInt(hm[1] ?? '', 10)
-        if (Number.isFinite(n) && n > 0) nums.add(n)
-      }
+      for (const n of parseClosingRefList(rest)) nums.add(n)
       m = KEYWORD_PREFIX_RE.exec(line)
     }
   }
@@ -59,8 +113,9 @@ export function formatClosesSection(issueNumbers: number[]): string {
   const lines = [
     '## Issues closed by this promote',
     '',
-    'Re-emitted from feature PR / commit closing keywords. GitHub auto-closes',
-    'these when this PR merges into the default branch (`main`):',
+    'Re-emitted from feature PR / commit closing keywords (same-repo, open at harvest).',
+    'GitHub auto-closes these when this PR merges into the default branch (`main`).',
+    'Review this list before merge — harvest is best-effort.',
     '',
     ...issueNumbers.map((n) => `Closes #${n}`),
     '',

--- a/plugins/dev-core/skills/promote/lib/closing-issues.ts
+++ b/plugins/dev-core/skills/promote/lib/closing-issues.ts
@@ -7,23 +7,36 @@
  *
  * Keywords (GitHub docs): close[sd]?, fix(e[sd])?, resolve[sd]?
  * Bare `(#N)` in titles is NOT a closing keyword — ignored here.
+ *
+ * Multi-ref: `Closes #10, #11` / `Fixes #1 and #2` → all numbers on that keyword line.
+ * This module is the **SSOT** for extract/format — collect-closing-issues.sh pipes
+ * harvested text here via closing-issues-cli.ts (do not reimplement regex in bash).
  */
 
-/** Match GitHub auto-close keywords → issue number. */
-export const CLOSING_KEYWORD_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi
+/** Keyword at start of a closing phrase (optional colon). */
+const KEYWORD_PREFIX_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*/gi
 
 /**
  * Extract unique issue numbers referenced by closing keywords in free text
  * (PR body, commit message). Sorted ascending.
+ *
+ * Scans each keyword occurrence, then takes every `#N` on the remainder of that line
+ * (GitHub multi-ref form).
  */
 export function extractClosingIssueNumbers(text: string): number[] {
   if (!text) return []
   const nums = new Set<number>()
-  // reset lastIndex for global regex reuse
-  CLOSING_KEYWORD_RE.lastIndex = 0
-  for (const m of text.matchAll(CLOSING_KEYWORD_RE)) {
-    const n = Number.parseInt(m[1] ?? '', 10)
-    if (Number.isFinite(n) && n > 0) nums.add(n)
+  for (const line of text.split(/\r?\n/)) {
+    KEYWORD_PREFIX_RE.lastIndex = 0
+    let m: RegExpExecArray | null = KEYWORD_PREFIX_RE.exec(line)
+    while (m !== null) {
+      const rest = line.slice(m.index + m[0].length)
+      for (const hm of rest.matchAll(/#(\d+)\b/g)) {
+        const n = Number.parseInt(hm[1] ?? '', 10)
+        if (Number.isFinite(n) && n > 0) nums.add(n)
+      }
+      m = KEYWORD_PREFIX_RE.exec(line)
+    }
   }
   return [...nums].sort((a, b) => a - b)
 }
@@ -57,7 +70,7 @@ export function formatClosesSection(issueNumbers: number[]): string {
 
 /**
  * Parse "Merge pull request #N" subjects from merge-commit subjects.
- * Returns PR numbers (not issue numbers).
+ * Returns PR numbers (not issue numbers). Fallback when `gh pr list` unavailable.
  */
 export function extractMergedPrNumbersFromSubjects(subjects: Iterable<string>): number[] {
   const re = /^Merge pull request #(\d+)\b/i
@@ -69,4 +82,9 @@ export function extractMergedPrNumbersFromSubjects(subjects: Iterable<string>): 
     if (Number.isFinite(n) && n > 0) nums.add(n)
   }
   return [...nums].sort((a, b) => a - b)
+}
+
+/** Format issue list as JSON. */
+export function formatIssuesJson(issueNumbers: number[]): string {
+  return JSON.stringify({ issues: issueNumbers })
 }

--- a/plugins/dev-core/skills/promote/lib/closing-issues.ts
+++ b/plugins/dev-core/skills/promote/lib/closing-issues.ts
@@ -1,0 +1,72 @@
+/**
+ * closing-issues.ts — extract GitHub closing keywords for /promote PR body
+ *
+ * Feature PRs merge into `staging` with `Closes #N`, but GitHub only auto-closes
+ * when the PR that carries the keyword merges into the **default branch**.
+ * Promote re-emits those keywords on the staging→main PR so merge to main closes them.
+ *
+ * Keywords (GitHub docs): close[sd]?, fix(e[sd])?, resolve[sd]?
+ * Bare `(#N)` in titles is NOT a closing keyword — ignored here.
+ */
+
+/** Match GitHub auto-close keywords → issue number. */
+export const CLOSING_KEYWORD_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi
+
+/**
+ * Extract unique issue numbers referenced by closing keywords in free text
+ * (PR body, commit message). Sorted ascending.
+ */
+export function extractClosingIssueNumbers(text: string): number[] {
+  if (!text) return []
+  const nums = new Set<number>()
+  // reset lastIndex for global regex reuse
+  CLOSING_KEYWORD_RE.lastIndex = 0
+  for (const m of text.matchAll(CLOSING_KEYWORD_RE)) {
+    const n = Number.parseInt(m[1] ?? '', 10)
+    if (Number.isFinite(n) && n > 0) nums.add(n)
+  }
+  return [...nums].sort((a, b) => a - b)
+}
+
+/** Union of extractClosingIssueNumbers over many texts. */
+export function collectClosingIssueNumbers(texts: Iterable<string>): number[] {
+  const nums = new Set<number>()
+  for (const t of texts) {
+    for (const n of extractClosingIssueNumbers(t)) nums.add(n)
+  }
+  return [...nums].sort((a, b) => a - b)
+}
+
+/**
+ * Markdown section for the promote PR body.
+ * Empty string when no issues — omit section entirely.
+ */
+export function formatClosesSection(issueNumbers: number[]): string {
+  if (issueNumbers.length === 0) return ''
+  const lines = [
+    '## Issues closed by this promote',
+    '',
+    'Re-emitted from feature PR / commit closing keywords. GitHub auto-closes',
+    'these when this PR merges into the default branch (`main`):',
+    '',
+    ...issueNumbers.map((n) => `Closes #${n}`),
+    '',
+  ]
+  return lines.join('\n')
+}
+
+/**
+ * Parse "Merge pull request #N" subjects from merge-commit subjects.
+ * Returns PR numbers (not issue numbers).
+ */
+export function extractMergedPrNumbersFromSubjects(subjects: Iterable<string>): number[] {
+  const re = /^Merge pull request #(\d+)\b/i
+  const nums = new Set<number>()
+  for (const s of subjects) {
+    const m = s.trim().match(re)
+    if (!m) continue
+    const n = Number.parseInt(m[1] ?? '', 10)
+    if (Number.isFinite(n) && n > 0) nums.add(n)
+  }
+  return [...nums].sort((a, b) => a - b)
+}


### PR DESCRIPTION
## Summary

- Add `collect-closing-issues.sh` + pure `lib/closing-issues.ts` to harvest `Closes`/`Fixes`/`Resolves` keywords from `main..staging` (commits + merged PR bodies)
- Inject `## Issues closed by this promote` into `/promote` Step 7 PR body so GitHub auto-closes issues when promote merges to the default branch
- Unit tests (8) + bump `dev-core` to **0.11.5**

## Why

Feature PRs often ship `Closes #N` but merge into **staging**. GitHub only auto-closes when the PR carrying the keyword merges into the **default branch**. Promote re-emits those keywords.

## Test plan

- [x] `bunx vitest run plugins/dev-core/skills/promote/__tests__/closing-issues.test.ts`
- [x] Full pre-push suite green
- [ ] Next `/promote`: body includes `Closes #…` for keywords in range; merge to main closes them