### PR TITLE
docs(dev-core): ADR-018 skill homes and trigger hygiene

### DIFF
--- a/artifacts/reviews/018-description-inventory.md
+++ b/artifacts/reviews/018-description-inventory.md
@@ -1,0 +1,164 @@
+---
+title: "ADR-018 description inventory — axis 2"
+status: review-complete
+date: 2026-08-18
+subject: plugins/dev-core/skills/*/SKILL.md
+---
+
+# ADR-018 description inventory — axis 2 (invocation budget)
+
+Measured 2026-08-18 from repo source `plugins/dev-core/skills/*/SKILL.md` (32 files; `shared/` and `init/` have no skill frontmatter). No `SKILL.md` was edited.
+
+**Method**
+
+- `desc_chars` = Unicode length of the YAML `description` **scalar** after quote-stripping (not the file, not the `description: ` key). Em dash / `→` / `×` count as 1.
+- `has_disable_model_invocation` = key present in frontmatter. **0 / 32** files set it (grep: no matches). All `false`.
+- `trigger_phrases` = quoted `Triggers:` / `Triggers ` list in that scalar; `—` if absent. All 32 have a Triggers list (clarify uses `Triggers "` — no colon).
+- `pipeline_class` = `chain-contract.md` class table when listed; else inferred from `/dev` Step 7 / `/ship` / the skill's own Chain Position. Inferred rows marked.
+- `invoked_by_factory` = **yes** iff `/dev` or `/ship` actually `Skill()`s it (Step 7 map, bootstrap, `--cleanup-context`, or `/ship` steps). `/dev` lists `skill: "promote"` but Step 4 **always skips** and the map says never auto-triggered → **no**.
+- `allowed_tools_has_Skill` = frontmatter `allowed-tools` contains `Skill`.
+- `axis2_today` = `model-invokable` for every row (ADR-018: 0 disable flags).
+- Tokens column **omitted**. `plugins/compress/scripts/count_tokens.py count` was not executed here (this pass has no shell; the script prefers `ANTHROPIC_API_KEY` / network and otherwise needs tiktoken or falls to estimate). Char count is the mandatory metric.
+
+**Hard constraint (ADR-018):** a parent cannot `Skill()` a child with `disable-model-invocation: true`. Do **not** flag `/dev` or `/ship`.
+
+## Inventory
+
+| skill | desc_chars | has_disable_model_invocation | trigger_phrases | pipeline_class | invoked_by_factory | allowed_tools_has_Skill | collision_notes | axis2_today | axis2_later_candidate |
+|---|---:|---|---|---|---|---|---|---|---|
+| adr | 135 | false | "create an ADR" \| "architecture decision" \| "document why we chose" \| "list ADRs" | standalone (inferred) | no | no | "architecture decision" vs clarify architecture language | model-invokable | unknown |
+| adversarial | 333 | false | "adversarial" \| "red team" \| "devil's advocate" \| "attack this design" \| "kill this idea" \| "stress test this" \| "what breaks this" \| "adversarial review" | standalone | no | no | "adversarial review" vs code-review / advisory review | model-invokable | keep-model |
+| advisory | 316 | false | "advisory" \| "second opinion" \| "advise on this" \| "strengthen this" \| "expert advice" \| "advisory review" \| "what would you improve" | standalone | no | no | "advisory review" vs adversarial / code-review | model-invokable | keep-model |
+| analyze | 284 | false | "analyze" \| "technical analysis" \| "explore the problem" \| "how deep is it" \| "deep dive" \| "investigate this" \| "analyze this feature" \| "what are the risks" \| "explore the codebase" \| "look into this" | adv + approval-stop | yes | yes | "explore the *" vs interview "explore ideas"; "write analysis" lives on interview | model-invokable | keep-model |
+| checkup | 217 | false | "checkup" \| "health check" \| "check setup" \| "verify config" \| "security baseline" | standalone (inferred) | no | no | "check setup" / "verify config" vs validate "check everything" | model-invokable | unknown |
+| ci-setup | 196 | false | "ci setup" \| "setup ci" \| "configure ci" \| "setup hooks" \| "setup github actions" | standalone (inferred) | no | no | "setup hooks" vs release-setup hook language (body, not trigger) | model-invokable | keep-model |
+| ci-watch | 224 | false | "watch ci" \| "ci watch" \| "watch the ci" \| "watch run" \| "monitor ci" | adv | yes | no | — | model-invokable | keep-model |
+| clarify | 507 | false | "clarify intent" \| "explain the architecture" \| "restate what we are solving" \| "recap the issue" \| "restructure the answer" \| "intent first" \| "explain it properly" \| "what is the architecture" \| "explain from intent down" \| "step back and explain" | view (inferred) | no | yes | longest desc; architecture phrasing vs adr; "what are we solving" lives on frame | model-invokable | unknown |
+| cleanup | 205 | false | "cleanup" \| "clean branches" \| "cleanup worktrees" \| "remove stale branches" | adv | yes | no | "cleanup" vs cleanup-context "cleanup context" | model-invokable | keep-model |
+| cleanup-context | 307 | false | "cleanup context" \| "context audit" \| "clean memory" \| "drain memory" \| "prune memory" \| "audit memory" \| "consolidate rules" \| "spa day" \| "memory audit" | standalone (inferred; `/dev --cleanup-context`) | yes | no | "cleanup context" vs cleanup | model-invokable | keep-model |
+| code-review | 260 | false | "code review" \| "review changes" \| "review PR #42" \| "check my code" \| "review my changes" \| "review this PR" \| "do a code review" \| "review the diff" \| "look at my code" | verdict | yes | yes | generic "review *" vs adversarial/advisory review | model-invokable | keep-model |
+| dev | 206 | false | "dev" \| "start working on" \| "work on issue" \| "work on #" \| "develop" \| "pick up issue" \| "tackle issue" \| "let's work on" | factory (inferred) | no (is the factory) | yes | NL factory path — must stay model-invokable | model-invokable | keep-model |
+| doc-sync | 222 | false | "sync docs" \| "update docs" \| "doc sync" \| "sync plugin docs" \| "update skill docs" \| "update the docs" | standalone (inferred) | no | no | "update docs" vs readme-upgrade "upgrade docs" / "improve docs" | model-invokable | unknown |
+| env-setup | 223 | false | "env setup" \| "setup environment" \| "configure stack" \| "scaffold rules" | standalone (inferred) | no | no | **exact** "configure stack" vs stack-setup | model-invokable | keep-model |
+| fix | 275 | false | "fix findings" \| "fix review" \| "apply fixes" \| "fix these" \| "apply review comments" \| "apply the review" \| "fix the review issues" \| "address review feedback" \| "fix PR comments" | loop | yes | yes | — | model-invokable | keep-model |
+| frame | 264 | false | "frame" \| "frame this" \| "what's the problem" \| "define the problem" \| "scope this out" \| "define the scope" \| "what are we solving" \| "help me think through this problem" \| "problem statement" | adv + approval-stop | yes | yes | "think through this problem" vs interview; "what are we solving" vs clarify | model-invokable | keep-model |
+| implement | 220 | false | "implement" \| "build this" \| "execute plan" \| "start coding" \| "write the code" \| "code this up" \| "let's build it" \| "build it out" \| "ship it" | adv | yes | yes | **"ship it" vs /ship**; "build this" vs spec "what will we build" | model-invokable | keep-model |
+| interview | 278 | false | "create a spec" \| "interview" \| "brainstorm" \| "write analysis" \| "promote to spec" \| "let's brainstorm" \| "think through this" \| "help me brainstorm" \| "let's think this through" \| "explore ideas" | standalone (inferred) | no | no | **"create a spec" vs /spec**; "write analysis" vs /analyze; "promote to spec" vs /promote; "think through" vs /frame | model-invokable | keep-model |
+| plan | 271 | false | "plan" \| "plan this" \| "implementation plan" \| "break it down" \| "plan this feature" \| "how should we build this" \| "make a plan" \| "create a plan" \| "break this down into tasks" \| "task breakdown" | adv + approval-stop | yes | yes | — | model-invokable | keep-model |
+| pr | 281 | false | "create PR" \| "open PR" \| "submit PR" \| "update PR" \| "/pr --draft" \| "open a pull request" \| "make a PR" \| "open pull request" \| "submit a pull request" \| "create a draft PR" \| "raise a PR" | adv | yes | no | — | model-invokable | keep-model |
+| promote | 256 | false | "promote staging" \| "release" \| "deploy" \| "cut a release" \| "--finalize" \| "merge to main" \| "promote to production" \| "ship a release" \| "tag and release" \| "publish release" | standalone | no | no | **"release"/"deploy"/"ship a release"** vs /ship + release-setup; "promote to spec" lives on interview | model-invokable | side-effect-gate-candidate |
+| readme-upgrade | 359 | false | "improve readme" \| "upgrade docs" \| "readme quality" \| "improve docs" \| "doc audit" \| "readme upgrade" \| "improve contributing" \| "docs health" | standalone (inferred) | no | no | **"upgrade docs"** exact vs doc-sync family; "improve contributing" vs seed-community | model-invokable | unknown |
+| recheck | 210 | false | "recheck" \| "is this issue still valid" \| "check drift" \| "check issue staleness" | adv | yes | yes | — | model-invokable | keep-model |
+| release-setup | 218 | false | "release setup" \| "setup releases" \| "commit standards" \| "setup release automation" | standalone (inferred) | no | no | "release setup" vs promote "release" | model-invokable | keep-model |
+| seed-community | 421 | false | "seed community" \| "bootstrap community files" \| "add contributing" \| "add license" \| "add security policy" \| "github community files" | standalone (inferred) | no | no | "add contributing" vs readme-upgrade; "bootstrap *" vs seed-docs | model-invokable | side-effect-gate-candidate |
+| seed-docs | 277 | false | "seed docs" \| "bootstrap docs" \| "populate docs" \| "fill architecture docs" \| "seed architecture" | standalone (inferred) | no | no | "bootstrap docs" vs seed-community / setup-worktree "bootstrap branch" | model-invokable | side-effect-gate-candidate |
+| setup-worktree | 154 | false | "setup worktree" \| "create worktree" \| "prepare workspace" \| "bootstrap branch" | adv (inferred; `/dev`/`/implement` bootstrap, ¬STEPS) | yes | no | "bootstrap branch" vs seed-* bootstrap | model-invokable | keep-model |
+| ship | 238 | false | "ship" \| "ship this" \| "land this" \| "land the PR" \| "ship PR" \| "submit for merge" \| "get this merged" \| "ship my branch" | meta-orchestrator | no (is the factory) | yes | **"ship" vs implement "ship it"**; merge language vs promote "merge to main" | model-invokable | keep-model |
+| spec | 251 | false | "write spec" \| "spec this" \| "solution design" \| "what will we build" \| "design the solution" \| "acceptance criteria" \| "define acceptance criteria" \| "spec it out" \| "write the spec" | adv + approval-stop | yes | yes | **"write spec" vs interview "create a spec"** | model-invokable | keep-model |
+| stack-setup | 309 | false | "stack setup" \| "setup stack" \| "configure stack" \| "fill stack.yml" \| "stack wizard" \| "stack-setup" | standalone (inferred) | no | no | **exact "configure stack" vs env-setup** | model-invokable | unknown |
+| test | 255 | false | "test this file" \| "write tests" \| "add coverage" \| "run tests" \| "e2e tests" \| "add tests" \| "test coverage" \| "generate tests" \| "test this" \| "write unit tests" \| "add integration tests" | standalone (inferred) | no | no | "run tests" adjacent to validate (QG includes test); `/implement` does **not** `Skill()` `/test` | model-invokable | unknown |
+| validate | 205 | false | "validate" \| "check everything" \| "quality check" \| "pre-push check" \| "are we green" | adv | yes | no | "check everything" vs checkup | model-invokable | keep-model |
+
+### Totals
+
+| metric | n |
+|---|---:|
+| skills (SKILL.md) | **32** |
+| sum desc_chars | **8377** |
+| with Triggers list | **32** |
+| `disable-model-invocation: true` | **0** |
+| factory-invoked (`/dev` or `/ship` `Skill()`s) | **14** |
+| `allowed-tools` contains Skill | **11** |
+| keep-model | **22** |
+| side-effect-gate-candidate | **3** |
+| unknown | **7** |
+
+No skill is missing a `description`.
+
+## Skill() graph (measured)
+
+**`/dev` factory** (`skills/dev/SKILL.md` Step 7 + bootstrap + Step 0):
+
+| callee | how |
+|---|---|
+| recheck, frame, analyze, spec, plan, implement, pr, ci-watch, validate, code-review, fix, cleanup | Step 7 invocation map |
+| setup-worktree | silent bootstrap when `S* ∈ {frame, analyze, spec, plan, implement}` |
+| cleanup-context | `--cleanup-context` → `skill: "cleanup-context"` then stop |
+| promote | listed as `skill: "promote"` but **never auto-triggered** (Step 4 `promote → skip`) |
+
+**`/ship` factory** (`skills/ship/SKILL.md` steps): `pr`, `code-review`, `fix`, `ci-watch`, `cleanup`.
+
+**Other skills `Skill()` a peer:**
+
+| caller | callee | note |
+|---|---|---|
+| frame, analyze, plan | adversarial, advisory | React tables |
+| analyze | interview | `Ω := skill: "interview"` + Step 2b `Ω, args: …` |
+| implement | setup-worktree | missing ω |
+| recheck | `issue-triage` (roxabi-issues) | external; not in this table |
+| clarify | `forge-chart` | not a dev-core skill |
+| spec | — | **¬** invoke `/interview`; adversarial is a **subagent**, not `Skill()` |
+| `/dev-init` (dev-init plugin) | `dev-core:env-setup`, `dev-core:ci-setup`, `dev-core:release-setup` | other-plugin Skill(); next-step prose only for checkup / seed-docs |
+
+`/test` SKILL.md mentions “when invoked by `/implement`” but `/implement` never `Skill()`s `/test` (inline tester agent + QG).
+
+## Analysis
+
+### Always-on description tax
+
+All 32 descriptions are in the host skill menu today (`axis2_today = model-invokable`). **8377 characters** of always-on description text.
+
+Distribution (chars): clarify 507, seed-community 421, readme-upgrade 359, adversarial 333, advisory 316, stack-setup 309, cleanup-context 307 — seven skills ≥300 chars carry 2512 / 8377 (30%). Shortest: adr 135, setup-worktree 154, ci-setup 196.
+
+Triggers are the bulk of several mid-length rows (pr 11 phrases, test 11, interview / plan / analyze / spec 9–10). That is menu-routing cost, not body-instruction cost.
+
+### Trigger collisions
+
+| overlap | skills | phrases |
+|---|---|---|
+| **exact duplicate** | env-setup, stack-setup | `"configure stack"` |
+| ship verb | implement, ship, promote | implement `"ship it"` · ship `"ship"` / `"ship this"` / `"ship PR"` · promote `"ship a release"` |
+| spec creation | interview, spec | interview `"create a spec"` · spec `"write spec"` / `"write the spec"` / `"spec this"` |
+| release / deploy | promote, release-setup, ship | promote `"release"` / `"deploy"` / `"cut a release"` / `"merge to main"` · release-setup `"release setup"` · ship `"submit for merge"` / `"get this merged"` |
+| docs upgrade | doc-sync, readme-upgrade | `"update docs"` / `"update the docs"` vs `"upgrade docs"` / `"improve docs"` |
+| cleanup noun | cleanup, cleanup-context | `"cleanup"` vs `"cleanup context"` |
+| think / explore / analysis | interview, frame, analyze | `"think through this"` · `"help me think through this problem"` · `"explore ideas"` / `"explore the problem"` · `"write analysis"` |
+| promote verb | interview, promote | `"promote to spec"` vs `"promote staging"` / `"promote to production"` |
+| contributing | seed-community, readme-upgrade | `"add contributing"` vs `"improve contributing"` |
+| check / health | validate, checkup | `"check everything"` vs `"check setup"` / `"health check"` |
+
+**Top collisions (routing risk):** (1) `"configure stack"` exact pair, (2) `"ship it"` vs `/ship`, (3) `"create a spec"` vs `/spec`, (4) promote `"release"`/`"deploy"` vs `/ship` + `/release-setup`, (5) `"upgrade docs"` / `"update docs"` pair.
+
+### Must stay model-invokable
+
+Parent cannot `Skill()` a `disable-model-invocation` child. This set must stay `keep-model`:
+
+**Factories (never flag):** `/dev`, `/ship`.
+
+**`/dev` / `/ship` callees (14):** recheck, frame, analyze, spec, plan, implement, pr, ci-watch, validate, code-review, fix, cleanup, setup-worktree, cleanup-context.
+
+**Peer-`Skill()` reachability:** adversarial, advisory (frame / analyze / plan React); interview (analyze `Ω`).
+
+**Other-plugin `Skill()`:** env-setup, ci-setup, release-setup (`/dev-init`). Flagging these would break init composition the same way it would break `/dev`.
+
+`cleanup` is **not** a side-effect-gate-candidate: both factories `Skill()` it (`/dev` Step 7 `args: "--scope #N"`; `/ship` Step 8). Verified against the user hedge (“cleanup only if nothing Skill()s it”).
+
+### Side-effect-gate candidates (later, not a context win)
+
+`disable-model-invocation` is a **side-effect gate** (ADR-018), not a menu-token lever. Only standalone mutators with **no** `Skill()` caller:
+
+| skill | why candidate | why not today |
+|---|---|---|
+| promote | staging→main / tag / release; `/dev` never invokes | human NL `/promote` still works if flagged |
+| seed-docs | writes architecture/standards docs; `/dev-init` only *mentions* it | same |
+| seed-community | writes LICENSE / CoC / templates; no Skill() caller | same |
+
+**3** candidates. Do not treat this as a context-load win — descriptions stay in the menu until flagged, and flagging only blocks model self-fire.
+
+**unknown (7), not flagged as candidates:** adr, checkup, clarify, doc-sync, readme-upgrade, stack-setup, test. Standalone; some mutate disk; none are Skill()-reachable from `/dev`/`/ship`. Left unknown because they are not in the ADR-018 example set (`promote`, `seed-*`, `cleanup`) and several are NL onboarding / view surfaces.
+
+### Out of scope for axis 2
+
+- Do not set `disable-model-invocation` on `/dev` or `/ship`.
+- Do not use the flag to shrink the 8377-char description tax on factory-reachable skills.
+- Axis 1 `standalone` ≠ humans-only (adversarial / advisory stay Skill()-reachable).

--- a/artifacts/reviews/018-description-inventory.md
+++ b/artifacts/reviews/018-description-inventory.md
@@ -162,3 +162,23 @@ Parent cannot `Skill()` a `disable-model-invocation` child. This set must stay `
 - Do not set `disable-model-invocation` on `/dev` or `/ship`.
 - Do not use the flag to shrink the 8377-char description tax on factory-reachable skills.
 - Axis 1 `standalone` ≠ humans-only (adversarial / advisory stay Skill()-reachable).
+
+## Trigger hygiene (2026-08-18)
+
+Axis 2 collision cleanup — thief drops the phrase; winner keeps it. Descriptions only (`disable-model-invocation` not set; `/dev`/`/ship` untouched).
+
+| phrase dropped | from (thief) | winner |
+|---|---|---|
+| `"configure stack"` | env-setup | stack-setup |
+| `"ship it"` | implement | ship |
+| `"create a spec"` | interview | spec |
+| `"write analysis"` | interview | analyze |
+| `"promote to spec"` | interview | promote |
+| `"release"` (bare) | promote | ship / release-setup |
+| `"deploy"` | promote | ship |
+| `"merge to main"` | promote | ship |
+| `"ship a release"` | promote | ship |
+| `"update docs"` | doc-sync | (docs family — kept on neither; readme-upgrade keeps readme-specific) |
+| `"update the docs"` | doc-sync | (same) |
+| `"upgrade docs"` | readme-upgrade | (docs family — doc-sync keeps sync-family) |
+| `"improve docs"` | readme-upgrade | (same) |

--- a/artifacts/reviews/018-description-inventory.md
+++ b/artifacts/reviews/018-description-inventory.md
@@ -182,3 +182,13 @@ Axis 2 collision cleanup — thief drops the phrase; winner keeps it. Descriptio
 | `"update the docs"` | doc-sync | (same) |
 | `"upgrade docs"` | readme-upgrade | (docs family — doc-sync keeps sync-family) |
 | `"improve docs"` | readme-upgrade | (same) |
+
+## Trigger hygiene pass 2 (2026-08-18)
+
+Residual collisions after 18ab44e. Same rule: thief drops the phrase; winner keeps it. Descriptions + README Triggers only (`disable-model-invocation` not set; `/dev`/`/ship` untouched).
+
+| phrase dropped | from (thief) | winner |
+|---|---|---|
+| `"help me think through this problem"` | frame | interview (`"think through this"` / `"explore ideas"`) |
+| `"explore the problem"` | analyze | interview (`"explore ideas"`); frame keeps problem/scope language |
+| `"check everything"` | validate | checkup (`"check setup"`) |

--- a/docs/architecture/adr/018-skill-system-homes-and-composition.md
+++ b/docs/architecture/adr/018-skill-system-homes-and-composition.md
@@ -1,0 +1,149 @@
+---
+title: "ADR-018: Skill-system homes and composition"
+description: "One home per fact in the dev-core skill system: three orthogonal axes, placement law, refuse list. /dev stays NL-routable."
+---
+
+## Status
+
+Accepted — 2026-08-17 (human confirmed the cadastre).
+
+## Context
+
+dev-core is a **factory**: TypeScript, hooks, CLI, doctor, and worktrees under `plugins/dev-core/`, plus 32 `SKILL.md` files that the host autoloads from `skills/` (`plugins/dev-core/.claude-plugin/plugin.json` has no `skills` allowlist). `/dev` and `/ship` stay model-invokable so natural language ("start working on #42") still launches the factory. Measured 2026-08-17: **0** of those 32 files set `disable-model-invocation`.
+
+The skill system already has three libraries of fact:
+
+1. `plugins/shared/references/notation.md` — marketplace glyphs + Reserved-Variable Registry.
+2. `plugins/dev-core/skills/shared/references/chain-contract.md` — author-facing pipeline contract. Header: **not loaded at runtime**.
+3. A `Let:` block in every skill (32 `SKILL.md` files; 34 `Let:` lines because `stack-setup` and `env-setup` each have a second block) that re-binds words the registry already names.
+
+The failure mode is **N homes for one fact**, not a missing fourth library. `τ` is defined in `notation.md`, `tier-classification.md`, `dev-process.md`, and dozens of `Let:` lines. `σ` is a four-way collision in the registry (`.claude/stack.yml` · spec artifact · status-icon map · staging branch). Approval-stop, done-signal, principal, factory, and Issue are English process words that glyphs cannot hold, so they get copied into skill bodies.
+
+Three questions are being answered by one informal mix:
+
+- How does a skill participate in `/dev` / `/ship`? (ADR-010 / `chain-contract.md` already answers this.)
+- Who is allowed to fire it? (unanswered — every skill is model-invokable.)
+- How does another author or skill reach a fact? (`Skill()`, `Read` of a format doc, named prose, inline copy, or `bun`/`bash` — all five are in use.)
+
+A first draft (Vague 0) proposed a `CONTEXT.md` plus `disable-model-invocation` on `/dev` and `/ship`. That would buy roughly a hundred tokens and would break installer natural-language routing. ADR-004 already rejected a standalone `/audit` skill (Option D). ADR-013 already chose named prose `write_candidate` over extracting `/falsify`. Re-compressing 400-line `SKILL.md` files is not the main lever.
+
+ADR-010 remains in force for the **pipeline** axis: `/dev` owns the dev-pipeline task lifecycle; skill classes (`adv`, `adv + approval-stop`, `verdict`, `loop`, `standalone`) stay. **Redundancy-with-locality** (each child inlines Chain Position / Task Integration / Exit because `chain-contract.md` is not runtime-included) is the **current mitigation**, not the target end-state. Retiring those inlines happens only after `/dev` is a reliable sole chain owner — not in this ADR's landing.
+
+## Options Considered
+
+### Option A: CONTEXT.md + hide `/dev` / `/ship`
+
+Add a fourth library (`CONTEXT.md`) and set `disable-model-invocation: true` on the two factories so they drop out of the model's skill list.
+
+- **Pros:** Slightly smaller default skill menu; one new file to point at.
+- **Cons:** Installer regression — "start working on #42" no longer routes to `/dev`. A parent cannot `Skill()` a child that has `disable-model-invocation: true` (Claude host docs; Grok is not assumed to honor the flag). Fourth glossary restates `notation.md` + `chain-contract.md` + the `Let:` corpus. Token win is ~100.
+
+### Option B: Placement law + three axes, no fourth glossary, `/dev` stays NL (chosen)
+
+Keep `/dev` and `/ship` model-invokable. Do not add `CONTEXT.md`. Lock glyphs in `notation.md`. Give English process words one thin home. Classify every fact by kind and give that kind one home. Record an extraction **gate** for turning a procedure into a callable skill; do not pre-commit "every procedure becomes a `Skill()`".
+
+- **Pros:** One test for authors. NL factory path preserved. Orthogonal to ADR-010. Vague 1 extracts become possible without a false mandate.
+- **Cons:** Notation lock will force collision resolution later. Child Exit blocks stay until `/dev` is the sole chain owner.
+
+### Option C: Become a Matt-style markdown-only skill kit / router
+
+Replace the TS / hooks / CLI / doctor / worktree factory with a markdown router that only `Skill()`s children.
+
+- **Pros:** Smaller runtime surface; closer to a pure skill pack.
+- **Cons:** Refuse list. We are a factory. Doctor, worktree, scan-state, hooks, and copy-sync (ADR-014) are the product, not a temporary scaffold.
+
+### Option D: Keep redundancy-with-locality forever as the architecture
+
+Treat the ADR-010 inline Chain Position / Exit copies as the permanent SSoT. Keep `chain-contract.md` as a second runtime-shaped source. Keep `Let:` redefinitions of canonical words.
+
+- **Pros:** Matches today's failure-mode mitigation (model asks "proceed to /X?" when chain context is only in `/dev`).
+- **Cons:** N homes stay the architecture. Drift between 13+ Exit blocks and `/dev` Step 7/8 is permanent. Rejected as **target**. Remains the **current mitigation** until `/dev` is the sole chain owner.
+
+## Decision
+
+Adopt **Option B**.
+
+### Three orthogonal axes
+
+| Axis | What it answers | Exists today? |
+|---|---|---|
+| (1) Pipeline class | How the skill participates in `/dev` / `/ship` | Yes — ADR-010 / `chain-contract.md`. Classes: `adv`, `adv + approval-stop`, `verdict`, `loop`, `standalone`. |
+| (2) Invocation budget | Who can fire it: human NL/slash vs model vs other `Skill()` | No — all 32 skills are model-invokable; 0 have `disable-model-invocation`. |
+| (3) Composition | How others reach a fact: `Skill()` vs `Read` format vs named prose vs inline vs `bun`/`bash` | Informal — mix of all five. |
+
+Axis 1 `standalone` means **never auto-triggered by `/dev`**. It does **not** mean "humans only." Today that class mixes two axis-2 budgets:
+
+- Human types it (`/promote`, `/cleanup` as a side-effect, `seed-*`).
+- Other skills may `Skill()` it (`/adversarial`, `/advisory` — invoked from `/frame`, `/analyze`, `/plan` React tables).
+
+Split those on axis 2. Do not invent a new pipeline class for "Skill()-reachable standalone."
+
+**Hard constraint on axis 2.** A parent **cannot** `Skill()` a child that has `disable-model-invocation: true` (Claude host / Anthropic). Therefore every skill that `/dev` or `/ship` invokes via `Skill()` **must** stay model-invokable. That set today includes at least `recheck`, `frame`, `analyze`, `spec`, `plan`, `implement`, `pr`, `ci-watch`, `validate`, `code-review`, `fix`, `cleanup`, `setup-worktree`, plus `/ship`'s `pr` / `code-review` / `fix` / `ci-watch` / `cleanup`. `disable-model-invocation` is Claude-only; do not assume Grok honors it. Treat the flag as a **side-effect gate** for later standalone side-effect skills (`promote`, `cleanup`, `seed-*`) — never as a context-load win on the factories. **Do not set it on `/dev` or `/ship`.**
+
+### Placement law (cadastre)
+
+One home per fact. If the fact already has a home, point or invoke — never recopy.
+
+| Kind of fact | Examples | One home | Others reach by | Forbidden |
+|---|---|---|---|---|
+| Word | Issue, approval-stop, principal, `τ` = tier only | Glyphs: `plugins/shared/references/notation.md` (bindings **locked** — one sense; `(local)` is no longer the desired steady state). English process words glyphs cannot hold: one thin section in that same file (`## English process words`) — not a sibling glossary, not `CONTEXT.md`. | Authors write with it; `/dev` may `Read` once. | 30+ `Let:` redefinitions of canonical words; a fourth glossary that restates `τ` / `σ` / `φ`. |
+| Format | frontmatter `status:`, done-signal keys, plan-task schema | One format doc under `plugins/dev-core/skills/shared/references/` (`artifact-frontmatter.md`, `plan-task-schema.md`). `tier-classification.md` is the S / F-lite / F-full SSoT (criteria, signals, scoring). | `Read` when writing that artifact. | Recopying keys into every `SKILL.md`. |
+| Procedure | approval-stop, falsification, interview, TDD | Prefer one model-invoked skill **only if** the extraction gate passes; else named prose in one file (ADR-013 `write_candidate` style). | `Skill("X")` or named-prose pointer. | Inline the same algorithm in 2+ `SKILL.md`. |
+| Orchestration | who runs next, task lifecycle | `/dev` (feature path) and `/ship` (land path) only. | Human NL or slash; factory `Skill()`s children. | Child Chain Position / Exit as the long-term SSoT; `chain-contract.md` as a second *runtime* source. |
+| Mechanism | worktree, scan-state, doctor, hooks | Code (TS / sh / hook) under `skills/shared/`, `hooks/`, `cli/`, `tools/`, or the owning skill's scripts. Copy-sync unchanged (ADR-014). | `bash` / `bun` / `Skill("setup-worktree")`. | Narrating the algorithm in `SKILL.md`. |
+
+**Extraction gate** (axis 3, procedures). Extraction to a callable skill is **allowed later**, not mandated. The gate holds when at least one of these is true:
+
+- two algorithms (callers need a named choice, not a copy);
+- a disk contract (writers would otherwise recopy keys — that is a Format, `Read` it; if the procedure *enforces* the contract across skills, it may become a skill);
+- a turn-stop (the procedure must own the HITL turn, the way approval-stop skills do).
+
+ADR-013 named prose and ADR-004's rejection of `/audit` remain the default when the gate fails.
+
+### Folder assignment
+
+| Path | Role |
+|---|---|
+| `plugins/shared/references/` | Marketplace language. `notation.md` is locked (glyphs + thin English process words). |
+| `plugins/dev-core/skills/shared/references/` | **Formats only** (target). Today this directory also holds author-facing and protocol files; those are cadastre follow-up, not this landing. Keep `artifact-frontmatter.md`, `plan-task-schema.md`, `tier-classification.md`, host contracts (`harness-*.md`), and format templates (`reasoning-audit.md`, `release-convention.md`). |
+| `plugins/dev-core/skills/shared/` TS | Mechanisms + copy-sync (ADR-014). Unchanged. |
+| `plugins/dev-core/references/` | Human contributor docs. Must stop being a second SSoT. Today `dev-process.md` **and** `tier-classification.md` both define S / F-lite / F-full — `tier-classification.md` wins. `dev-process.md` keeps phases / artifacts / git overview and points at the tier file. |
+| `skills/<name>/SKILL.md` | Either a factory (`/dev`, `/ship`) or a procedure. No canonical `Let:` of shared words. No long-term Chain Position copy. |
+| `agents/` | Roles. `base.md` is the only shared agent protocol (`engineer.md` is the implementation-agent companion). |
+| `hooks/` `cli/` `tools/` | Host / CI mechanisms. |
+| `plugin.json` | Shipped set (allowlist is the **target**; autodiscovery of all `skills/` is the current state). This ADR does not edit `plugin.json`. |
+
+`chain-contract.md` becomes an **author-facing view** of `/dev` (or is retired). It is not a runtime include. This ADR does not edit that file.
+
+### Refuse list
+
+- Keep the TS / hooks / CLI / doctor / worktree factory.
+- Do not replace `/dev` with a Matt-style markdown-only router.
+- Do not treat re-compress of 400-line `SKILL.md` as the main lever.
+- Do not add `CONTEXT.md`.
+- Do not set `disable-model-invocation` on `/dev` or `/ship`.
+- Do not pre-commit "every procedure becomes a `Skill()`."
+
+### Relation to ADR-010
+
+Pipeline class, `/dev`-owns-lifecycle, and the five skill classes stay. Redundancy-with-locality stays as the **current** mitigation for the "proceed to /X?" failure mode. This ADR is orthogonal on axes 2 and 3. Retiring child Exit / Chain Position inlines is **out of landing** — it waits on `/dev` being a reliable sole chain owner.
+
+## Consequences
+
+### Positive
+
+- One author test: does this fact already have a home? Then point or invoke, never recopy.
+- Vague 1 extracts become possible without a false `Skill()` mandate; the extraction gate is the check.
+- Installer natural-language path is preserved (`/dev` and `/ship` stay model-invokable).
+- Axis 1 `standalone` is no longer overloaded with "humans only" — `Skill()`-reachable advisory skills stay legal.
+
+### Negative
+
+- Notation lock will force collision resolution. `σ` is four-way today (stack.yml · spec artifact · status-icon map · staging branch); `α`, `β`, `ω`, `μ`, `τ`, `φ`, `π`, `Σ`, `Ω` are also marked collision in the 2026-07-04 registry. This ADR names them; it does not pick winners.
+- Retiring child Exit blocks is deferred and will feel like a risk versus ADR-010's original failure mode (model asks "proceed to /X?").
+
+### Neutral
+
+- No `SKILL.md` edits in the landing of this ADR. No `CONTEXT.md`. No `disable-model-invocation` flip. No `plugin.json` allowlist edit.
+- First follow-up is **cadastre**, not primitive extraction: lock `notation.md` bindings; add the thin English process-words section; make `tier-classification.md` the only tier SSoT (`dev-process.md` points, does not redefine); inventory skill `description` fields against axis 2.
+- `chain-contract.md` stays on disk as an author-facing view until a later change retires or folds it into `/dev`.

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -17,6 +17,7 @@
     "014-shared-ts-governance-scope",
     "015-direct-call-over-role-interface-ports-typescript",
     "016-plain-markdown-docs-no-fumadocs",
-    "017-principal-freeze-state-assert"
+    "017-principal-freeze-state-assert",
+    "018-skill-system-homes-and-composition"
   ]
 }

--- a/plugins/dev-core/.claude-plugin/plugin.json
+++ b/plugins/dev-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-core",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Full development workflow — frame, shape, plan, implement, review, ship. Skills + agents (incl. /adversarial, /advisory), dual-harness task list + worktrees, safety hooks (Claude + Grok).",
   "author": {
     "name": "Roxabi"

--- a/plugins/dev-core/references/dev-process.md
+++ b/plugins/dev-core/references/dev-process.md
@@ -1,18 +1,18 @@
 # Dev Process Reference
 
-> Extracted from Roxabi boilerplate `CLAUDE.md`. Reference copy for dev-core. Canonical source in boilerplate repo.
+> Contributor view of the `/dev` pipeline (phases, artifacts, git). Not a SSoT for τ.
 
 Let: τ := tier | α := agent
 
 ## Tier System
 
-`/dev #N` determines τ based on complexity:
+`/dev` chooses τ. Criteria, signals, scoring, label mapping: [tier-classification.md](../skills/shared/references/tier-classification.md).
 
-| τ | Criteria | Phases |
-|---|----------|--------|
-| **S** | ≤3 files, no arch, no risk | triage → implement → pr → validate → review → fix* → promote* → cleanup* |
-| **F-lite** | Clear scope, single domain | Frame → spec → plan → implement → verify → ship |
-| **F-full** | New arch, unclear reqs, >2 domains | Frame → analyze → spec → plan → implement → verify → ship |
+| τ (from tier-classification.md) | Steps `/dev` runs |
+|---|---|
+| **S** | triage → implement → pr → validate → review → fix* → promote* → cleanup* |
+| **F-lite** | Frame → spec → plan → implement → verify → ship |
+| **F-full** | Frame → analyze → spec → plan → implement → verify → ship |
 
 `*` = conditional (runs only if applicable)
 

--- a/plugins/dev-core/skills/analyze/README.md
+++ b/plugins/dev-core/skills/analyze/README.md
@@ -13,7 +13,7 @@ For complex issues (F-full tier), jumping from frame to spec skips the most impo
 /analyze --frame path     Analyze from an explicit frame file
 ```
 
-Triggers: `"analyze"` | `"technical analysis"` | `"deep dive"` | `"explore the problem"` | `"investigate this"` | `"what are the risks"`
+Triggers: `"analyze"` | `"technical analysis"` | `"deep dive"` | `"investigate this"` | `"what are the risks"`
 
 ## How it works
 

--- a/plugins/dev-core/skills/analyze/SKILL.md
+++ b/plugins/dev-core/skills/analyze/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: analyze
 argument-hint: '[--issue <N> | --frame <path>]'
-description: Deep technical analysis — explore existing code, risks, alternatives. Triggers: "analyze" | "technical analysis" | "explore the problem" | "how deep is it" | "deep dive" | "investigate this" | "analyze this feature" | "what are the risks" | "explore the codebase" | "look into this".
+description: Deep technical analysis — explore existing code, risks, alternatives. Triggers: "analyze" | "technical analysis" | "how deep is it" | "deep dive" | "investigate this" | "analyze this feature" | "what are the risks" | "explore the codebase" | "look into this".
 version: 0.4.5
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, Skill, ToolSearch
 ---

--- a/plugins/dev-core/skills/doc-sync/README.md
+++ b/plugins/dev-core/skills/doc-sync/README.md
@@ -13,7 +13,7 @@ After renaming a tool, moving a file, or changing a config field, docs silently 
 /doc-sync "gitleaks → trufflehog"  Supply a description directly
 ```
 
-Triggers: `"sync docs"` | `"update docs"` | `"doc sync"` | `"sync plugin docs"` | `"update the docs"`
+Triggers: `"sync docs"` | `"doc sync"` | `"sync plugin docs"` | `"update skill docs"`
 
 ## How it works
 

--- a/plugins/dev-core/skills/doc-sync/SKILL.md
+++ b/plugins/dev-core/skills/doc-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: doc-sync
 argument-hint: '[description of change]'
-description: 'Sync all project docs after a code change — scans every doc for stale references, updates affected sections. Triggers: "sync docs" | "update docs" | "doc sync" | "sync plugin docs" | "update skill docs" | "update the docs".'
+description: 'Sync all project docs after a code change — scans every doc for stale references, updates affected sections. Triggers: "sync docs" | "doc sync" | "sync plugin docs" | "update skill docs".'
 version: 0.4.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, ToolSearch
 ---

--- a/plugins/dev-core/skills/env-setup/README.md
+++ b/plugins/dev-core/skills/env-setup/README.md
@@ -13,7 +13,7 @@ Before using dev-core skills, a project needs a `stack.yml` describing its runti
 /env-setup --force   Re-run all phases, overwriting existing config
 ```
 
-Triggers: `"env setup"` | `"setup environment"` | `"configure stack"` | `"scaffold rules"`
+Triggers: `"env setup"` | `"setup environment"` | `"scaffold rules"`
 
 ## Phases
 

--- a/plugins/dev-core/skills/env-setup/SKILL.md
+++ b/plugins/dev-core/skills/env-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: env-setup
 argument-hint: '[--force]'
-description: 'Set up local dev environment — stack.yml, CLAUDE.md Critical Rules, docs scaffolding, LSP. Triggered by /dev-init or standalone /env-setup. Triggers: "env setup" | "setup environment" | "configure stack" | "scaffold rules".'
+description: 'Set up local dev environment — stack.yml, CLAUDE.md Critical Rules, docs scaffolding, LSP. Triggered by /dev-init or standalone /env-setup. Triggers: "env setup" | "setup environment" | "scaffold rules".'
 version: 0.1.0
 allowed-tools: Bash, Read, Write, Edit, ToolSearch
 ---

--- a/plugins/dev-core/skills/frame/SKILL.md
+++ b/plugins/dev-core/skills/frame/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: frame
 argument-hint: '["idea" | --issue <N>]'
-description: Problem framing — capture problem, constraints, scope, tier. Triggers: "frame" | "frame this" | "what's the problem" | "define the problem" | "scope this out" | "define the scope" | "what are we solving" | "help me think through this problem" | "problem statement".
+description: Problem framing — capture problem, constraints, scope, tier. Triggers: "frame" | "frame this" | "what's the problem" | "define the problem" | "scope this out" | "define the scope" | "what are we solving" | "problem statement".
 version: 0.6.1
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, ToolSearch
 ---

--- a/plugins/dev-core/skills/implement/README.md
+++ b/plugins/dev-core/skills/implement/README.md
@@ -14,7 +14,7 @@ Execute the plan — set up a worktree, spawn agents, write code + tests, run th
 /implement --issue 42 --audit     Show reasoning checkpoint before coding
 ```
 
-Triggers: `"implement"` | `"build this"` | `"execute plan"` | `"start coding"` | `"write the code"` | `"ship it"`
+Triggers: `"implement"` | `"build this"` | `"execute plan"` | `"start coding"` | `"write the code"` | `"code this up"` | `"let's build it"` | `"build it out"`
 
 ## How it works
 

--- a/plugins/dev-core/skills/implement/SKILL.md
+++ b/plugins/dev-core/skills/implement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement
 argument-hint: '[--issue <N> | --plan <path> | --audit]'
-description: Execute plan — setup worktree, spawn agents, write code + tests. Triggers: "implement" | "build this" | "execute plan" | "start coding" | "write the code" | "code this up" | "let's build it" | "build it out" | "ship it".
+description: Execute plan — setup worktree, spawn agents, write code + tests. Triggers: "implement" | "build this" | "execute plan" | "start coding" | "write the code" | "code this up" | "let's build it" | "build it out".
 version: 0.3.2
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, EnterWorktree, ExitWorktree, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill, ToolSearch
 ---

--- a/plugins/dev-core/skills/interview/README.md
+++ b/plugins/dev-core/skills/interview/README.md
@@ -14,7 +14,7 @@ Unstructured conversations produce vague documents. `/interview` conducts a phas
 /interview --promote path          Promote an existing doc to the next level
 ```
 
-Triggers: `"create a spec"` | `"interview"` | `"brainstorm"` | `"write analysis"` | `"promote to spec"` | `"let's brainstorm"` | `"think through this"`
+Triggers: `"interview"` | `"brainstorm"` | `"let's brainstorm"` | `"think through this"` | `"help me brainstorm"` | `"let's think this through"` | `"explore ideas"`
 
 ## Document types
 

--- a/plugins/dev-core/skills/interview/SKILL.md
+++ b/plugins/dev-core/skills/interview/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: interview
 argument-hint: [topic | --promote <path>]
-description: Structured interview → brainstorm | analysis | spec (with promotion). Triggers: "create a spec" | "interview" | "brainstorm" | "write analysis" | "promote to spec" | "let's brainstorm" | "think through this" | "help me brainstorm" | "let's think this through" | "explore ideas".
+description: Structured interview → brainstorm | analysis | spec (with promotion). Triggers: "interview" | "brainstorm" | "let's brainstorm" | "think through this" | "help me brainstorm" | "let's think this through" | "explore ideas".
 version: 0.2.3
 allowed-tools: Write, Read, Edit, Glob, ToolSearch
 ---

--- a/plugins/dev-core/skills/promote/README.md
+++ b/plugins/dev-core/skills/promote/README.md
@@ -15,7 +15,7 @@ Releasing to production involves a checklist: verify CI, bump the version, write
 /promote --finalize       Post-merge: tag + GitHub Release (run after merging the promotion PR)
 ```
 
-Triggers: `"promote staging"` | `"release"` | `"deploy"` | `"cut a release"` | `"merge to main"` | `"ship a release"` | `"tag and release"`
+Triggers: `"promote staging"` | `"cut a release"` | `"--finalize"` | `"promote to production"` | `"tag and release"` | `"publish release"`
 
 ## How it works
 

--- a/plugins/dev-core/skills/promote/SKILL.md
+++ b/plugins/dev-core/skills/promote/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: promote
 argument-hint: [--dry-run | --skip-preview | --finalize]
-description: Promote staging→main — pre-flight, version bump, changelog, PR & tag. Triggers: "promote staging" | "release" | "deploy" | "cut a release" | "--finalize" | "merge to main" | "promote to production" | "ship a release" | "tag and release" | "publish release".
+description: Promote staging→main — pre-flight, version bump, changelog, PR & tag. Triggers: "promote staging" | "cut a release" | "--finalize" | "promote to production" | "tag and release" | "publish release".
 version: 0.5.0
 allowed-tools: Bash, Read, Grep, Write, Edit, ToolSearch
 ---

--- a/plugins/dev-core/skills/readme-upgrade/README.md
+++ b/plugins/dev-core/skills/readme-upgrade/README.md
@@ -33,4 +33,4 @@ Direct and imperative. No filler. Each new section ≤150 words. Mermaid diagram
 
 ## Triggers
 
-`"improve readme"` | `"upgrade docs"` | `"readme quality"` | `"readme upgrade"` | `"docs health"`
+`"improve readme"` | `"readme quality"` | `"doc audit"` | `"readme upgrade"` | `"improve contributing"` | `"docs health"`

--- a/plugins/dev-core/skills/readme-upgrade/SKILL.md
+++ b/plugins/dev-core/skills/readme-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: readme-upgrade
 argument-hint: '[--target root|plugins|contributing|all] [--plugin <name>] [--force]'
-description: 'Audit and upgrade project documentation quality — README.md, CONTRIBUTING.md, plugin READMEs — against the developer-tool pattern (Why, Quick Start, How it works, command tables with categories, diagram). Triggers: "improve readme" | "upgrade docs" | "readme quality" | "improve docs" | "doc audit" | "readme upgrade" | "improve contributing" | "docs health".'
+description: 'Audit and upgrade project documentation quality — README.md, CONTRIBUTING.md, plugin READMEs — against the developer-tool pattern (Why, Quick Start, How it works, command tables with categories, diagram). Triggers: "improve readme" | "readme quality" | "doc audit" | "readme upgrade" | "improve contributing" | "docs health".'
 version: 0.1.0
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, ToolSearch
 ---

--- a/plugins/dev-core/skills/shared/references/tier-classification.md
+++ b/plugins/dev-core/skills/shared/references/tier-classification.md
@@ -1,5 +1,7 @@
 # Tier Classification
 
+ADR-018 Word/Format home for τ (S / F-lite / F-full).
+
 Let: τ := tier | C := complexity score (1–10) | α := agent
 
 Canonical rules for classifying work into S / F-lite / F-full. Referenced by `/frame`, `/dev`, `/issue-triage`.

--- a/plugins/dev-core/skills/validate/README.md
+++ b/plugins/dev-core/skills/validate/README.md
@@ -15,7 +15,7 @@ Before a code review, you want a single command that runs every quality check an
 /validate --affected   Only check files changed vs main
 ```
 
-Triggers: `"validate"` | `"check everything"` | `"quality check"` | `"pre-push check"` | `"are we green"`
+Triggers: `"validate"` | `"quality check"` | `"pre-push check"` | `"are we green"`
 
 ## How it works
 

--- a/plugins/dev-core/skills/validate/SKILL.md
+++ b/plugins/dev-core/skills/validate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validate
 argument-hint: [--quick | --full | --affected]
-description: Run all quality gates (lint, typecheck, test, env, i18n, license) and produce a structured pass/fail report. Triggers: "validate" | "check everything" | "quality check" | "pre-push check" | "are we green".
+description: Run all quality gates (lint, typecheck, test, env, i18n, license) and produce a structured pass/fail report. Triggers: "validate" | "quality check" | "pre-push check" | "are we green".
 version: 0.2.0
 allowed-tools: Bash, Read
 ---

--- a/plugins/shared/references/notation.md
+++ b/plugins/shared/references/notation.md
@@ -1,6 +1,8 @@
 # Notation — Canonical Glossary
 
-Single source of truth for the formal notation used across this marketplace's skills and agents. It merges the three prior legends (compress `## Symbols`, dev-core `base.md` Notation, dev-core `doc-writer.md` compressed-notation line) — dispositions recorded in the merge audit below. This glossary is writer-side tooling: consumers of compressed files never need it — every emitted symbol must be self-sufficient via the whitelist or a local Let-binding with gloss.
+Single source of truth for the formal notation used across this marketplace's skills and agents. It merges the three prior legends (compress `## Symbols`, dev-core `base.md` Notation, dev-core `doc-writer.md` compressed-notation line) — dispositions recorded in the merge audit below. This glossary is writer-side tooling: consumers of compressed files never need it — every emitted symbol must be self-sufficient via the whitelist or a Let-binding with gloss.
+
+Word home (ADR-018): glyphs and English process words live here. A reserved variable has one **target** sense. File-local re-bind of a target binding is not the desired model; `(local)` is a legacy lint escape only.
 
 Consumers: compress Phase 0 loads `## Core Table` only; compress Phase 3 checks Let-bindings against the Reserved-Variable Registry; the glossary mode loads Grammar + Maintenance; `tools/validate_plugins.py --check notation-legends` holds the core table set-equal to compress's `Whitelist:` line and gates the dev-core pointer lines.
 
@@ -83,6 +85,7 @@ Loaded by glossary mode. The glossary is closed-vocabulary: extension is human-g
 - **Add** — measure first (`git grep` counts + file spread over `plugins/`), record an adjudication (counts, outcome, rationale, date) in the glyph's notes cell, then → present choice before the row lands. Adding a core-active operator glyph requires the same change to compress SKILL.md's `Whitelist:` line — `--check notation-legends` fails the commit otherwise.
 - **Deprecate** — move the row out of `## Core Table` into the table below and drop the glyph from the whitelist in the same change; the equality gate keeps the two in lockstep. Never delete the record.
 - **Version** — this file rides normal PRs; the validator (CI + lefthook) is the drift gate. Counts in adjudications are point-in-time and dated, never silently edited.
+- **Word-home lock (2026-08-18)** — ADR-018 cadastre. Bindings locked (`target` column); thin `## English process words` added. Core Table unchanged.
 
 | Deprecated / rejected glyph | Record |
 |-----------------------------|--------|
@@ -90,24 +93,61 @@ Loaded by glossary mode. The glossary is closed-vocabulary: extension is human-g
 
 ## Reserved-Variable Registry
 
-Variables carry file-local bindings — they are NOT operators and sit outside the whitelist equality domain. Counts: `git grep` over `plugins/`, 2026-07-04. Status ∈ canonical / collision / aspirational.
+Variables are NOT operators and sit outside the whitelist equality domain. Counts: `git grep` over `plugins/`, 2026-07-04. **target** = intended canonical sense. A **dominant** mark is the corpus / compress-Phase-3 lint heuristic — it is the target when one exists, except the unresolved rows below. Other listed senses are **residuals** (still in the corpus; not equal alternatives). Status ∈ canonical / target-locked / collision (unresolved).
 
-| var | binding(s) | grep counts | status |
-|-----|-----------|-------------|--------|
-| `σ` | `.claude/stack.yml` (dominant) · spec artifact · status-icon map · staging branch | ×162 · 27 files | collision (4-way) |
-| `Ω` | override file (dominant) · `/interview` skill handle | ×14 · 3 files | collision |
-| `α` | agent (dominant) · analysis artifact · agent-memory file | ×153 · 20 files | collision |
-| `β` | base branch (dominant) · brainstorm artifact · frontend path | ×42 · 7 files | collision |
-| `ω` | worktree (dominant) · option/choice | ×36 · 4 files | collision |
-| `μ` | mode (compress) · memory file · micro-task · main branch | ×46 · 10 files | collision |
-| `τ` | tier (dominant) · memory topic files | ×121 · 26 files | collision |
-| `φ` | frame artifact (dominant) · finding · face-reference config | ×79 · 9 files | collision |
-| `Δ` | delta — changed files / Δtokens · changelog entry | ×36 · 7 files | canonical (one concept: difference) |
-| `Σ` | state map/dict (dominant — the base.md + doc-writer legend sense) · severity icon · testing-standards path | ×52 · 12 files | collision |
-| `π` | plan artifact · open PR · test file · proposed config table | ×46 · 7 files | collision (no dominant sense) |
-| `S*` | next-step variable (dev-core base legend) | ×42 · 14 files | canonical |
+| var | binding(s) | target | grep counts | status |
+|-----|-----------|--------|-------------|--------|
+| `σ` | `.claude/stack.yml` (dominant) · spec artifact · status-icon map · staging branch | — (unresolved) | ×162 · 27 files | collision (4-way) |
+| `Ω` | override file (dominant) · `/interview` skill handle (residual) | override file | ×14 · 3 files | target-locked |
+| `α` | agent (dominant) · analysis artifact (residual) · agent-memory file (residual) | agent | ×153 · 20 files | target-locked |
+| `β` | base branch (dominant) · brainstorm artifact (residual) · frontend path (residual) | base branch | ×42 · 7 files | target-locked |
+| `ω` | worktree (dominant) · option/choice (residual) | worktree | ×36 · 4 files | target-locked |
+| `μ` | mode (compress) · memory file · micro-task · main branch | — (unresolved) | ×46 · 10 files | collision (no dominant sense) |
+| `τ` | tier (dominant) · memory topic files (residual) | tier | ×121 · 26 files | target-locked |
+| `φ` | frame artifact (dominant) · finding (residual) · face-reference config (residual) | frame artifact | ×79 · 9 files | target-locked |
+| `Δ` | delta — changed files / Δtokens · changelog entry | delta (difference) | ×36 · 7 files | canonical (one concept: difference) |
+| `Σ` | state map/dict (dominant — the base.md + doc-writer legend sense) · severity icon (residual) · testing-standards path (residual) | state map/dict | ×52 · 12 files | target-locked |
+| `π` | plan artifact · open PR · test file · proposed config table | — (unresolved) | ×46 · 7 files | collision (no dominant sense) |
+| `S*` | next-step variable (dev-core base legend) | next-step variable | ×42 · 14 files | canonical |
 
-**`(local)` re-binding rule:** a file may re-bind a registry variable by marking it `(local)` in its `Let:` block — e.g. `π := pattern list (local)`. compress Phase 3 flags any un-marked collision against this table; with the glossary absent (standalone install) only whitelist-glyph collisions are checkable — accepted degradation.
+**Unresolved (follow-up, not this lock):**
+- `σ` — factory English word is Spec (`## English process words`). Glyph target is unresolved because `.claude/stack.yml` (registry-dominant / lint heuristic) and spec-artifact both live. Do not treat the dominant mark as the winner.
+- `π` — no dominant; stay collision.
+- `μ` — no dominant; stay collision.
+
+**`(local)` rule:** desired steady state is no re-bind of a **target** binding. `(local)` remains a **legacy escape** so compress Phase 3 does not explode — it still flags any un-marked non-dominant Let-binding as `reserved-collision` (dominant-sense uses are never findings). New skills must not introduce `(local)` for a target binding. With the glossary absent (standalone install) only whitelist-glyph collisions are checkable — accepted degradation. Legacy form: `π := pattern list (local)`.
+
+## English process words
+
+Word home for factory English that glyphs cannot hold ([ADR-018](../../../docs/architecture/adr/018-skill-system-homes-and-composition.md)). This section owns the English words only — it does not own `τ` / `σ` / `φ`. Authors write with these words; `/dev` may Read this file once. Skills must not recopy this section.
+
+**Issue** — GitHub issue the factory works; identified by N.
+Avoid: ticket (except quoting an external tracker).
+
+**Factory** — `/dev` (feature path) and `/ship` (land path). Owns pipeline task lifecycle.
+Avoid: "the orchestrator" as a third thing.
+
+**Approval-stop** — skill prints an Executive Summary and stops the turn; human replies in free text.
+Avoid: `/dev` treating "summary printed" as done.
+
+**Done-signal** — on-disk fact that completes an approval-stop step (see `artifact-frontmatter.md` / chain-contract table).
+Avoid: completing these steps from chat memory (`Σ_s`) alone.
+
+**Principal** — main checkout; always stays on the base branch.
+Avoid: "the repo", "cwd".
+
+**Worktree** — isolated checkout on `feat/{N}-*` where code is written.
+Avoid: calling the branch itself the worktree (the branch can exist without `ω`).
+
+**Spec** — solution artifact for an Issue.
+Avoid: treating the English word as settling the glyph `σ` (named residual collision — registry).
+
+### Relationships
+
+- An Issue has one Tier (glyph `τ` — target binding in the registry).
+- Frame / Analysis / Spec / Plan are artifacts of one Issue.
+- Approval-stop writes a Done-signal; `/dev` reads it.
+- Code is written in a Worktree; Principal never switches to `feat/*`.
 
 ## Register Conventions (aspirational)
 


### PR DESCRIPTION
## Why

dev-core skills had N homes for the same fact (30 `Let:` dialects, colliding Triggers). ADR-018 locks one home per fact. Cadastre + trigger hygiene follow.

## What

- ADR-018: three axes (pipeline class × invocation budget × composition), placement law, refuse list. `/dev` stays NL-routable.
- Cadastre: `notation.md` Word home (target bindings + English process words), single tier SSoT, axis-2 description inventory.
- Trigger hygiene (two passes): overlapping Triggers removed from the thief skill. Winners keep the phrase.
- `dev-core` plugin `0.12.2` → `0.12.3` (pre-push skill-version gate).

## Not in this PR

No `disable-model-invocation` on `/dev`/`/ship`. No primitive extraction. `σ`/`π`/`μ` glyph collisions named, not resolved.

Closes nothing — no issue filed.