### PR TITLE
feat(dev-init): seed lefthook principal-freeze persist gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ predate that and were produced by release-please or `/promote`.
 
 ## Unreleased
 
+### Changed
+
+* **dev-core / dev-init:** principal freeze = lefthook persist gate (`/ci-setup` 2e + `seed-principal-freeze`) **and** plugin Pre/Post **deny** (agent). ADR-017 amended.
+
 ### Added
 
 * **dev-core/ship:** meta-orchestrator `/ship` — commit → `/pr` → `/code-review` → `/fix` loop → `reviewed` label + `/ci-watch` → optional `/cleanup` (code-already-ready path; review-before-CI order differs from `/dev` Verify)

--- a/docs/architecture/adr/017-principal-freeze-state-assert.md
+++ b/docs/architecture/adr/017-principal-freeze-state-assert.md
@@ -1,14 +1,16 @@
 ---
-title: "ADR-017: Principal freeze via state assert (not shell argv denylist)"
+title: "ADR-017: Principal freeze — lefthook persist + plugin agent deny"
 description: >
-  Principal HEAD pin for agent shells uses PostToolUse state measurement
-  (principal branch ∈ {staging,main,master}) plus a thin PreToolUse UX nudge.
-  Rejects expanding a full shell/git parser as the primary control.
+  Principal HEAD pin (HEAD ∈ {staging,main,master} on the principal worktree).
+  Persist law = lefthook / pre-commit seeded by /dev-init → /ci-setup.
+  Agent layer = plugin PreToolUse deny + PostToolUse deny-after-exec.
+  Still rejects a full shell/git argv parser.
 ---
 
 ## Status
 
-Accepted — 2026-08-07.
+Accepted — 2026-08-07. **Amended 2026-08-14** — lefthook persist gate offered by
+`/dev-init`; plugin Pre/Post kept as **agent deny** (not the persist law).
 
 ## Context
 
@@ -16,74 +18,47 @@ dev-core skills (`harness-worktree.md`) require **principal freeze**: the princi
 worktree stays on β (`staging` \| `main` \| `master`); feature work runs in a
 dedicated worktree ω.
 
-A PreToolUse hook attempted to enforce this by **parsing the agent command string**
-(shell segments, nested `bash -c`, `env`, `GIT_DIR`, `cd` tracking, git globals,
-ref-moves, …). That design grew to ~1.2k LOC + ~800 LOC tests across multiple
-adversarial fix loops. Each closed hole predicted a new encoding (scripts,
-`node -e`, aliases, heredocs, `git -c alias…`).
+A PreToolUse hook that **parsed the agent command string** grew to ~1.2k LOC.
+The priced invariant is **git state**, not argv shape.
 
-**Root mismatch:** the priced invariant is **git state** (closed, one `rev-parse`);
-the control measured **argv shape** (open language).
-
-## Options considered
-
-### A — Keep expanding the argv denylist
-- Pros: blocks some common forms before execution.
-- Cons: unbounded maintenance; residual set infinite; tests prove the parser, not I.
-- **Rejected** as primary strategy.
-
-### B — PostToolUse state assert only
-- Pros: measures I directly; closes script/node/alias holes.
-- Cons: damage already done when the hook fires (agent must restore).
-
-### C — Coarse allowlist of all `git` on principal
-- Pros: smaller Pre surface.
-- Cons: still bypassed by non-inline git; blocks legitimate ops unless carefully listed.
-
-### D — Hybrid: state primary + thin Pre UX (chosen)
-- Pros: state **detect** of I after shell tools; soft pre for high-traffic `git switch feat`; hatch unchanged.
-- Cons: two hooks; Pre never claimed complete; post is not an OS-level session halt.
+2026-08-14: Grok listed plugin hooks but did not execute them (plugin trust;
+fail-open). `git checkout -b feat/…` on the principal succeeded. Lefthook cannot
+block checkout (no Git `pre-checkout`); it can refuse commit/push. Two agents
+on the same principal can still flip HEAD — isolation is ω, not lefthook.
 
 ## Decision
 
-**Option D.**
+**Lefthook = persist law. Plugin = agent deny. ω = isolation.**
 
-1. **Primary control — `principal-branch-post.cjs` (PostToolUse Bash / `run_terminal_command`)**  
-   After the tool runs, resolve principal worktree path and  
-   `git -C <principal> rev-parse --abbrev-ref HEAD` (probes use stripped `GIT_DIR`/`GIT_WORK_TREE` env).  
-   Outcomes:
-   - branch ∈ β → allow  
-   - branch ∉ β (or detached `HEAD`) → deny payload + restore guidance (exit 2) — **detect + nudge**, not a guaranteed agent-loop halt  
-   - not a git repo → allow  
-   - git probe error while in a repo context → fail-closed deny (cannot verify I)  
-   Escape: `DEV_CORE_ALLOW_PRINCIPAL_SWITCH=1` (process env only; not in deny text).
+1. **Persist — `scripts/check-principal-branch.sh`** (lefthook `pre-commit` +
+   `pre-push`, or pre-commit framework). If CWD is not principal → allow. If
+   principal HEAD ∈ β → allow. Else deny. Probe errors fail-closed.
+   Offered by `/dev-init` → `/ci-setup` 2e (`bun init.ts seed-principal-freeze`).
 
-2. **Soft control — `principal-branch-pre.cjs` (PreToolUse)**  
-   High-traffic patterns only (`git switch|checkout -b|branch -m|-M|stash branch|…`)  
-   when CWD is principal. No nested-shell completeness, no full `env` matrix, no script body open.  
-   Does **not** price `git reset --hard` (branch name may stay β). Residual encodings → post.
+2. **Agent Pre — `principal-branch-pre.cjs`**  
+   **Deny** (`{"decision":"deny"}`, exit 2) on high-traffic
+   `git switch` / `checkout -b` / `branch -M` / `stash branch` off β when CWD
+   is principal. Not a complete shell parser. Blocks the tool **before** exec
+   if the hook actually runs (plugin trusted).
 
-3. **Shared helpers — `hooks/lib/principal-freeze.cjs`**  
-   `isBaseBranch`, principal path, principal HEAD, hatch, emit helpers.  
-   Align with `skills/shared/lib.sh` principal-first porcelain entry.
+3. **Agent Post — `principal-branch-post.cjs`**  
+   After any shell tool: measure principal HEAD. Off β → **deny payload**
+   (same JSON). Does **not** undo the checkout; nudges restore. Not an OS halt.
 
-4. **Explicit non-goals of PreToolUse**  
-   Script bodies, `source`, aliases, `xargs git`, `node -e` / `python -c` — documented residual;  
-   closed by post state detect, not more parser features.
-
-5. **Stop rule**  
-   Further work on principal freeze must **not** grow Pre into a shell interpreter.  
-   Prefer post assert, restore UX, or skill discipline (`principal_branch` checks).
+4. **Stop rule** — do not grow a git-argv interpreter. Measure state. Hatch:
+   `DEV_CORE_ALLOW_PRINCIPAL_SWITCH=1` (not printed).
 
 ## Consequences
 
-- Delete / replace the large argv-parser guard; ~400 LOC hybrid instead of ~2k LOC parser+tests arms race.
-- Post detect can fire **after** a bad switch (agent must `git switch` back to β) — acceptable for agent loops; hatch for humans. Edit/Write are not re-asserted until the next shell tool.
-- Pre red ≠ “I violated”; post is SSoT for I. Pre false positives kept low (no bare path checkout / no reset --hard).
-- Skills that run `bash preflight.sh` with inner `git checkout staging` remain OK (post sees β).
+- Trusted plugin: agent `git checkout -b feat` on principal is **denied**.
+- Untrusted plugin / human terminal / other harness: lefthook still refuses
+  commit/push on principal off β.
+- Two agents on the **same** worktree still conflict; give each ω.
 
 ## Related
 
-- `plugins/dev-core/skills/shared/references/harness-worktree.md` — principal freeze invariant
-- `plugins/dev-core/hooks/README.md` — operator docs
-- ADR-010 — pipeline chain contract (skills already re-assert principal after setup)
+- `plugins/dev-core/scripts/check-principal-branch.sh`
+- `plugins/dev-core/hooks/principal-branch-pre.cjs`
+- `plugins/dev-init/skills/dev-init/lib/seed-principal-freeze.ts`
+- `plugins/dev-core/skills/ci-setup/cookbooks/hooks.md`
+- `plugins/dev-core/skills/shared/references/harness-worktree.md`

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,6 +20,8 @@ pre-commit:
       skip:
         - merge
         - rebase
+    principal-freeze:
+      run: bash plugins/dev-core/scripts/check-principal-branch.sh
     license-check:
       run: "[ -f .venv/bin/python ] && .venv/bin/python tools/license_check.py || true"
     taxonomy-sync:
@@ -50,6 +52,8 @@ pre-push:
       run: bun run test
     trufflehog:
       run: scripts/trufflehog-check.sh
+    principal-freeze:
+      run: bash plugins/dev-core/scripts/check-principal-branch.sh
     check-no-claude-comments:
       run: scripts/check-no-claude-comments.sh
     check-skill-version:

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. /adversarial, /advisory), dual-harness task list + worktrees, safety hooks (Claude + Grok).",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/README.md
+++ b/plugins/dev-core/README.md
@@ -156,9 +156,11 @@ Plugin hooks for safety and consistency (Claude + Grok compatible):
 |------|---------|--------------|
 | Security check | PreToolUse on Edit/Write | Blocks hardcoded secrets, SQL injection patterns, command injection |
 | Bun test blocker | PreToolUse on Bash | Enforces `bun run test` over `bun test` (the latter uses the Bun test runner instead of Vitest and causes CPU spin) |
-| Principal freeze (pre) | PreToolUse on Bash | Soft UX nudge — high-traffic git branch moves on principal CWD (ADR-017) |
-| Principal freeze (post) | PostToolUse on Bash | State detect + restore nudge — principal HEAD on staging\|main\|master after shell tools (ADR-017) |
+| Principal freeze (pre) | PreToolUse on Bash | **Deny** — blocks `git switch` / `checkout -b` off β on the principal CWD |
+| Principal freeze (post) | PostToolUse on Bash | **Deny after exec** — if principal HEAD left β, tell the agent to restore (checkout already happened) |
 | Auto-format | PostToolUse on Edit/Write | Reads `build.formatter_fix_cmd` (single) or `build.formatters[]` (multi, for mixed JS+Python monorepos) from `stack.yml` and runs the right formatter per file extension. Silent no-op when unconfigured. |
+
+Lefthook (`/dev-init` → `/ci-setup`, `scripts/check-principal-branch.sh`) is the persist gate (commit/push). Plugin hooks are the agent deny. Both needed. ADR-017.
 
 ## Optional companion plugins
 

--- a/plugins/dev-core/hooks/README.md
+++ b/plugins/dev-core/hooks/README.md
@@ -9,16 +9,12 @@ Plugin hooks that run automatically on file writes and shell commands (Claude Co
 | `format.cjs` (PostToolUse) | After Edit / Write / `search_replace` / `write` | Auto-formats files using `build.formatter_fix_cmd` from `stack.yml` |
 | `security-check.cjs` (PreToolUse) | Before Edit / Write / `search_replace` / `write` | Blocks hardcoded secrets, SQL/command injection patterns |
 | `bun-test-guard.cjs` (PreToolUse) | Before Bash / `run_terminal_command` | Blocks `bun test` (wrong runner), enforces `bun run test` |
-| `principal-branch-pre.cjs` (PreToolUse) | Before Bash / `run_terminal_command` | **Soft UX** — high-traffic `git switch\|checkout -b\|branch -M\|stash branch` on principal CWD only (not a complete parser) |
-| `principal-branch-post.cjs` (PostToolUse) | After Bash / `run_terminal_command` | **State detect + restore nudge** — principal HEAD must be staging\|main\|master after shell tools (`rev-parse`; closes scripts / `node -e` / aliases). Exit 2 informs the agent; not an OS session kill. Probe errors fail-closed; non-git workspaces allow. |
+| `principal-branch-pre.cjs` (PreToolUse) | Before Bash / `run_terminal_command` | **Deny** — blocks high-traffic `git switch` / `checkout -b` off β on the principal CWD (not a full shell parser) |
+| `principal-branch-post.cjs` (PostToolUse) | After Bash / `run_terminal_command` | **Deny after exec** — principal HEAD must be staging\|main\|master. Cannot undo the checkout; nudges restore. |
 
-**Architecture (ADR-017):** primary control is **git state**, not a shell argv denylist. Pre = UX nudge (pre red ≠ I violated). Post = SSoT for I. Do not re-expand Pre into a full shell parser.
-
-**Escape hatch (human/session env only, not printed in deny text):** `DEV_CORE_ALLOW_PRINCIPAL_SWITCH=1`
+**Persist law** = lefthook (`scripts/check-principal-branch.sh`, `/ci-setup` 2e). Plugin hooks = **agent deny** (need plugin trust). Hatch: `DEV_CORE_ALLOW_PRINCIPAL_SWITCH=1`. ADR-017.
 
 **Dual harness input** (`lib/hook-input.cjs`): Claude env (`CLAUDE_TOOL_INPUT`, `CLAUDE_FILE_PATHS`) **or** Grok stdin JSON envelope (`toolInput`). Plugin root: `${CLAUDE_PLUGIN_ROOT:-$GROK_PLUGIN_ROOT}`.
-
-Shared freeze helpers: `lib/principal-freeze.cjs`.
 
 ## How `format.cjs` Works
 

--- a/plugins/dev-core/scripts/__tests__/check-principal-branch.test.ts
+++ b/plugins/dev-core/scripts/__tests__/check-principal-branch.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const script = join(import.meta.dirname, '..', 'check-principal-branch.sh')
+
+function gitEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...extra }
+  for (const k of Object.keys(env)) {
+    if (
+      k === 'GIT_DIR' ||
+      k === 'GIT_WORK_TREE' ||
+      k === 'GIT_INDEX_FILE' ||
+      k === 'GIT_COMMON_DIR' ||
+      k.startsWith('GIT_CONFIG') ||
+      k.startsWith('LEFTHOOK')
+    ) {
+      delete env[k]
+    }
+  }
+  env.LEFTHOOK = '0'
+  env.GIT_AUTHOR_NAME = 't'
+  env.GIT_AUTHOR_EMAIL = 't@t'
+  env.GIT_COMMITTER_NAME = 't'
+  env.GIT_COMMITTER_EMAIL = 't@t'
+  return env
+}
+
+function git(cwd: string, args: string[]) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', env: gitEnv() })
+}
+
+function initRepo(dir: string, branch: string) {
+  git(dir, ['init', '-b', branch])
+  git(dir, ['config', 'user.email', 't@t'])
+  git(dir, ['config', 'user.name', 't'])
+  writeFileSync(join(dir, 'README'), 'x\n')
+  git(dir, ['add', 'README'])
+  git(dir, ['commit', '--no-verify', '-m', 'init'])
+}
+
+function runCheck(cwd: string, extra?: NodeJS.ProcessEnv): { code: number; stderr: string } {
+  try {
+    execFileSync('bash', [script], {
+      cwd,
+      encoding: 'utf8',
+      env: gitEnv(extra),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    return { code: 0, stderr: '' }
+  } catch (e) {
+    const err = e as { status?: number; stderr?: string }
+    return { code: err.status ?? 1, stderr: String(err.stderr ?? '') }
+  }
+}
+
+describe('check-principal-branch.sh', () => {
+  let tmp: string
+
+  afterEach(() => {
+    if (tmp) rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('allows principal on main', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'pf-main-'))
+    initRepo(tmp, 'main')
+    expect(runCheck(tmp).code).toBe(0)
+  })
+
+  it('allows principal on staging', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'pf-stg-'))
+    initRepo(tmp, 'staging')
+    expect(runCheck(tmp).code).toBe(0)
+  })
+
+  it('denies principal on a feature branch', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'pf-feat-'))
+    initRepo(tmp, 'main')
+    git(tmp, ['checkout', '-b', 'feat/x'])
+    const r = runCheck(tmp)
+    expect(r.code).toBe(1)
+    expect(r.stderr).toContain('feat/x')
+    expect(r.stderr).not.toContain('DEV_CORE_ALLOW')
+  })
+
+  it('allows a non-principal worktree on a feature branch', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'pf-wt-'))
+    initRepo(tmp, 'main')
+    git(tmp, ['branch', 'feat/x'])
+    const wt = join(tmp, 'wt-feat')
+    mkdirSync(wt)
+    git(tmp, ['worktree', 'add', wt, 'feat/x'])
+    expect(runCheck(wt).code).toBe(0)
+    expect(runCheck(tmp).code).toBe(0)
+  })
+
+  it('honors the escape hatch', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'pf-hatch-'))
+    initRepo(tmp, 'main')
+    git(tmp, ['checkout', '-b', 'feat/x'])
+    expect(runCheck(tmp, { DEV_CORE_ALLOW_PRINCIPAL_SWITCH: '1' }).code).toBe(0)
+  })
+
+  it('allows a non-git directory', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'pf-nogit-'))
+    expect(runCheck(tmp).code).toBe(0)
+  })
+})

--- a/plugins/dev-core/scripts/check-principal-branch.sh
+++ b/plugins/dev-core/scripts/check-principal-branch.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Principal freeze — lefthook / pre-commit gate.
+# Fail if THIS worktree is the principal checkout AND HEAD ∉ {staging, main, master}.
+# Feature worktrees are a no-op. Hatch: DEV_CORE_ALLOW_PRINCIPAL_SWITCH=1 (not printed).
+set -euo pipefail
+
+if [ "${DEV_CORE_ALLOW_PRINCIPAL_SWITCH:-}" = "1" ]; then
+  exit 0
+fi
+
+git_probe() {
+  # Strip decoy GIT_* so a hook env cannot redirect probes (same axis as former plugin hook).
+  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR \
+    -u GIT_OBJECT_DIRECTORY -u GIT_INDEX_FILE \
+    -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_CEILING_DIRECTORIES \
+    git "$@"
+}
+
+top=""
+if ! top=$(git_probe rev-parse --show-toplevel 2>/dev/null); then
+  exit 0
+fi
+if [ -z "$top" ]; then
+  echo "Principal freeze: could not verify git toplevel." >&2
+  exit 1
+fi
+
+porcelain=""
+if ! porcelain=$(git_probe worktree list --porcelain 2>/dev/null); then
+  echo "Principal freeze: could not list worktrees." >&2
+  exit 1
+fi
+
+principal=$(printf '%s\n' "$porcelain" | awk '/^worktree / { print substr($0, 10); exit }')
+if [ -z "$principal" ]; then
+  echo "Principal freeze: could not resolve principal worktree." >&2
+  exit 1
+fi
+
+realpath_safe() {
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$1"
+  else
+    (cd "$1" && pwd -P)
+  fi
+}
+
+if [ "$(realpath_safe "$top")" != "$(realpath_safe "$principal")" ]; then
+  exit 0
+fi
+
+branch=""
+if ! branch=$(git_probe -C "$principal" rev-parse --abbrev-ref HEAD 2>/dev/null); then
+  echo "Principal freeze: could not read principal HEAD." >&2
+  exit 1
+fi
+if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+  echo "Principal freeze: principal HEAD is detached. Restore staging|main." >&2
+  exit 1
+fi
+
+b="$branch"
+b="${b#refs/heads/}"
+b="${b#origin/}"
+
+case "$b" in
+  staging | main | master) exit 0 ;;
+  *)
+    echo "Principal freeze: principal HEAD is '${branch}', expected staging|main|master." >&2
+    echo "Feature work belongs in a dedicated worktree (/setup-worktree or /dev #N)." >&2
+    echo "Restore: git -C ${principal} switch staging  # or main" >&2
+    exit 1
+    ;;
+esac

--- a/plugins/dev-core/skills/checkup/cookbooks/devcore-checks.md
+++ b/plugins/dev-core/skills/checkup/cookbooks/devcore-checks.md
@@ -23,6 +23,7 @@
 | License violations | Run `uv run tools/license_check.py`, create/update `.license-policy.json` |
 | `tools/licenseChecker.ts` missing | Run `/init` Phase 10d |
 | trufflehog not in lefthook | Run `/init` Phase 10d — regenerates `lefthook.yml` |
+| principal freeze not in lefthook | Run `/ci-setup` Phase 2e or `bun init.ts seed-principal-freeze` |
 | license check not in lefthook | Run `/init` Phase 10d — regenerates `lefthook.yml` |
 | `PR_Main` ruleset missing | `bun $I_TS protect-branches --repo <owner/repo>` — a protected branch that does not exist is reported `skipped` and left alone. Pass `--create-missing` only when bootstrapping a fresh repo: on a trunk-mode repo the absent branch (`staging`) was retired on purpose, and creating it resurrects it. |
 | `PR_Main` allowed_merge_methods ≠ `["merge"]` | **Rulesets PUT is a full replace — never send a partial body (it wipes the other rules + bypass actors).** Fetch, mutate, send whole object: `gh api repos/:owner/:repo/rulesets/<id> \| jq '(.rules[] \| select(.type=="pull_request") \| .parameters.allowed_merge_methods) = ["merge"]' \| gh api repos/:owner/:repo/rulesets/<id> --method PUT --input -` — merge-commit only, see `shared/references/release-convention.md` |

--- a/plugins/dev-core/skills/checkup/doctor-local.ts
+++ b/plugins/dev-core/skills/checkup/doctor-local.ts
@@ -315,6 +315,14 @@ export function checkSecurity(): Section {
       status: hasLicense ? 'pass' : 'warn',
       detail: hasLicense ? 'configured in lefthook.yml' : 'not found in lefthook.yml — run /init to add',
     })
+    const hasFreeze = lefthookContent.includes('check-principal-branch') || lefthookContent.includes('principal-freeze')
+    checks.push({
+      name: 'principal freeze in lefthook',
+      status: hasFreeze ? 'pass' : 'warn',
+      detail: hasFreeze
+        ? 'configured in lefthook.yml'
+        : 'not found in lefthook.yml — run /ci-setup (2e) or bun init.ts seed-principal-freeze',
+    })
   }
 
   // trufflehog in pre-commit (if .pre-commit-config.yaml present — Python repos)

--- a/plugins/dev-core/skills/ci-setup/SKILL.md
+++ b/plugins/dev-core/skills/ci-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: ci-setup
 argument-hint: '[--force]'
 description: 'Set up CI/CD — GitHub Actions workflows, TruffleHog, Dependabot, pre-commit hooks, marketplace plugins. Triggers: "ci setup" | "setup ci" | "configure ci" | "setup hooks" | "setup github actions".'
-version: 0.1.0
+version: 0.2.0
 allowed-tools: Bash, Read, ToolSearch
 ---
 
@@ -38,7 +38,8 @@ CI Setup Complete
   CI/CD workflows   ✅ Created / ✅ Already configured / ⏭ Skipped
   TruffleHog        ✅ scripts seeded + secret-scan.yml / ⏭ Skipped
   Dependabot        ✅ .github/dependabot.yml created / ⏭ Skipped
-  Pre-commit hooks  ✅ lefthook installed (trufflehog on commit/push) / ✅ pre-commit / ✅ Already configured / ⏭ Disabled / ⏭ Skipped
+  Pre-commit hooks  ✅ lefthook installed (principal-freeze + trufflehog on commit/push) / ✅ pre-commit / ✅ Already configured / ⏭ Disabled / ⏭ Skipped
+  Principal freeze  ✅ lefthook/pre-commit seeded / ⏭ Skipped
   License checker   ✅ tools/licenseChecker.ts copied (JS) / ✅ tools/license_check.py copied (Python) / ⏭ Skipped
   License policy    ✅ .license-policy.json created (N packages) / ✅ All compliant / ⏭ Skipped / ⏭ pip-licenses missing
   Marketplace       ✅ N plugins installed (name, name, ...) / ⏭ Skipped

--- a/plugins/dev-core/skills/ci-setup/cookbooks/hooks.md
+++ b/plugins/dev-core/skills/ci-setup/cookbooks/hooks.md
@@ -39,9 +39,9 @@ Detect mismatch: if a config file for a *different* tool exists (not configFile 
 Then skip Phase 2 (don't clobber existing setup without --force).
 
 Cases (for the resolved tool):
-- configFile ∃ + hooksInstalled=yes + ¬F → D("Pre-commit hooks", "✅ Already configured"), skip Phase 2.
+- configFile ∃ + hooksInstalled=yes + ¬F → D("Pre-commit hooks", "✅ Already configured"), jump to **2e** (principal freeze offer).
 - configFile ∃ + hooksInstalled=no + ¬F → config exists but hooks not installed → skip to **2d-install-only** (run install without regenerating config).
-- configFile ∃ + F → present choice: **Overwrite** (regenerate from stack.yml) | **Skip** (keep existing). Skip → D⏭("Pre-commit hooks"), stop Phase 2.
+- configFile ∃ + F → present choice: **Overwrite** (regenerate from stack.yml) | **Skip** (keep existing). Skip → D⏭("Pre-commit hooks"), jump to **2e**.
 - configFile ∄ → proceed to 2c (full setup).
 
 ### 2c — Offer setup
@@ -69,6 +69,8 @@ d. Write `lefthook.yml` (trufflehog **inside** `commands:`):
    ```yaml
    pre-commit:
      commands:
+       principal-freeze:
+         run: bash scripts/check-principal-branch.sh
        lint:
          run: <commands.lint>
        typecheck:
@@ -78,13 +80,20 @@ d. Write `lefthook.yml` (trufflehog **inside** `commands:`):
 
    pre-push:
      commands:
+       principal-freeze:
+         run: bash scripts/check-principal-branch.sh
        trufflehog:
          run: bash scripts/trufflehog-check.sh
        license:
          run: <license-cmd>
    ```
-e. `bunx lefthook install`
-f. Copy license tools (JS/bun only — after lefthook install):
+e. Seed principal freeze script (`scripts/check-principal-branch.sh`):
+   ```bash
+   bun $I_TS seed-principal-freeze
+   test -f scripts/check-principal-branch.sh || echo "WARN: seed principal-freeze failed — install dev-init + re-run"
+   ```
+f. `bunx lefthook install`
+g. Copy license tools (JS/bun only — after lefthook install):
    ```bash
    [[ "${CLAUDE_PLUGIN_ROOT}" =~ ^/[a-zA-Z0-9/_.-]+$ ]] || { echo "ERROR: invalid CLAUDE_PLUGIN_ROOT"; exit 1; }
    Φ=$(dirname "$(dirname "${CLAUDE_PLUGIN_ROOT}")")
@@ -107,6 +116,11 @@ c. Write `.pre-commit-config.yaml`:
    repos:
      - repo: local
        hooks:
+         - id: principal-freeze
+           name: principal freeze
+           entry: bash scripts/check-principal-branch.sh
+           language: system
+           pass_filenames: false
          - id: lint
            name: lint
            entry: <commands.lint>
@@ -159,7 +173,12 @@ g. Ensure TruffleHog scripts exist (idempotent seed if Phase 1b skipped):
      || bun $I_TS seed-trufflehog
    ```
 
-h. Check trufflehog binary:
+h. Ensure principal freeze script exists (idempotent):
+   ```bash
+   test -f scripts/check-principal-branch.sh || bun $I_TS seed-principal-freeze
+   ```
+
+i. Check trufflehog binary:
    ```bash
    which trufflehog 2>/dev/null && echo "installed" || echo "missing"
    ```
@@ -171,7 +190,7 @@ h. Check trufflehog binary:
          • GitHub release: https://github.com/trufflesecurity/trufflehog/releases
    ```
 
-i. Run license check + offer policy generation:
+j. Run license check + offer policy generation:
    - JS: `bun tools/licenseChecker.ts --json 2>/dev/null`
    - Python: `uv run tools/license_check.py --json 2>/dev/null`
    - exit 0 → D("License check", "✅ All packages compliant").
@@ -180,4 +199,23 @@ i. Run license check + offer policy generation:
      - skip → D("License policy", "⏭ Skipped — first push will fail").
    - exit 2 (Python, pip-licenses missing) → D("License check", "⏭ pip-licenses not installed — run `uv add --dev pip-licenses`").
 
-j. D("Pre-commit hooks", "✅ {tool} installed (lint + typecheck + trufflehog on commit/push, license on push)").
+k. D("Pre-commit hooks", "✅ {tool} installed (principal-freeze + lint + typecheck + trufflehog on commit/push, license on push)").
+
+Then run **2e**.
+
+### 2e — Principal freeze (offer, lefthook or pre-commit)
+
+Gate: refuse `git commit` / `git push` when **this** worktree is the principal checkout and HEAD ∉ `{staging, main, master}`. Feature worktrees are a no-op. Hatch (not printed in deny text): `DEV_CORE_ALLOW_PRINCIPAL_SWITCH=1`.
+
+Does **not** block `git switch` (Git has no pre-checkout). Law = lefthook, not a plugin PreToolUse hook.
+
+1. Detect:
+   ```bash
+   test -f scripts/check-principal-branch.sh && echo script_ok || echo script_missing
+   grep -E 'check-principal-branch|principal-freeze' lefthook.yml .lefthook.yml .pre-commit-config.yaml 2>/dev/null || true
+   ```
+2. script_ok ∧ lefthook/pre-commit already lists the check → D("Principal freeze", "✅ Already configured").
+3. No lefthook.yml / `.lefthook.yml` / `.pre-commit-config.yaml` → D⏭("Principal freeze — no hook runner").
+4. Else Ask: **Add principal freeze** (Recommended) — lefthook refuse commit/push off β | **Skip**.
+   - Add → `bun $I_TS seed-principal-freeze` (copies script + patches lefthook / `.pre-commit-config.yaml`). D✅("Principal freeze").
+   - Skip → D⏭("Principal freeze").

--- a/plugins/dev-core/skills/shared/references/harness-worktree.md
+++ b/plugins/dev-core/skills/shared/references/harness-worktree.md
@@ -12,7 +12,7 @@
 | Capability probe | Detect which tools exist **in this session** (schema / known names) |
 | **Branch + issue link** | **dev-core invariant** — harness-agnostic |
 | **Path / enter / exit** | **Harness owns layout** — do not dual-hardcode opaque Grok hash paths in skills |
-| **Principal freeze** | Principal checkout **always** stays on β (`staging` \| `main` \| `master`) — **never** `git switch` / `checkout` of `feat/…` there |
+| **Principal freeze** | Principal checkout **always** stays on β (`staging` \| `main` \| `master`) — **never** `git switch` / `checkout` of `feat/…` there. Agent: plugin Pre **deny**. Persist: lefthook (`check-principal-branch.sh`, `/ci-setup` 2e). |
 
 ## Invariants (all harnesses)
 

--- a/plugins/dev-init/skills/dev-init/SKILL.md
+++ b/plugins/dev-init/skills/dev-init/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Use when setting up a new repo or re-running Roxabi project init.
   Triggers: "dev-init" | "setup project" | "initialize project" | "/dev-init".
   Not the harness built-in /init (CLAUDE.md scaffold only).
-version: 0.9.2
+version: 0.9.3
 ---
 
 # Dev-init
@@ -27,7 +27,7 @@ Full project initialization harness. Orchestrates three focused sub-skills in se
 |-----------|---------|
 | `/dev-core:env-setup` | stack.yml, CLAUDE.md rules, docs stubs, LSP |
 | `axial-adr-create` (agent) | **Axis of decomposition ADR** — mandatory drift prevention (N×M trap). Skippable via `--skip-axial` for trivial single-axis projects. See `shared/references/axial-decomposition.md` |
-| `/dev-core:ci-setup` | GitHub Actions, TruffleHog (**seed** `scripts/trufflehog-check.sh` + exclude + lefthook + CI `secret-scan.yml`), Dependabot, marketplace plugins |
+| `/dev-core:ci-setup` | GitHub Actions, TruffleHog (**seed** `scripts/trufflehog-check.sh` + exclude + lefthook + CI `secret-scan.yml`), principal freeze lefthook gate (offer), Dependabot, marketplace plugins |
 | `/dev-core:release-setup` | Commit standards (Commitizen), hook additions, release automation (semantic-release / Release Please) |
 
 Run sub-skills directly to reconfigure a single concern without re-running the full init.

--- a/plugins/dev-init/skills/dev-init/__tests__/seed-principal-freeze.test.ts
+++ b/plugins/dev-init/skills/dev-init/__tests__/seed-principal-freeze.test.ts
@@ -1,0 +1,118 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  insertLefthookPrincipalFreeze,
+  lefthookHasPrincipalFreeze,
+  resolvePrincipalFreezeSourceDir,
+  seedPrincipalFreeze,
+} from '../lib/seed-principal-freeze'
+
+const monorepoScripts = join(import.meta.dirname, '..', '..', '..', '..', 'dev-core', 'scripts')
+
+describe('resolvePrincipalFreezeSourceDir', () => {
+  it('finds monorepo scripts via explicit path', () => {
+    const dir = resolvePrincipalFreezeSourceDir(monorepoScripts)
+    expect(dir).toBe(monorepoScripts)
+    expect(existsSync(join(monorepoScripts, 'check-principal-branch.sh'))).toBe(true)
+  })
+
+  it('returns null for explicit missing path', () => {
+    expect(resolvePrincipalFreezeSourceDir(join(tmpdir(), 'nope-pf-src'))).toBeNull()
+  })
+
+  it('finds monorepo scripts without args', () => {
+    const dir = resolvePrincipalFreezeSourceDir()
+    expect(dir).toBeTruthy()
+    expect(existsSync(join(dir as string, 'check-principal-branch.sh'))).toBe(true)
+  })
+})
+
+describe('insertLefthookPrincipalFreeze', () => {
+  it('inserts under pre-commit and pre-push commands', () => {
+    const src = `pre-commit:
+  commands:
+    lint:
+      run: bun run lint
+
+pre-push:
+  commands:
+    test:
+      run: bun run test
+`
+    const { yaml, changed } = insertLefthookPrincipalFreeze(src)
+    expect(changed).toBe(true)
+    expect(yaml).toContain('principal-freeze:')
+    expect((yaml.match(/check-principal-branch\.sh/g) ?? []).length).toBe(2)
+    expect(lefthookHasPrincipalFreeze(yaml)).toBe(true)
+  })
+
+  it('is idempotent', () => {
+    const src = `pre-commit:
+  commands:
+    principal-freeze:
+      run: bash scripts/check-principal-branch.sh
+    lint:
+      run: bun run lint
+`
+    const { changed } = insertLefthookPrincipalFreeze(src)
+    expect(changed).toBe(false)
+  })
+})
+
+describe('seedPrincipalFreeze', () => {
+  let tmp: string
+
+  afterEach(() => {
+    if (tmp) rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('writes the script and patches lefthook.yml', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'seed-pf-'))
+    writeFileSync(
+      join(tmp, 'lefthook.yml'),
+      `pre-commit:
+  commands:
+    lint:
+      run: bun run lint
+
+pre-push:
+  commands:
+    test:
+      run: bun run test
+`,
+    )
+    const r = seedPrincipalFreeze({ cwd: tmp, sourceDir: monorepoScripts })
+    expect(r.error).toBeUndefined()
+    expect(r.written.some((p) => p.endsWith('check-principal-branch.sh'))).toBe(true)
+    expect(existsSync(join(tmp, 'scripts/check-principal-branch.sh'))).toBe(true)
+    expect(r.patched).toEqual([join(tmp, 'lefthook.yml')])
+    const y = readFileSync(join(tmp, 'lefthook.yml'), 'utf8')
+    expect(y).toContain('bash scripts/check-principal-branch.sh')
+  })
+
+  it('skips existing script without --force and does not re-patch', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'seed-pf-'))
+    mkdirSync(join(tmp, 'scripts'))
+    writeFileSync(join(tmp, 'scripts/check-principal-branch.sh'), '#!/bin/sh\n')
+    writeFileSync(
+      join(tmp, 'lefthook.yml'),
+      `pre-commit:
+  commands:
+    principal-freeze:
+      run: bash scripts/check-principal-branch.sh
+`,
+    )
+    const r = seedPrincipalFreeze({ cwd: tmp, sourceDir: monorepoScripts })
+    expect(r.written).toEqual([])
+    expect(r.skipped.length).toBe(1)
+    expect(r.patched).toEqual([])
+  })
+
+  it('errors when source missing', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'seed-pf-'))
+    const r = seedPrincipalFreeze({ cwd: tmp, sourceDir: join(tmp, 'nope') })
+    expect(r.error).toBeTruthy()
+  })
+})

--- a/plugins/dev-init/skills/dev-init/init.ts
+++ b/plugins/dev-init/skills/dev-init/init.ts
@@ -20,6 +20,7 @@ Usage:
   bun init.ts scaffold-docs [--path docs]
   bun init.ts scaffold-rules [--stack-path .claude/stack.yml] [--project-name <name>] [--claude-md CLAUDE.md]
   bun init.ts seed-trufflehog [--force] [--cwd <dir>] [--source-dir <dir>]
+  bun init.ts seed-principal-freeze [--force] [--cwd <dir>] [--source-dir <dir>] [--no-patch-hooks]
   bun init.ts scaffold --github-repo <owner/repo> [--vercel-token <token>] [--vercel-project-id <id>] [--vercel-team-id <id>] [--force]`
 
 const args = process.argv.slice(2)
@@ -180,6 +181,19 @@ switch (command) {
       force: hasFlag('--force'),
       cwd: parseFlag('--cwd', process.cwd()),
       sourceDir: parseFlag('--source-dir', '') || undefined,
+    })
+    console.log(JSON.stringify(result, null, 2))
+    if (result.error) process.exit(1)
+    break
+  }
+
+  case 'seed-principal-freeze': {
+    const { seedPrincipalFreeze } = await import('./lib/seed-principal-freeze')
+    const result = seedPrincipalFreeze({
+      force: hasFlag('--force'),
+      cwd: parseFlag('--cwd', process.cwd()),
+      sourceDir: parseFlag('--source-dir', '') || undefined,
+      patchHooks: !hasFlag('--no-patch-hooks'),
     })
     console.log(JSON.stringify(result, null, 2))
     if (result.error) process.exit(1)

--- a/plugins/dev-init/skills/dev-init/lib/seed-principal-freeze.ts
+++ b/plugins/dev-init/skills/dev-init/lib/seed-principal-freeze.ts
@@ -1,0 +1,215 @@
+/**
+ * Seed principal-freeze lefthook/pre-commit gate into a consumer project.
+ * Canonical script: plugins/dev-core/scripts/check-principal-branch.sh
+ */
+
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SCRIPT = 'check-principal-branch.sh'
+const RUN = 'bash scripts/check-principal-branch.sh'
+
+export type SeedPrincipalFreezeOpts = {
+  cwd?: string
+  force?: boolean
+  sourceDir?: string
+  /** When false, only copy the script (default: also patch lefthook / pre-commit if present). */
+  patchHooks?: boolean
+}
+
+export type SeedPrincipalFreezeResult = {
+  written: string[]
+  skipped: string[]
+  patched: string[]
+  sourceDir: string
+  error?: string
+}
+
+function newestScriptsDir(pluginRoot: string): string | null {
+  if (!existsSync(pluginRoot)) return null
+  let best: { path: string; mtime: number } | null = null
+  let entries: string[]
+  try {
+    entries = readdirSync(pluginRoot)
+  } catch {
+    return null
+  }
+  for (const name of entries) {
+    if (name.startsWith('.')) continue
+    const scripts = join(pluginRoot, name, 'scripts')
+    const check = join(scripts, SCRIPT)
+    if (!existsSync(check)) continue
+    let mtime = 0
+    try {
+      mtime = statSync(check).mtimeMs
+    } catch {
+      continue
+    }
+    if (!best || mtime > best.mtime) best = { path: scripts, mtime }
+  }
+  return best?.path ?? null
+}
+
+export function resolvePrincipalFreezeSourceDir(explicit?: string): string | null {
+  if (explicit) {
+    return existsSync(join(explicit, SCRIPT)) ? explicit : null
+  }
+
+  for (const envKey of ['CLAUDE_PLUGIN_ROOT', 'GROK_PLUGIN_ROOT'] as const) {
+    const root = process.env[envKey]
+    if (!root) continue
+    const candidate = join(root, 'scripts')
+    if (existsSync(join(candidate, SCRIPT))) return candidate
+    const peer = join(dirname(root), 'dev-core', 'scripts')
+    if (existsSync(join(peer, SCRIPT))) return peer
+    const scanned = newestScriptsDir(join(dirname(root), 'dev-core'))
+    if (scanned) return scanned
+  }
+
+  const here = dirname(fileURLToPath(import.meta.url))
+  const monorepo = join(here, '..', '..', '..', '..', 'dev-core', 'scripts')
+  if (existsSync(join(monorepo, SCRIPT))) return monorepo
+
+  return null
+}
+
+export function lefthookHasPrincipalFreeze(yaml: string): boolean {
+  return yaml.includes('check-principal-branch.sh') || /^\s*principal-freeze\s*:/m.test(yaml)
+}
+
+export function insertLefthookPrincipalFreeze(yaml: string): { yaml: string; changed: boolean } {
+  if (lefthookHasPrincipalFreeze(yaml)) return { yaml, changed: false }
+  let out = yaml
+  let changed = false
+  for (const section of ['pre-commit', 'pre-push'] as const) {
+    const next = insertIntoLefthookSection(out, section)
+    if (next !== out) {
+      out = next
+      changed = true
+    }
+  }
+  return { yaml: out, changed }
+}
+
+function insertIntoLefthookSection(yaml: string, section: string): string {
+  const header = new RegExp(`^${section}:\\s*$`, 'm')
+  const m = header.exec(yaml)
+  if (!m) return yaml
+  const start = m.index + m[0].length
+  const rest = yaml.slice(start)
+  const nextTop = rest.search(/^\S/m)
+  const body = nextTop === -1 ? rest : rest.slice(0, nextTop)
+  const cmds = /^([ \t]*)commands:\s*$/m.exec(body)
+  if (!cmds) return yaml
+  const indent = cmds[1] ?? '  '
+  const child = `${indent}  `
+  const block = `\n${child}principal-freeze:\n${child}  run: ${RUN}`
+  const insertAt = start + (cmds.index ?? 0) + cmds[0].length
+  return yaml.slice(0, insertAt) + block + yaml.slice(insertAt)
+}
+
+const PRE_COMMIT_BLOCK = `  - repo: local
+    hooks:
+      - id: principal-freeze
+        name: principal freeze
+        entry: ${RUN}
+        language: system
+        pass_filenames: false
+`
+
+export function insertPreCommitPrincipalFreeze(yaml: string): { yaml: string; changed: boolean } {
+  if (yaml.includes('check-principal-branch.sh') || yaml.includes('id: principal-freeze')) {
+    return { yaml, changed: false }
+  }
+  const trimmed = yaml.endsWith('\n') ? yaml : `${yaml}\n`
+  return { yaml: trimmed + PRE_COMMIT_BLOCK, changed: true }
+}
+
+export function seedPrincipalFreeze(opts: SeedPrincipalFreezeOpts = {}): SeedPrincipalFreezeResult {
+  const cwd = opts.cwd ?? process.cwd()
+  const force = opts.force === true
+  const patchHooks = opts.patchHooks !== false
+  const sourceDir = resolvePrincipalFreezeSourceDir(opts.sourceDir)
+
+  if (!sourceDir) {
+    return {
+      written: [],
+      skipped: [],
+      patched: [],
+      sourceDir: '',
+      error: 'principal-freeze seed source not found — install/enable dev-core or pass sourceDir',
+    }
+  }
+
+  const destDir = join(cwd, 'scripts')
+  mkdirSync(destDir, { recursive: true })
+
+  const written: string[] = []
+  const skipped: string[] = []
+  const patched: string[] = []
+
+  const src = join(sourceDir, SCRIPT)
+  const dest = join(destDir, SCRIPT)
+  if (!existsSync(src)) {
+    return {
+      written,
+      skipped,
+      patched,
+      sourceDir,
+      error: `missing seed file: ${src}`,
+    }
+  }
+
+  if (existsSync(dest) && !force) {
+    skipped.push(dest)
+  } else if (existsSync(dest) && force && readFileSync(src).equals(readFileSync(dest))) {
+    skipped.push(dest)
+  } else {
+    copyFileSync(src, dest)
+    written.push(dest)
+  }
+
+  try {
+    chmodSync(dest, 0o755)
+  } catch {
+    // non-fatal on platforms without chmod
+  }
+
+  if (patchHooks) {
+    const lefthookPath = existsSync(join(cwd, 'lefthook.yml'))
+      ? join(cwd, 'lefthook.yml')
+      : existsSync(join(cwd, '.lefthook.yml'))
+        ? join(cwd, '.lefthook.yml')
+        : null
+    if (lefthookPath) {
+      const raw = readFileSync(lefthookPath, 'utf8')
+      const next = insertLefthookPrincipalFreeze(raw)
+      if (next.changed) {
+        writeFileSync(lefthookPath, next.yaml)
+        patched.push(lefthookPath)
+      }
+    }
+
+    const preCommitPath = join(cwd, '.pre-commit-config.yaml')
+    if (existsSync(preCommitPath)) {
+      const raw = readFileSync(preCommitPath, 'utf8')
+      const next = insertPreCommitPrincipalFreeze(raw)
+      if (next.changed) {
+        writeFileSync(preCommitPath, next.yaml)
+        patched.push(preCommitPath)
+      }
+    }
+  }
+
+  return { written, skipped, patched, sourceDir }
+}


### PR DESCRIPTION
## Summary
- Persist principal freeze via lefthook (`scripts/check-principal-branch.sh` + `seed-principal-freeze`), offered by `/dev-init` → `/ci-setup` 2e.
- Plugin Pre/Post stay as **agent deny** (trust-gated). Persist law is lefthook so a dead hook cannot leave principal on a feat branch.
- `/checkup` warns when lefthook exists without the check. Fixture git commits isolate host lefthook/GIT_DIR.

## Lifecycle

S-tier / no issue — implementation + verification only.

## Test Plan
- [x] `check-principal-branch.sh` unit tests (principal β / feat / worktree / hatch)
- [x] `seed-principal-freeze` copies script and patches lefthook.yml
- [x] Plugin principal-freeze hook unit tests still pass
- [ ] `/ci-setup` on an existing repo offers 2e and wires the check

## SC → Test Matrix

Omitted (no spec / S-tier ship).

---
Generated with [Roxabi dev-core](https://github.com/Roxabi/roxabi-plugins) via `/pr`
